### PR TITLE
Fix yarn test warning of paragraph tag nesting

### DIFF
--- a/src/components/EventListCard/EventListCard.tsx
+++ b/src/components/EventListCard/EventListCard.tsx
@@ -49,14 +49,10 @@ function EventListCard(props: EventListCardProps): JSX.Element {
         <Col className={styles.singledetails}>
           <div className={styles.singledetails_data_left}>
             <p className={styles.orgname}>
-              {props.eventName ? <p>{props.eventName}</p> : <p>Dogs Care</p>}
+              {props.eventName ? <>{props.eventName}</> : <>Dogs Care</>}
             </p>
             <p className={styles.orgfont}>
-              {props.eventLocation ? (
-                <p>{props.eventLocation}</p>
-              ) : (
-                <p>India</p>
-              )}
+              {props.eventLocation ? <>{props.eventLocation}</> : <>India</>}
             </p>
             <p className={styles.orgfont}>
               Admin: <span>{props.totalAdmin}</span>

--- a/src/components/MemberRequestCard/MemberRequestCard.tsx
+++ b/src/components/MemberRequestCard/MemberRequestCard.tsx
@@ -69,11 +69,7 @@ function MemberRequestCard(props: MemberRequestCardProps): JSX.Element {
           <Col className={styles.singledetails}>
             <div className={styles.singledetails_data_left}>
               <p className={styles.membername}>
-                {props.memberName ? (
-                  <p>{props.memberName}</p>
-                ) : (
-                  <p>Dogs Care</p>
-                )}
+                {props.memberName ? <>{props.memberName}</> : <>Dogs Care</>}
               </p>
               <p className={styles.memberfont}>{props.memberLocation}</p>
               <p className={styles.memberfontcreated}>{props.email}</p>

--- a/src/components/OrgAdminListCard/OrgAdminListCard.tsx
+++ b/src/components/OrgAdminListCard/OrgAdminListCard.tsx
@@ -51,11 +51,7 @@ function OrgAdminListCard(props: OrgPeopleListCardProps): JSX.Element {
           <Col className={styles.singledetails}>
             <div className={styles.singledetails_data_left}>
               <p className={styles.membername}>
-                {props.memberName ? (
-                  <p>{props.memberName}</p>
-                ) : (
-                  <p>Dogs Care</p>
-                )}
+                {props.memberName ? <>{props.memberName}</> : <>Dogs Care</>}
               </p>
               <p className={styles.memberfont}>
                 <span>{props.memberLocation}</span>

--- a/src/components/OrgPeopleListCard/OrgPeopleListCard.tsx
+++ b/src/components/OrgPeopleListCard/OrgPeopleListCard.tsx
@@ -51,11 +51,7 @@ function OrgPeopleListCard(props: OrgPeopleListCardProps): JSX.Element {
           <Col className={styles.singledetails}>
             <div className={styles.singledetails_data_left}>
               <p className={styles.membername}>
-                {props.memberName ? (
-                  <p>{props.memberName}</p>
-                ) : (
-                  <p>Dogs Care</p>
-                )}
+                {props.memberName ? <>{props.memberName}</> : <>Dogs Care</>}
               </p>
               <p className={styles.memberfont}>{props.memberLocation}</p>
               <p className={styles.memberfontcreated}>saumya47999@gmail.com</p>

--- a/src/components/SuperDashListCard/SuperDashListCard.tsx
+++ b/src/components/SuperDashListCard/SuperDashListCard.tsx
@@ -32,7 +32,7 @@ function SuperDashListCard(props: SuperDashListCardProps): JSX.Element {
         <Col className={styles.singledetails}>
           <div className={styles.singledetails_data_left}>
             <p className={styles.orgname}>
-              {props.orgName ? <p>{props.orgName}</p> : <p>Dogs Care</p>}
+              {props.orgName ? <>{props.orgName}</> : <>Dogs Care</>}
             </p>
             <p className={styles.orgfont}>{props.orgLocation}</p>
             <p className={styles.orgfontcreated}>

--- a/src/components/UserListCard/UserListCard.tsx
+++ b/src/components/UserListCard/UserListCard.tsx
@@ -49,11 +49,7 @@ function UserListCard(props: UserListCardProps): JSX.Element {
           <Col className={styles.singledetails}>
             <div className={styles.singledetails_data_left}>
               <p className={styles.membername}>
-                {props.memberName ? (
-                  <p>{props.memberName}</p>
-                ) : (
-                  <p>Dogs Care</p>
-                )}
+                {props.memberName ? <>{props.memberName}</> : <>Dogs Care</>}
               </p>
               <p className={styles.memberfont}>{props.memberLocation}</p>
               <p className={styles.memberfontcreated}>saumya47999@gmail.com</p>


### PR DESCRIPTION

**What kind of change does this PR introduce?**

bugFix

**Issue Number:**
Fixes #218 

Instead of nesting `<p> tags inside a <p> tag` , empty tag (equivalent of React.Fragment has been used)
There is no change caused in UI and the warnings have been resolved

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
