### PR TITLE
Bugfix : Confirm User before Deleting an Organization

### DIFF
--- a/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
@@ -24,16 +24,22 @@ function OrganizationDashboard(): JSX.Element {
   const [del] = useMutation(DELETE_ORGANIZATION_MUTATION);
 
   const delete_org = async () => {
-    if (confirm('Are you sure to Delete the Organization ?')) {
-      const { data } = await del({
-        variables: {
-          id: currentUrl,
-        },
-      });
-      console.log(data);
-      window.location.replace('/orglist');
-    } else {
-      alert('Could Not Delete Organization');
+    if (
+      confirm(
+        'This action cannot be undone. This will permanently delete the organization, calendars, chats, news feeds, groups, and remove all collaborator associations.'
+      )
+    ) {
+      if (confirm('Are you sure to Delete this Organization ?')) {
+        const { data } = await del({
+          variables: {
+            id: currentUrl,
+          },
+        });
+        console.log(data);
+        window.location.replace('/orglist');
+      } else {
+        alert('Could Not Delete Organization');
+      }
     }
   };
 

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
@@ -24,13 +24,17 @@ function OrganizationDashboard(): JSX.Element {
   const [del] = useMutation(DELETE_ORGANIZATION_MUTATION);
 
   const delete_org = async () => {
-    const { data } = await del({
-      variables: {
-        id: currentUrl,
-      },
-    });
-    console.log(data);
-    window.location.replace('/orglist');
+    if (confirm('Are you sure to Delete the Organization ?')) {
+      const { data } = await del({
+        variables: {
+          id: currentUrl,
+        },
+      });
+      console.log(data);
+      window.location.replace('/orglist');
+    } else {
+      alert('Could Not Delete Organization');
+    }
   };
 
   if (loading) {


### PR DESCRIPTION

**What kind of change does this PR introduce?**

 bugfix

**Issue Number:**

Fixes #195 

**Did you add tests for your changes?**

 No

**Snapshots/Videos:**

Before : 

![BeforeGif](https://github.com/Lord-Aman/Workspace/blob/master/before.gif?raw=true)

After : 

![AfterGif](https://github.com/Lord-Aman/Workspace/blob/master/after.gif?raw=true)

**Summary**

Deleting an organization is a major event. Calendars, chats, news feeds, groups could all be deleted. This could severely impact an organization by removing relationships between members.

I have prompted the user asking them whether they are sure they want to do this.

Only the Creator of an Organization can delete it (according to the API ) : So whenever the creator will click on the delete button, the organization will be Deleted.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
