### PR TITLE
Synchronised package versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "lint": "eslint \"**/*.{ts,tsx}\"",
     "lint-fix": "eslint \"**/*.{ts,tsx}\" --fix",
     "format": "prettier --write \"**/*.{ts,tsx,json,scss,css}\"",
-    "setup": "npm i boxen@4.2.0 chalk@4.1.0 inquirer markdown-js marked@2.0.1 marked-terminal@4.1.0 node-cmd@5.0.0 -f && node setup_file.js"
+    "setup": "yarn add boxen@^4.2.0 chalk@^4.1.0 inquirer@^8.2.4 markdown-js@^0.0.4 marked@^4.0.10 marked-terminal@^4.1.0 node-cmd@^5.0.0 -f && node setup_file.js"
   },
   "eslintConfig": {
     "extends": [

--- a/setup/utils/markdown.js
+++ b/setup/utils/markdown.js
@@ -1,7 +1,7 @@
 /**
  * @function to display the content of a markdown file
  */
-import marked from 'marked';
+import { marked } from 'marked';
 import TerminalRenderer from 'marked-terminal';
 
 marked.setOptions({


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR solves a bug that caused unnecessary changes during the initial setup

**Issue Number:**

Fixes  #372 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

Not Relevant, the setup doesn't cause any files to change now.

**If relevant, did you update the documentation?**

Not Relevant 

**Summary**

- In the `yarn setup` script, some packages are initially installed to carry out setup tasks
- These packages cannot be updated by the dependa-bot unlike in the `dependencies` object
- Thus, this [PR](https://github.com/PalisadoesFoundation/talawa-admin/pull/301/files) caused the bug by bumping the version of the `marked` package
- I've synchronized the versions of packages between the setup script and dependencies object.
- Also, used `yarn` to install these packages instead of `npm`

**Does this PR introduce a breaking change?**

No

**Other information**

This issue can arise again in the future if the packages installed initially in the `setup` scripts are updated by dependa-bot or by someone else, to prevent this bug, the version must be manually synchronized between the `setup` script and `dependencies` object.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes