### PR TITLE
Unit Tests for Organisation Settings Page

### DIFF
--- a/src/screens/OrgSettings/OrganizationDashboard.test.tsx
+++ b/src/screens/OrgSettings/OrganizationDashboard.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { MockedProvider } from '@apollo/react-testing';
+import { act, render } from '@testing-library/react';
+import OrgSettings from './OrgSettings';
+import { MEMBERSHIP_REQUEST } from 'GraphQl/Queries/Queries';
+import { Provider } from 'react-redux';
+import { store } from 'state/store';
+import { BrowserRouter } from 'react-router-dom';
+
+const MOCKS = [
+  {
+    request: {
+      query: MEMBERSHIP_REQUEST,
+    },
+    result: {
+      data: {
+        organizations: [
+          {
+            _id: 1,
+            membershipRequests: {
+              _id: 1,
+              user: {
+                _id: 1,
+                firstName: 'John',
+                lastName: 'Doe',
+                email: 'johndoe@gmail.com',
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
+];
+
+async function wait(ms = 0) {
+  await act(() => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  });
+}
+
+describe('Organisation Settings Page', () => {
+  test('correct mock data should be queried', async () => {
+    const dataQuery1 = MOCKS[0]?.result?.data?.organizations[0];
+
+    console.log(`Data is ${dataQuery1}`);
+    expect(dataQuery1).toEqual({
+      _id: 1,
+      membershipRequests: {
+        _id: 1,
+        user: {
+          _id: 1,
+          email: 'johndoe@gmail.com',
+          firstName: 'John',
+          lastName: 'Doe',
+        },
+      },
+    });
+  });
+  test('should render props and text elements test for the screen', async () => {
+    const { container } = render(
+      <MockedProvider addTypename={false} mocks={MOCKS}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <OrgSettings />
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    expect(container.textContent).not.toBe('Loading data...');
+    await wait();
+    expect(container.textContent).toMatch('Settings');
+    expect(container.textContent).toMatch('Update Your Details');
+    expect(container.textContent).toMatch('Update Organization');
+    expect(container.textContent).toMatch('Delete Organization');
+    expect(container.textContent).toMatch('See Request');
+  });
+});


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Testing

**Description**

Adds Unit Tests for Organisation Settings Page

1). Mock data for useQuery on `MEMBERSHIP_REQUEST`
2). Testing whether Mock Data is correctly queried or not
3). Testing container content matching


**Issue Number:**

Fixes #162 
Also in reference to #157 

Also increases test code coverage by 1.83%  to a total of `24.25%`

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![image](https://user-images.githubusercontent.com/59202075/148992927-8d5b4062-8015-4bb5-b990-86e66012b511.png)

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
