### PR TITLE
Move Linting action to Linter Section in GitHub Workflow [Fixes #432]

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -27,8 +27,9 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Dependencies
         run: yarn
-      - name: Run ESLint
-        run: yarn lint
+      - name: Run linting check
+        run: yarn lint:check
+
 
   Count-lines-of-code:
     name: Total number of lines in every file should not be more than 400
@@ -39,10 +40,6 @@ jobs:
       - run: chmod +x ./.github/workflows/countline.py
       - run: |
           ./.github/workflows/countline.py --exclude_files src/screens/LoginPage/LoginPage.tsx
-      - name: Install Dependencies
-        run: yarn
-      - name: Check linting
-        run: yarn lint:check
       
   Formatting:
     name: Check formatting


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Bug Fix
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #432 
**Did you add tests for your changes?**
NA
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**If relevant, did you update the documentation?**
NA
<!--Add link to Talawa-Docs.-->

**Summary**
Moved the linting action to the linter section in the GitHub workflow file. Also changed the linting action to just check for the linting errors, instead of running and linting the code.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
