### PR TITLE
Removed spamInOrganizations from User Query and Fixed Various Pages

### DIFF
--- a/src/GraphQl/Queries/Queries.ts
+++ b/src/GraphQl/Queries/Queries.ts
@@ -75,10 +75,6 @@ export const USER_LIST = gql`
       email
       userType
       adminApproved
-      spamInOrganizations {
-        _id
-        name
-      }
       organizationsBlockedBy {
         _id
         name

--- a/src/screens/BlockUser/BlockUser.test.tsx
+++ b/src/screens/BlockUser/BlockUser.test.tsx
@@ -33,12 +33,6 @@ const MOCKS = [
             userType: 'SUPERADMIN',
             adminApproved: true,
             createdAt: '20/06/2022',
-            spamInOrganizations: [
-              {
-                _id: '123',
-                name: 'ABC',
-              },
-            ],
             organizationsBlockedBy: [
               {
                 _id: '123',
@@ -55,12 +49,6 @@ const MOCKS = [
             userType: 'ADMIN',
             adminApproved: false,
             createdAt: '20/06/2022',
-            spamInOrganizations: [
-              {
-                _id: '123',
-                name: 'ABC',
-              },
-            ],
             organizationsBlockedBy: [
               {
                 _id: '443',

--- a/src/screens/BlockUser/BlockUser.tsx
+++ b/src/screens/BlockUser/BlockUser.tsx
@@ -43,11 +43,7 @@ const Requests = () => {
 
   useEffect(() => {
     if (data) {
-      setUsersData(
-        data.users.filter((user: any) =>
-          user.spamInOrganizations.some((spam: any) => spam._id === currentUrl)
-        )
-      );
+      setUsersData(data.users);
     }
   }, [data]);
 

--- a/src/screens/OrganizationPeople/OrganizationPeople.test.tsx
+++ b/src/screens/OrganizationPeople/OrganizationPeople.test.tsx
@@ -76,12 +76,6 @@ const MOCKS = [
             userType: 'SUPERADMIN',
             adminApproved: true,
             createdAt: '24/06/2022',
-            spamInOrganizations: [
-              {
-                _id: '123',
-                name: 'Sam',
-              },
-            ],
             organizationsBlockedBy: [
               {
                 _id: '256',
@@ -157,12 +151,6 @@ describe('Organisation People Page', () => {
         userType: 'SUPERADMIN',
         adminApproved: true,
         createdAt: '24/06/2022',
-        spamInOrganizations: [
-          {
-            _id: '123',
-            name: 'Sam',
-          },
-        ],
         organizationsBlockedBy: [
           {
             _id: '256',

--- a/src/screens/Requests/Requests.test.tsx
+++ b/src/screens/Requests/Requests.test.tsx
@@ -34,12 +34,6 @@ const MOCKS = [
             userType: 'SUPERADMIN',
             adminApproved: true,
             createdAt: '20/06/2022',
-            spamInOrganizations: [
-              {
-                _id: '123',
-                name: 'Sam',
-              },
-            ],
             organizationsBlockedBy: [
               {
                 _id: '256',
@@ -56,12 +50,6 @@ const MOCKS = [
             userType: 'ADMIN',
             adminApproved: false,
             createdAt: '20/06/2022',
-            spamInOrganizations: [
-              {
-                _id: '123',
-                name: 'Sam',
-              },
-            ],
             organizationsBlockedBy: [
               {
                 _id: '256',
@@ -78,12 +66,6 @@ const MOCKS = [
             userType: 'USER',
             adminApproved: true,
             createdAt: '20/06/2022',
-            spamInOrganizations: [
-              {
-                _id: '123',
-                name: 'Sam',
-              },
-            ],
             organizationsBlockedBy: [
               {
                 _id: '256',

--- a/src/screens/Roles/Roles.test.tsx
+++ b/src/screens/Roles/Roles.test.tsx
@@ -31,12 +31,6 @@ const MOCKS = [
             userType: 'SUPERADMIN',
             adminApproved: true,
             createdAt: '20/06/2022',
-            spamInOrganizations: [
-              {
-                _id: '123',
-                name: 'Sam',
-              },
-            ],
             organizationsBlockedBy: [
               {
                 _id: '256',
@@ -53,12 +47,6 @@ const MOCKS = [
             userType: 'ADMIN',
             adminApproved: true,
             createdAt: '20/06/2022',
-            spamInOrganizations: [
-              {
-                _id: '123',
-                name: 'Sam',
-              },
-            ],
             organizationsBlockedBy: [
               {
                 _id: '256',
@@ -75,12 +63,6 @@ const MOCKS = [
             userType: 'USER',
             adminApproved: true,
             createdAt: '20/06/2022',
-            spamInOrganizations: [
-              {
-                _id: '123',
-                name: 'Sam',
-              },
-            ],
             organizationsBlockedBy: [
               {
                 _id: '256',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug Fix

**Issue Number:**

Fixes #371 

**Did you add tests for your changes?**

Not Needed

**Snapshots/Videos:**

`Roles` and `Request` pages working fine -

<img width="1768" alt="Screenshot 2023-02-11 at 6 11 12 PM" src="https://user-images.githubusercontent.com/28570857/218258493-a5fa526b-f0a1-4550-9f8d-5f46c75af7f9.png">

The `OrganizationPeople`  page working fine -

<img width="1768" alt="Screenshot 2023-02-11 at 6 12 08 PM" src="https://user-images.githubusercontent.com/28570857/218258537-61bdd9c7-ea0a-4ebf-bf71-695948368d92.png">

The `Block/Unblock User` page working fine -

<img width="1768" alt="Screenshot 2023-02-11 at 6 12 53 PM" src="https://user-images.githubusercontent.com/28570857/218258561-db9ee80b-46c4-4f8a-a277-7187be5ea63b.png">

**If relevant, did you update the documentation?**

Not Relevant

**Summary**

- The `LIST_USER` query has a type mismatch between the frontend and backend
- The `spamInOrganisation` param was removed from the backend
- This causes many pages like `Roles`, `Request`, `OrganizationPeople `, `BlockUser`, and `AddOnStore` to fail
- I've removed the `spamInOrganisation` param from frontend and fixed the failing tests as result of it
- Also, removed mock data from other test files

**Does this PR introduce a breaking change?**

No

**Other information**

All test cases passing -

<img width="653" alt="Screenshot 2023-02-11 at 6 10 37 PM" src="https://user-images.githubusercontent.com/28570857/218258471-3ac24f24-203d-4180-b899-e5a97bec024a.png">


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes