### PR TITLE
Fix Org creation error

### DIFF
--- a/src/GraphQl/Mutations/mutations.ts
+++ b/src/GraphQl/Mutations/mutations.ts
@@ -143,7 +143,7 @@ export const CREATE_ORGANIZATION_MUTATION = gql`
     $name: String!
     $visibleInSearch: Boolean!
     $isPublic: Boolean!
-    $tags: [String]
+    $tags: [String!]!
   ) {
     createOrganization(
       data: {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

**Issue Number:**

Fixes #370 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

Error when creating a new organization -

<img width="1904" alt="Screenshot 2023-01-30 at 3 00 41 AM" src="https://user-images.githubusercontent.com/28570857/215357145-6cd7fe12-2a7f-430d-9062-04958a50916b.png">

The response returned from the server -

<img width="757" alt="Screenshot 2023-01-30 at 3 01 41 AM" src="https://user-images.githubusercontent.com/28570857/215357223-237795ca-2847-4ca8-b635-72550f6ef1ee.png">

**If relevant, did you update the documentation?**

Not Relevant 

**Summary**

- The backend returned an error when creating a new organization with `tags`
- This was due type mismatch between frontend (`[String]`) and backend (`[String!]!`)
- I've fixed the GraphQL mutation query to match the backend
- Thus, the error has been resolved, I've added supporting screenshots below

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

No

**Other information**

New organization getting created with `tags` - 

<img width="1904" alt="Screenshot 2023-01-30 at 3 04 05 AM" src="https://user-images.githubusercontent.com/28570857/215357421-fd0d0811-2234-447b-9e72-f1e45ade60c8.png">

All tests passing -

<img width="757" alt="Screenshot 2023-01-30 at 3 07 00 AM" src="https://user-images.githubusercontent.com/28570857/215357431-b96d02a2-2e63-465a-a31f-a2af8385938a.png">


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
