### PR TITLE
Remove Heroku Reference from OrgDelete Tests

### DIFF
--- a/src/Constant/constant.ts
+++ b/src/Constant/constant.ts
@@ -1,1 +1,2 @@
 export const AUTH_TOKEN = '';
+export const BACKEND_URL = process.env.REACT_APP_TALAWA_URL;

--- a/src/components/OrgDelete/OrgDelete.test.tsx
+++ b/src/components/OrgDelete/OrgDelete.test.tsx
@@ -13,7 +13,6 @@ import i18nForTest from 'utils/i18nForTest';
 
 const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
   cache: new InMemoryCache(),
-  uri: 'https://talawa-graphql-api.herokuapp.com/graphql',
 });
 
 describe('Testing Organization People List Card', () => {

--- a/src/components/OrgDelete/OrgDelete.test.tsx
+++ b/src/components/OrgDelete/OrgDelete.test.tsx
@@ -10,9 +10,11 @@ import { I18nextProvider } from 'react-i18next';
 
 import OrgDelete from './OrgDelete';
 import i18nForTest from 'utils/i18nForTest';
+import { BACKEND_URL } from 'Constant/constant';
 
 const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
   cache: new InMemoryCache(),
+  uri: BACKEND_URL,
 });
 
 describe('Testing Organization People List Card', () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #409 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

<img width="730" alt="Screenshot 2023-01-28 at 11 43 59 PM" src="https://user-images.githubusercontent.com/28570857/215283896-30b295c7-8223-44ef-b089-cd499baecad6.png">

**If relevant, did you update the documentation?**

Not Relevant

**Summary**

- Added the `BACKEND_URL` constant
- The constant extracts value from the `REACT_APP_TALAWA_URL` environment variable
- Replaced the hard-coded reference to `talawa-graphql-api.herokuapp.com` with a new constant

**Does this PR introduce a breaking change?**

No

**Other information**

- The other test cases directly access the `REACT_APP_TALAWA_URL` environment variable
- There is nothing wrong with this approach 
- But using a constant to extract the environment variable and later using the same constant in the different files is a better approach
- As it is easy to maintain and refactor
- We may change the name of the environment variable in the future and that would require us to refactor dozens of files
- Using constant solves this issue
- I've created another issue to replicate this approach across other tests pages - #417 

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes