### PR TITLE
Add tests for organisation events page

### DIFF
--- a/src/screens/OrganizationEvents/OrganizationEvents.test.tsx
+++ b/src/screens/OrganizationEvents/OrganizationEvents.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { MockedProvider } from '@apollo/react-testing';
+import { act, render } from '@testing-library/react';
+import OrganizationEvents from './OrganizationEvents';
+import { ORGANIZATION_EVENT_LIST } from 'GraphQl/Queries/Queries';
+import { Provider } from 'react-redux';
+import { store } from 'state/store';
+import { BrowserRouter } from 'react-router-dom';
+
+const MOCKS = [
+  {
+    request: {
+      query: ORGANIZATION_EVENT_LIST,
+    },
+    result: {
+      data: {
+        eventsByOrganization: [
+          {
+            _id: 1,
+            title: 'Event',
+            description: 'Event Test',
+            startDate: '',
+          },
+        ],
+      },
+    },
+  },
+];
+
+async function wait(ms = 0) {
+  await act(() => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  });
+}
+
+describe('Organisation Events Page', () => {
+  test('It is necessary to query the correct mock data.', async () => {
+    const dataQuery1 = MOCKS[0]?.result?.data?.eventsByOrganization[0];
+
+    console.log(`Data is ${dataQuery1}`);
+    expect(dataQuery1).toEqual({
+      _id: 1,
+      title: 'Event',
+      description: 'Event Test',
+      startDate: '',
+    });
+  });
+  test('It is necessary to check correct render', async () => {
+    const { container } = render(
+      <MockedProvider addTypename={false} mocks={MOCKS}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <OrganizationEvents />
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    expect(container.textContent).not.toBe('Loading data...');
+    await wait();
+    expect(container.textContent).toMatch('Events');
+    expect(container.textContent).toMatch('Filter by Organization');
+    expect(container.textContent).toMatch('Filter by Location');
+    expect(container.textContent).toMatch('Events');
+  });
+});


### PR DESCRIPTION
What kind of change does this PR introduce?

Testing

Description

Adds Unit Tests for Organisation Events Page

1). Mock data for useQuery on `ORGANIZATION_EVENT_LIST`
2). Testing whether Mock Data is correctly queried or not
3). Testing container content matching

Issue Number:

Fixes #164 
Also in reference to #157

Also increases test code coverage to a total of 30.32%

Did you add tests for your changes?

Yes


![image](https://user-images.githubusercontent.com/59202075/149772283-2d4dfee3-dca3-42e1-b726-5bf02327cbfc.png)
