### PR TITLE
Fix main right section overlap at width les than 576px

### DIFF
--- a/src/screens/OrgContribution/OrgContribution.module.css
+++ b/src/screens/OrgContribution/OrgContribution.module.css
@@ -115,6 +115,14 @@
   display: flex;
   justify-content: space-between;
 }
+@media screen and (max-width: 575.5px) {
+  .justifysp {
+    padding-left: 55px;
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  }
+}
 .addbtn {
   border: 1px solid #e8e5e5;
   box-shadow: 0 2px 2px #e8e5e5;

--- a/src/screens/OrgPost/OrgPost.module.css
+++ b/src/screens/OrgPost/OrgPost.module.css
@@ -122,6 +122,18 @@
   display: flex;
   justify-content: space-between;
 }
+@media screen and (max-width: 575.5px) {
+  .justifysp {
+    padding-left: 55px;
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .mainpageright {
+    width: 98%;
+  }
+}
 .addbtn {
   border: 1px solid #e8e5e5;
   box-shadow: 0 2px 2px #e8e5e5;

--- a/src/screens/OrganizationEvents/OrganizationEvents.module.css
+++ b/src/screens/OrganizationEvents/OrganizationEvents.module.css
@@ -114,6 +114,19 @@
   display: flex;
   justify-content: space-between;
 }
+
+@media screen and (max-width: 575.5px) {
+  .justifysp {
+    padding-left: 55px;
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  }
+
+  .mainpageright {
+    width: 90%;
+  }
+}
 .addbtn {
   border: 1px solid #e8e5e5;
   box-shadow: 0 2px 2px #e8e5e5;

--- a/src/screens/OrganizationPeople/OrganizationPeople.module.css
+++ b/src/screens/OrganizationPeople/OrganizationPeople.module.css
@@ -88,6 +88,15 @@
   display: flex;
   justify-content: space-between;
 }
+@media screen and (max-width: 575.5px) {
+  .justifysp {
+    padding-left: 55px;
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+  }
+}
+
 .logintitleadmin {
   color: #707070;
   font-weight: 600;


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #224 

In reference to parent issue #207 

Fixes the content overflow in right section of each page

1). Content no longer overflows at width breakpoint of  less than 576px.
2). Proper media queries have been used

Tests:-
1). yarn serve
2). yarn lint
3). yarn test  --coverage --watchAll ran to check changes by PR

**Snapshots/Videos:**

![image](https://user-images.githubusercontent.com/59202075/149125956-96e4763e-acdf-431f-a031-f85edbce024e.png)

![image](https://user-images.githubusercontent.com/59202075/149126025-fdc6ff24-5a1b-46e1-94ee-2297c9dcb415.png)

![image](https://user-images.githubusercontent.com/59202075/149126056-189ef909-cea2-481c-b2d0-4ec112af2513.png)

![image](https://user-images.githubusercontent.com/59202075/149126568-d2f9f7ea-f179-4c4b-b3e5-0141983485a0.png)



**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
