### PR TITLE
Add tests for Reducer Action Interface

### DIFF
--- a/src/state/helpers/Action.test.ts
+++ b/src/state/helpers/Action.test.ts
@@ -1,0 +1,8 @@
+import { Action } from './Action'
+
+test("Testing Reducer Action Interface", () => {
+  ({
+    type: 'STRING_ACTION_TYPE',
+    payload: 'ANY_PAYLOAD',
+  } as Action);
+})

--- a/src/state/helpers/Action.test.ts
+++ b/src/state/helpers/Action.test.ts
@@ -1,8 +1,8 @@
-import { Action } from './Action'
+import { Action } from './Action';
 
-test("Testing Reducer Action Interface", () => {
+test('Testing Reducer Action Interface', () => {
   ({
     type: 'STRING_ACTION_TYPE',
     payload: 'ANY_PAYLOAD',
   } as Action);
-})
+});


### PR DESCRIPTION

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #282 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![ActionTest](https://user-images.githubusercontent.com/56475750/158036055-a6f15194-e731-4021-a20a-2f9107575f2e.png)


<!--Add snapshots or videos wherever possible.-->


**If relevant, did you update the documentation?**

Not required.

**Summary**

Added tests for Action interface present in `src/state/helpers/Action.ts`
However, There is no code to cover here, since nothing is executable. 
The file has only one interface which only exist at compile-time not at runtime. 
But it will notify if the interface is wrongly initiated at build time.

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes