### PR TITLE
Added Unit tests for Landing Page

### DIFF
--- a/src/components/LandingPage/LandingPage.test.tsx
+++ b/src/components/LandingPage/LandingPage.test.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import LandingPage from './LandingPage';
+import {
+  ApolloClient,
+  NormalizedCacheObject,
+  ApolloProvider,
+  InMemoryCache,
+} from '@apollo/client';
+
+const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
+  cache: new InMemoryCache(),
+  uri: 'https://talawa-graphql-api.herokuapp.com/graphql',
+});
+
+describe('Testing LandingPage', () => {
+  test('should render props and text elements test for the page component', () => {
+    render(
+      <ApolloProvider client={client}>
+        <LandingPage />
+      </ApolloProvider>
+    );
+    expect(
+      screen.getByText('Talawa Admin Management Portal')
+    ).toBeInTheDocument();
+    expect(screen.getByText('FROM PALISADOES')).toBeInTheDocument();
+  });
+});

--- a/src/components/LandingPage/LandingPage.tsx
+++ b/src/components/LandingPage/LandingPage.tsx
@@ -25,9 +25,12 @@ function LandingPage(): JSX.Element {
             </Carousel.Item>
           </Carousel>
         </div>
-        <h2 className={styles.fromtitle}>FROM PALISADOES</h2>
+        <h2 className={styles.fromtitle}>
+          <p>FROM PALISADOES</p>
+        </h2>
       </div>
     </>
   );
 }
+export {};
 export default LandingPage;


### PR DESCRIPTION
This PR adds unit tests for the landing page under a single test suite

Related to issue #157 

Tests run:
1). yarn test
2). yarn serve
3). yarn lint