### PR TITLE
Add button to logout user

### DIFF
--- a/src/components/AdminNavbar/AdminNavbar.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.tsx
@@ -92,7 +92,12 @@ function AdminNavbar({ targets, url_1 }: NavbarProps): JSX.Element {
               <i className="fa fa-cogs"></i>
               Settings
             </Dropdown.Item>
-            <Dropdown.Item href="/">
+            <Dropdown.Item
+              onClick={() => {
+                localStorage.clear();
+                window.location.replace('/');
+              }}
+            >
               <i className="fa fa-arrow-right"></i>
               Logout
             </Dropdown.Item>

--- a/src/screens/OrgList/OrgList.module.css
+++ b/src/screens/OrgList/OrgList.module.css
@@ -6,7 +6,7 @@
   z-index: 1;
   position: relative;
   flex-direction: row;
-  justify-content: space-between;
+  justify-content: space-between !important;
   box-shadow: 0px 0px 8px 2px #c8c8c8;
 }
 .titlemodal .logo {
@@ -301,4 +301,20 @@ form > input {
 }
 .checkboxdiv > div {
   width: 50%;
+}
+
+.logoutbtn {
+  border: 1px solid #e8e5e5;
+  box-shadow: 0 2px 2px #e8e5e5;
+  border-radius: 5px;
+  background-color: #31bb6b;
+  height: 40px;
+  font-size: 16px;
+  color: white;
+  outline: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+  padding: 0 20px;
+  margin-right: 10px;
 }

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -79,6 +79,12 @@ function OrgList(): JSX.Element {
             </a>
           </Row>
         </Navbar.Brand>
+        <button
+          className={styles.logoutbtn}
+          onClick={() => window.location.replace('/')}
+        >
+          Logout
+        </button>
       </Navbar>
       <Row>
         <Col sm={3}>

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -81,7 +81,10 @@ function OrgList(): JSX.Element {
         </Navbar.Brand>
         <button
           className={styles.logoutbtn}
-          onClick={() => window.location.replace('/')}
+          onClick={() => {
+            localStorage.clear();
+            window.location.replace('/');
+          }}
         >
           Logout
         </button>


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Add a button on the /orglist page to logout user and redirects to login page i.e /

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
Fixes #180  <!--Add related issue number here.-->

**Did you add tests for your changes?**
No.
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**

![image](https://user-images.githubusercontent.com/41731424/145759092-9540689c-6223-4268-b23e-35b172a496fd.png)

<!--Add snapshots or videos wherever possible.-->

<!--Add link to Talawa-Docs.-->

**Summary**
Currently, there is no logout option on the site, except the one that logs the user out of the manage organization page.
If a user wants to log out he has to manually go to the '/' route and the local storage is cleared which is not a widely used logout flow.

**Does this PR introduce a breaking change?**
No.
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes.
<!--Yes or No-->
