### PR TITLE
Remove reference to heroku URL in LandingPage test

### DIFF
--- a/src/components/LandingPage/LandingPage.test.tsx
+++ b/src/components/LandingPage/LandingPage.test.tsx
@@ -10,10 +10,11 @@ import {
   InMemoryCache,
 } from '@apollo/client';
 import i18n from 'utils/i18n';
+import { BACKEND_URL } from 'Constant/constant';
 
 const client: ApolloClient<NormalizedCacheObject> = new ApolloClient({
   cache: new InMemoryCache(),
-  uri: 'https://talawa-graphql-api.herokuapp.com/graphql',
+  uri: BACKEND_URL,
 });
 
 describe('Testing LandingPage', () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #410 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

<img width="757" alt="Screenshot 2023-01-29 at 4 34 21 AM" src="https://user-images.githubusercontent.com/28570857/215295139-25555459-3f66-45a2-9306-90822b2cfe9a.png">


**If relevant, did you update the documentation?**

Not Relevant

**Summary**

- Replaced the hard-coded reference to `talawa-graphql-api.herokuapp.com` with a `BACKEND_URL` constant

**Does this PR introduce a breaking change?**

No

**Other information**

None

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes