### PR TITLE
Rendering of components fixes

### DIFF
--- a/src/components/AdminNavbar/AdminNavbar.test.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.test.tsx
@@ -2,10 +2,15 @@ import React from 'react';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { render, screen } from '@testing-library/react';
 import AdminNavbar from './AdminNavbar';
+import { BrowserRouter } from 'react-router-dom';
 
 describe('Testing Admin Navbar', () => {
   // eslint-disable-next-line jest/expect-expect
   test('should render following text elements', () => {
-    render(<AdminNavbar url_1="palisadoes" targets={[]} />);
+    render(
+      <BrowserRouter>
+        <AdminNavbar url_1="palisadoes" targets={[]} />
+      </BrowserRouter>
+    );
   });
 });

--- a/src/components/AdminNavbar/AdminNavbar.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.tsx
@@ -5,6 +5,8 @@ import Dropdown from 'react-bootstrap/Dropdown';
 import Logo from 'assets/talawa-logo-200x200.png';
 import Row from 'react-bootstrap/Row';
 import { Nav } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+
 interface NavbarProps {
   targets: {
     url?: string;
@@ -24,15 +26,20 @@ function AdminNavbar({ targets, url_1 }: NavbarProps): JSX.Element {
       <Navbar className={styles.navbarbg}>
         <Navbar.Brand>
           <Row className={styles.navallitem}>
-            <a className={styles.logo} href="/orglist">
+            <Link className={styles.logo} to="/orglist">
               <img src={Logo} />
               <strong>Talawa Portal</strong>
-            </a>
+            </Link>
             <div className={styles.navit}>
               {targets.map(({ name, url, subTargets }) => {
                 return url ? (
                   <Nav.Item key={name} className={styles.navitems}>
-                    <Nav.Link href={url} id={name} className={styles.navlinks}>
+                    <Nav.Link
+                      as={Link}
+                      to={url}
+                      id={name}
+                      className={styles.navlinks}
+                    >
                       {name}
                     </Nav.Link>
                   </Nav.Item>
@@ -56,7 +63,8 @@ function AdminNavbar({ targets, url_1 }: NavbarProps): JSX.Element {
                           {subTargets.map((subTarget: any, index: number) => (
                             <Dropdown.Item
                               key={index}
-                              href={subTarget.url}
+                              as={Link}
+                              to={subTarget.url}
                               className={styles.dropdownitem}
                             >
                               <i
@@ -84,10 +92,10 @@ function AdminNavbar({ targets, url_1 }: NavbarProps): JSX.Element {
             />
           </Dropdown.Toggle>
           <Dropdown.Menu className={styles.dropdownMenu}>
-            <Dropdown.Item href="/notification">
+            <Dropdown.Item as={Link} to="/notification">
               <i className="fa fa-bell"></i>&ensp; Notify
             </Dropdown.Item>
-            <Dropdown.Item href={url_1}>
+            <Dropdown.Item as={Link} to={url_1}>
               <i className="fa fa-cogs"></i>&ensp; Settings
             </Dropdown.Item>
             <Dropdown.Item

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.test.tsx
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.test.tsx
@@ -5,6 +5,7 @@ import OrganizationDashboard from './OrganizationDashboard';
 import { ORGANIZATIONS_LIST } from 'GraphQl/Queries/Queries';
 import { Provider } from 'react-redux';
 import { store } from 'state/store';
+import { BrowserRouter } from 'react-router-dom';
 
 const MOCKS = [
   {
@@ -43,9 +44,11 @@ describe('Organisation Dashboard Page', () => {
   test('should render props and text elements test for the screen', async () => {
     const { container } = render(
       <MockedProvider addTypename={false} mocks={MOCKS}>
-        <Provider store={store}>
-          <OrganizationDashboard />
-        </Provider>
+        <BrowserRouter>
+          <Provider store={store}>
+            <OrganizationDashboard />
+          </Provider>
+        </BrowserRouter>
       </MockedProvider>
     );
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**

Fixes #214 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

![fix_talawa](https://user-images.githubusercontent.com/63240102/148667790-c90cd559-704b-48e8-af79-ddb55c53bc68.gif)

**If relevant, did you update the documentation?**

No

**Summary**

While rendering components from the navigation bar page is reloading. Instead of just rendering the component, which is not a good user experience. The user expects, when someone clicks on a navigation link, only the component is loaded instead of the whole page.

**Does this PR introduce a breaking change?**

No

**Other information**

Nil

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
