### PR TITLE
Add a seperate CodeQl workflow file to perform all workflows without errors

### DIFF
--- a/.github/workflows/codeql-codescan.yml
+++ b/.github/workflows/codeql-codescan.yml
@@ -1,0 +1,43 @@
+##############################################################################
+##############################################################################
+#
+# NOTE!
+#
+# Please read the README.md file in this directory that defines what should 
+# be placed in this file
+#
+##############################################################################
+##############################################################################
+
+name: codeql codescan workflow
+
+on:
+  pull_request:
+    branches:
+      - '**'  
+  push:
+    branches:
+      - '**'   
+jobs:
+  CodeQL:
+    name: Analyse code with codeQL on push
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript' ]
+    steps:
+       - name: Checkout repository
+         uses: actions/checkout@v2
+
+       - name: Initialize CodeQL
+         uses: github/codeql-action/init@v1
+         with:
+          languages: ${{ matrix.language }}
+          debug: true
+
+       - name: Autobuild
+         uses: github/codeql-action/autobuild@v1
+
+       - name: Perform CodeQL Analysis
+         uses: github/codeql-action/analyze@v1

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -56,26 +56,3 @@ jobs:
           path: "./coverage/lcov.info"
           min_coverage: 20       
 
-  CodeQL:
-    name: Analyse code with codeQL
-    runs-on: ubuntu-latest
-    needs: Code-Coverage
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'javascript' ]
-    steps:
-       - name: Checkout repository
-         uses: actions/checkout@v2
-
-       - name: Initialize CodeQL
-         uses: github/codeql-action/init@v1
-         with:
-          languages: ${{ matrix.language }}
-          debug: true
-
-       - name: Autobuild
-         uses: github/codeql-action/autobuild@v1
-
-       - name: Perform CodeQL Analysis
-         uses: github/codeql-action/analyze@v1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -15,33 +15,9 @@ on:
   push:
     branches:
       - '**'   
-jobs:
-  CodeQL:
-    name: Analyse code with codeQL on push
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        language: [ 'javascript' ]
-    steps:
-       - name: Checkout repository
-         uses: actions/checkout@v2
-
-       - name: Initialize CodeQL
-         uses: github/codeql-action/init@v1
-         with:
-          languages: ${{ matrix.language }}
-          debug: true
-
-       - name: Autobuild
-         uses: github/codeql-action/autobuild@v1
-
-       - name: Perform CodeQL Analysis
-         uses: github/codeql-action/analyze@v1
-
+jobs:      
   Code-Coverage:
     runs-on: ubuntu-latest
-    needs: CodeQL
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1


### PR DESCRIPTION
Created a seperate workflow file for codeQL that will have branches for both `on.push` and `on.pull-request` instances and will fix all codeQL warnings 

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

bugFix

**Issue Number:**

Fixes #210 


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

YEs
