### PR TITLE
Unit tests for testing Organisations People Page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "my-app",
+  "type": "module",
   "version": "0.1.0",
   "private": true,
   "dependencies": {
@@ -27,6 +28,7 @@
     "eslint-plugin-prettier": "^3.4.0",
     "graphql": "^15.5.1",
     "jest": "^27.4.5",
+    "jest-docblock": "^27.4.0",
     "prettier": "^2.3.2",
     "react": "^17.0.2",
     "react-apollo": "^3.1.5",
@@ -85,5 +87,16 @@
   },
   "resolutions": {
     "@apollo/client": "^3.4.0-beta.19"
+  },
+  "jest": {
+    "collectCoverageFrom": [
+      "src/**/*.ts*"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "lines": 20,
+        "statements": 20
+      }
+    }
   }
 }

--- a/src/screens/OrgList/OrgList.test.tsx
+++ b/src/screens/OrgList/OrgList.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { MockedProvider } from '@apollo/react-testing';
+import { act, render } from '@testing-library/react';
+import OrgList from './OrgList';
+import {
+  ORGANIZATION_LIST,
+  USER_ORGANIZATION_LIST,
+} from 'GraphQl/Queries/Queries';
+import { Provider } from 'react-redux';
+import { store } from 'state/store';
+
+const MOCKS = [
+  {
+    request: {
+      query: ORGANIZATION_LIST,
+    },
+    result: {
+      data: {
+        organizations: [
+          {
+            _id: 1,
+            image: '',
+            name: 'Akatsuki',
+            creator: {
+              firstName: 'John',
+              lastName: 'Doe',
+            },
+          },
+        ],
+      },
+    },
+  },
+  {
+    request: {
+      query: USER_ORGANIZATION_LIST,
+      variables: { id: localStorage.getItem('id') },
+    },
+    result: {
+      data: {
+        user: [
+          {
+            firstName: 'John',
+            lastName: 'Doe',
+            image: '',
+            email: 'John_Does_Palasidoes@gmail.com',
+            userType: '',
+            adminFor: {
+              _id: 1,
+              image: '',
+              name: 'Akatsuki',
+            },
+          },
+        ],
+      },
+    },
+  },
+];
+
+async function wait(ms = 0) {
+  await act(() => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  });
+}
+
+describe('Organisation List Page', () => {
+  test('correct mock data should be queried', async () => {
+    const dataQuery1 = MOCKS[0]?.result?.data?.organizations;
+
+    console.log(`Data is ${dataQuery1}`);
+    expect(dataQuery1).toEqual([
+      {
+        _id: 1,
+        creator: { firstName: 'John', lastName: 'Doe' },
+        image: '',
+        name: 'Akatsuki',
+      },
+    ]);
+  });
+  test('should render props and text elements test for the screen', async () => {
+    const { container } = render(
+      <MockedProvider addTypename={false} mocks={MOCKS}>
+        <Provider store={store}>
+          <OrgList />
+        </Provider>
+      </MockedProvider>
+    );
+
+    expect(container.textContent).not.toBe('Loading data...');
+    await wait();
+    console.log(container);
+    expect(container.textContent).toMatch('Name:');
+    expect(container.textContent).toMatch('Designation:');
+    expect(container.textContent).toMatch('Email:');
+    expect(container.textContent).toMatch('Contact:');
+  });
+});


### PR DESCRIPTION
Adds Unit tests for Organisations People Page

FIxes #165 ,  
Also in reference to #157 
1). Tests whether correct mock data is queried or not
2). Two mock objects created for two useQueries (1 for each) :- 
     a). `Organisations People Page`
     b). `ORGANIZATION_LIST`
3). Tests whether content is rendered on DOM or not
4). Tests whether correct content is labelled or not
5). Updates package `jest-docblock` to avoid errors during testing

Future tests possible:-
1). Testing Create Mutation     
                                                                                                     
![image](https://user-images.githubusercontent.com/59202075/148644103-09196281-a74f-446d-8cb8-14c33ef882c1.png)

