### PR TITLE
orgSettings: UI refactor with locale

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -275,6 +275,15 @@
     "settings": "Settings",
     "noData": "No data"
   },
+  "orgDelete": {
+    "location": "Location",
+    "about": "About",
+    "deleteThisOrganization": "Delete This Organization",
+    "deleteOrg": "Delete Organization",
+    "deleteMsg": "Do you want to delete this organization?",
+    "no": "No",
+    "yes": "Yes"
+  },
   "userUpdate": {
     "firstName": "First Name",
     "lastName": "Last Name",
@@ -287,9 +296,6 @@
     "displayImage": "Display Image",
     "saveChanges": "Save Changes",
     "cancel": "Cancel"
-  },
-  "orgDelete": {
-    "deleteOrg": "Delete Org"
   },
   "membershipRequest": {
     "joined": "Joined",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -289,7 +289,13 @@
     "cancel": "Annuler"
   },
   "orgDelete": {
-    "deleteOrg": "Supprimer l'organisation"
+    "location": "Emplacement",
+    "about": "À propos de",
+    "deleteThisOrganization": "Supprimer cette organisation",
+    "deleteOrg": "Supprimer l'organisation",
+    "deleteMsg": "Voulez-vous supprimer cette organisation ?",
+    "no": "Non",
+    "yes": "Oui"
   },
   "membershipRequest": {
     "joined": "Inscrit",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -289,7 +289,13 @@
     "cancel": "रद्द करना"
   },
   "orgDelete": {
-    "deleteOrg": "संगठन हटाएं"
+    "location": "स्थान",
+    "about": "के बारे में",
+    "deleteThisOrganization": "इस संगठन को हटाएं",
+    "deleteOrg": "संगठन हटाएं",
+    "deleteMsg": "क्या आप इस संगठन को हटाना चाहते हैं?",
+    "no": "नहीं",
+    "yes": "हाँ"
   },
   "membershipRequest": {
     "joined": "में शामिल हो गए",

--- a/public/locales/sp.json
+++ b/public/locales/sp.json
@@ -289,7 +289,13 @@
     "cancel": "Cancelar"
   },
   "orgDelete": {
-    "deleteOrg": "Eliminar organización"
+    "location": "Ubicación",
+    "about": "Sobre",
+    "deleteThisOrganization": "Eliminar esta organización",
+    "deleteOrg": "Eliminar organización",
+    "deleteMsg": "¿Desea eliminar esta organización?",
+    "no": "No",
+    "yes": "Sí"
   },
   "membershipRequest": {
     "joined": "Unido",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -289,7 +289,13 @@
     "cancel": "取消"
   },
   "orgDelete": {
-    "deleteOrg": "刪除組織"
+    "location": "地點",
+    "about": "關於",
+    "deleteThisOrganization": "刪除此組織",
+    "deleteOrg": "刪除組織",
+    "deleteMsg": "您要刪除此組織嗎？",
+    "no": "不",
+    "yes": "是的"
   },
   "membershipRequest": {
     "joined": "加入",

--- a/src/GraphQl/Queries/Queries.ts
+++ b/src/GraphQl/Queries/Queries.ts
@@ -294,6 +294,9 @@ export const MEMBERSHIP_REQUEST = gql`
           firstName
           lastName
           email
+          image
+          location
+          created_at
         }
       }
     }

--- a/src/components/MemberRequestCard/MemberRequestCard.tsx
+++ b/src/components/MemberRequestCard/MemberRequestCard.tsx
@@ -74,7 +74,7 @@ function MemberRequestCard(props: MemberRequestCardProps): JSX.Element {
             />
           ) : (
             <img
-              src="https://via.placeholder.com/200x100"
+              src={props.memberLocation}
               className={styles.memberimg}
               alt="userImage"
             />

--- a/src/components/MemberRequestCard/MemberRequestCard.tsx
+++ b/src/components/MemberRequestCard/MemberRequestCard.tsx
@@ -74,7 +74,7 @@ function MemberRequestCard(props: MemberRequestCardProps): JSX.Element {
             />
           ) : (
             <img
-              src={props.memberLocation}
+              src="https://via.placeholder.com/200x100"
               className={styles.memberimg}
               alt="userImage"
             />

--- a/src/components/OrgDelete/OrgDelete.module.css
+++ b/src/components/OrgDelete/OrgDelete.module.css
@@ -1,43 +1,4 @@
-.greenregbtn {
-  margin: 1rem 0 0;
-  margin-top: 15px;
-  border: 1px solid #e8e5e5;
-  box-shadow: 0 2px 2px #e8e5e5;
-  padding: 6px 8px;
-  border-radius: 5px;
-  background-color: #31bb6b;
-  width: 70%;
-  font-size: 14px;
-  color: white;
-  outline: none;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 0.2s, box-shadow 0.2s;
-}
-
-.loader,
-.loader:after {
-  border-radius: 50%;
-  width: 10em;
-  height: 10em;
-}
-.loader {
-  margin: 60px auto;
-  margin-top: 35vh !important;
-  font-size: 10px;
-  position: relative;
-  text-indent: -9999em;
-  border-top: 1.1em solid rgba(255, 255, 255, 0.2);
-  border-right: 1.1em solid rgba(255, 255, 255, 0.2);
-  border-bottom: 1.1em solid rgba(255, 255, 255, 0.2);
-  border-left: 1.1em solid #febc59;
-  -webkit-transform: translateZ(0);
-  -ms-transform: translateZ(0);
-  transform: translateZ(0);
-  -webkit-animation: load8 1.1s infinite linear;
-  animation: load8 1.1s infinite linear;
-}
-.tagdetailsGreen > button {
+.greenDeleteButton > button {
   background-color: #31bb6b;
   color: white;
   outline: none;

--- a/src/components/OrgDelete/OrgDelete.module.css
+++ b/src/components/OrgDelete/OrgDelete.module.css
@@ -1,76 +1,75 @@
-  .greenregbtn {
-    margin: 1rem 0 0;
-    margin-top: 15px;
-    border: 1px solid #e8e5e5;
-    box-shadow: 0 2px 2px #e8e5e5;
-    padding: 6px 8px;
-    border-radius: 5px;
-    background-color: #31bb6b;
-    width: 70%;
-    font-size: 14px;
-    color: white;
-    outline: none;
-    font-weight: 600;
-    cursor: pointer;
-    transition: transform 0.2s, box-shadow 0.2s;
+.greenregbtn {
+  margin: 1rem 0 0;
+  margin-top: 15px;
+  border: 1px solid #e8e5e5;
+  box-shadow: 0 2px 2px #e8e5e5;
+  padding: 6px 8px;
+  border-radius: 5px;
+  background-color: #31bb6b;
+  width: 70%;
+  font-size: 14px;
+  color: white;
+  outline: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.loader,
+.loader:after {
+  border-radius: 50%;
+  width: 10em;
+  height: 10em;
+}
+.loader {
+  margin: 60px auto;
+  margin-top: 35vh !important;
+  font-size: 10px;
+  position: relative;
+  text-indent: -9999em;
+  border-top: 1.1em solid rgba(255, 255, 255, 0.2);
+  border-right: 1.1em solid rgba(255, 255, 255, 0.2);
+  border-bottom: 1.1em solid rgba(255, 255, 255, 0.2);
+  border-left: 1.1em solid #febc59;
+  -webkit-transform: translateZ(0);
+  -ms-transform: translateZ(0);
+  transform: translateZ(0);
+  -webkit-animation: load8 1.1s infinite linear;
+  animation: load8 1.1s infinite linear;
+}
+.tagdetailsGreen > button {
+  background-color: #31bb6b;
+  color: white;
+  outline: none;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+  border: none;
+  border-radius: 5px;
+  margin-top: -12px;
+  margin-bottom: 10px;
+  margin-right: 30px;
+  padding-right: 20px;
+  padding-left: 20px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+@-webkit-keyframes load8 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
   }
-  
-  .loader,
-  .loader:after {
-    border-radius: 50%;
-    width: 10em;
-    height: 10em;
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
   }
-  .loader {
-    margin: 60px auto;
-    margin-top: 35vh !important;
-    font-size: 10px;
-    position: relative;
-    text-indent: -9999em;
-    border-top: 1.1em solid rgba(255, 255, 255, 0.2);
-    border-right: 1.1em solid rgba(255, 255, 255, 0.2);
-    border-bottom: 1.1em solid rgba(255, 255, 255, 0.2);
-    border-left: 1.1em solid #febc59;
-    -webkit-transform: translateZ(0);
-    -ms-transform: translateZ(0);
-    transform: translateZ(0);
-    -webkit-animation: load8 1.1s infinite linear;
-    animation: load8 1.1s infinite linear;
+}
+@keyframes load8 {
+  0% {
+    -webkit-transform: rotate(0deg);
+    transform: rotate(0deg);
   }
-  .tagdetailsGreen > button {
-    background-color: #31bb6b;
-    color: white;
-    outline: none;
-    cursor: pointer;
-    transition: transform 0.2s, box-shadow 0.2s;
-    border: none;
-    border-radius: 5px;
-    margin-top: -12px;
-    margin-bottom: 10px;
-    margin-right: 30px;
-    padding-right: 20px;
-    padding-left: 20px;
-    padding-top: 5px;
-    padding-bottom: 5px;
+  100% {
+    -webkit-transform: rotate(360deg);
+    transform: rotate(360deg);
   }
-  @-webkit-keyframes load8 {
-    0% {
-      -webkit-transform: rotate(0deg);
-      transform: rotate(0deg);
-    }
-    100% {
-      -webkit-transform: rotate(360deg);
-      transform: rotate(360deg);
-    }
-  }
-  @keyframes load8 {
-    0% {
-      -webkit-transform: rotate(0deg);
-      transform: rotate(0deg);
-    }
-    100% {
-      -webkit-transform: rotate(360deg);
-      transform: rotate(360deg);
-    }
-  }
-  
+}

--- a/src/components/OrgDelete/OrgDelete.module.css
+++ b/src/components/OrgDelete/OrgDelete.module.css
@@ -1,0 +1,76 @@
+  .greenregbtn {
+    margin: 1rem 0 0;
+    margin-top: 15px;
+    border: 1px solid #e8e5e5;
+    box-shadow: 0 2px 2px #e8e5e5;
+    padding: 6px 8px;
+    border-radius: 5px;
+    background-color: #31bb6b;
+    width: 70%;
+    font-size: 14px;
+    color: white;
+    outline: none;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s, box-shadow 0.2s;
+  }
+  
+  .loader,
+  .loader:after {
+    border-radius: 50%;
+    width: 10em;
+    height: 10em;
+  }
+  .loader {
+    margin: 60px auto;
+    margin-top: 35vh !important;
+    font-size: 10px;
+    position: relative;
+    text-indent: -9999em;
+    border-top: 1.1em solid rgba(255, 255, 255, 0.2);
+    border-right: 1.1em solid rgba(255, 255, 255, 0.2);
+    border-bottom: 1.1em solid rgba(255, 255, 255, 0.2);
+    border-left: 1.1em solid #febc59;
+    -webkit-transform: translateZ(0);
+    -ms-transform: translateZ(0);
+    transform: translateZ(0);
+    -webkit-animation: load8 1.1s infinite linear;
+    animation: load8 1.1s infinite linear;
+  }
+  .tagdetailsGreen > button {
+    background-color: #31bb6b;
+    color: white;
+    outline: none;
+    cursor: pointer;
+    transition: transform 0.2s, box-shadow 0.2s;
+    border: none;
+    border-radius: 5px;
+    margin-top: -12px;
+    margin-bottom: 10px;
+    margin-right: 30px;
+    padding-right: 20px;
+    padding-left: 20px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+  }
+  @-webkit-keyframes load8 {
+    0% {
+      -webkit-transform: rotate(0deg);
+      transform: rotate(0deg);
+    }
+    100% {
+      -webkit-transform: rotate(360deg);
+      transform: rotate(360deg);
+    }
+  }
+  @keyframes load8 {
+    0% {
+      -webkit-transform: rotate(0deg);
+      transform: rotate(0deg);
+    }
+    100% {
+      -webkit-transform: rotate(360deg);
+      transform: rotate(360deg);
+    }
+  }
+  

--- a/src/components/OrgDelete/OrgDelete.tsx
+++ b/src/components/OrgDelete/OrgDelete.tsx
@@ -1,15 +1,93 @@
 import React from 'react';
+import styles from './OrgDelete.module.css';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
+import { useMutation } from '@apollo/client';
+import { DELETE_ORGANIZATION_MUTATION } from 'GraphQl/Mutations/mutations';
 
 function OrgDelete(): JSX.Element {
   const { t } = useTranslation('translation', {
     keyPrefix: 'orgDelete',
   });
 
+  const [del] = useMutation(DELETE_ORGANIZATION_MUTATION);
+  const currentUrl = window.location.href.split('=')[1];
+
+  const delete_org = async () => {
+    try {
+      const { data } = await del({
+        variables: {
+          id: currentUrl,
+        },
+      });
+
+      if (data) {
+        window.location.replace('/orglist');
+      }
+    } catch (error: any) {
+      toast.error(error.message);
+    }
+  };
+
   return (
     <>
       <div id="OrgDelete" className="search-OrgDelete">
-        {t('deleteOrg')}
+        <p className={styles.tagdetailsGreen}>
+          <button
+            type="button"
+            className="mt-3"
+            data-testid="deleteClick"
+            data-toggle="modal"
+            data-target="#deleteOrganizationModal"
+          >
+            {t('deleteOrg')}
+          </button>
+        </p>
+      </div>
+
+      <div
+        className="modal fade"
+        id="deleteOrganizationModal"
+        tabIndex={-1}
+        role="dialog"
+        aria-labelledby="deleteOrganizationModalLabel"
+        aria-hidden="true"
+      >
+        <div className="modal-dialog" role="document">
+          <div className="modal-content">
+            <div className="modal-header">
+              <h5 className="modal-title" id="deleteOrganizationModalLabel">
+                {t('deleteOrg')}
+              </h5>
+              <button
+                type="button"
+                className="close"
+                data-dismiss="modal"
+                aria-label="Close"
+              >
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div className="modal-body">{t('deleteMsg')}</div>
+            <div className="modal-footer">
+              <button
+                type="button"
+                className="btn btn-danger"
+                data-dismiss="modal"
+              >
+                {t('no')}
+              </button>
+              <button
+                type="button"
+                className="btn btn-success"
+                onClick={delete_org}
+                data-testid="deleteOrganizationBtn"
+              >
+                {t('yes')}
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </>
   );

--- a/src/components/OrgDelete/OrgDelete.tsx
+++ b/src/components/OrgDelete/OrgDelete.tsx
@@ -32,7 +32,7 @@ function OrgDelete(): JSX.Element {
   return (
     <>
       <div id="OrgDelete" className="search-OrgDelete">
-        <p className={styles.tagdetailsGreen}>
+        <p className={styles.greenDeleteButton}>
           <button
             type="button"
             className="mt-3"

--- a/src/screens/OrgSettings/OrgSettings.tsx
+++ b/src/screens/OrgSettings/OrgSettings.tsx
@@ -55,7 +55,6 @@ function OrgSettings(): JSX.Element {
     );
   }
 
-  /* istanbul ignore next */
   if (error) {
     window.location.href = '/orglist';
   }
@@ -74,7 +73,6 @@ function OrgSettings(): JSX.Element {
                   value="userupdate"
                   data-testid="userUpdateBtn"
                   onClick={() => handleClick(1)}
-                  // onClick={() => setScreenVariable(1)}
                 >
                   {t('updateYourDetails')}
                 </button>
@@ -84,7 +82,6 @@ function OrgSettings(): JSX.Element {
                   value="orgupdate"
                   data-testid="orgUpdateBtn"
                   onClick={() => handleClick(2)}
-                  // onClick={() => setScreenVariable(2)}
                 >
                   {t('updateOrganization')}
                 </button>
@@ -94,17 +91,15 @@ function OrgSettings(): JSX.Element {
                   value="orgdelete"
                   data-testid="orgDeleteBtn"
                   onClick={() => handleClick(3)}
-                  // onClick={() => setScreenVariable(3)}
                 >
                   {t('deleteOrganization')}
                 </button>
                 <button
                   className={styles.greenregbtn}
                   type="button"
-                  value="orgdelete"
-                  data-testid="orgDeleteBtn2"
+                  value="orgrequests"
+                  data-testid="orgRequestsBtn"
                   onClick={() => handleClick(4)}
-                  // onClick={() => setScreenVariable(4)}
                 >
                   {t('seeRequest')}
                 </button>
@@ -122,16 +117,15 @@ function OrgSettings(): JSX.Element {
                     {t(screenDisplayVariable)}
                   </p>
                 )}
-                {/* <p className={styles.loginSubtitle}>{t("abc")}</p> */}
               </div>
-
-              {/* <p className={styles.logintitle}>{t('settings')}</p> */}
             </Row>
-            <div>{screenVariable == 1 ? <UserUpdate id="abcd" /> : null}</div>
+            <div>
+              {screenVariable == 1 ? <UserUpdate id="userupdate" /> : null}
+            </div>
             <div>
               {screenVariable == 2 ? (
                 <OrgUpdate
-                  id="abcd"
+                  id="orgupdate"
                   orgid={window.location.href.split('=')[1]}
                 />
               ) : null}
@@ -139,7 +133,7 @@ function OrgSettings(): JSX.Element {
             <div>{screenVariable == 3 ? <OrgDelete /> : null}</div>
             <div>
               {screenVariable == 4 ? (
-                data.organizations.membershipRequests ? (
+                data.organizations[0].membershipRequests.length > 0 ? (
                   data.organizations.map(
                     (datas: {
                       _id: string;
@@ -150,6 +144,9 @@ function OrgSettings(): JSX.Element {
                           firstName: string;
                           lastName: string;
                           email: string;
+                          image: string;
+                          location: string;
+                          created_at: string;
                         };
                       };
                     }) => {
@@ -158,10 +155,12 @@ function OrgSettings(): JSX.Element {
                           key={datas.membershipRequests._id}
                           id={datas.membershipRequests._id}
                           memberName={datas.membershipRequests.user.firstName}
-                          memberLocation="India"
-                          joinDate="12/12/2012"
-                          memberImage="https://via.placeholder.com/200x100"
+                          joinDate={datas.membershipRequests.user.created_at}
+                          memberImage={datas.membershipRequests.user.image}
                           email={datas.membershipRequests.user.email}
+                          memberLocation={
+                            datas.membershipRequests.user.location
+                          }
                         />
                       );
                     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI Refactor and bugfix for OrgSettings.tsx

## Issue Number

Referenced from GH-396 - [link to thread](https://github.com/PalisadoesFoundation/talawa-admin/issues/396#issuecomment-1457867253)

Partially Fixes #396 
Fixes GH-559

## Did you add tests for your changes?
Not yet, that would be the next step if the current changes are reviewed and alright.

## Snapshots/Videos

[Screencast from 2023-03-07 22-48-19.webm](https://user-images.githubusercontent.com/55971005/223499207-49d92d99-38f2-493e-b884-2c9d1c12b428.webm)

## If relevant, did you update the documentation?

There was no need to update the documentation. No API changes occur in this PR.

## Summary

The UI buttons for the various sections on the Settings page were not working. This was because of bad mapping of the div with their caller hrefs. I was assigned the issue #396 to write tests for this file, but I saw these bugs. Hence, decided to fix them while I was at it anyways. After describing the issue on the linked issue, and when prompted, I worked on this PR.

There were a few hard-coded values for member-locations and images on the admin panel for this page. Made those fields dynamic as well.

I also added locale translations for the required fields by copy-pasting from existing keywords.

## Does this PR introduce a breaking change?

No

## Other information

This PR enables admins to see the `member.location`, `member.image` and `member.join_date` for every `membershipRequest` to an organisation. Need to check if it is okay to reveal this metadata on the users. Else, I will revert my changes here.

## Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?

Yes