### PR TITLE
Moved organization location to about section

### DIFF
--- a/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
@@ -83,9 +83,6 @@ function OrganizationDashboard(): JSX.Element {
       <AdminNavbar targets={targets} url_1={configUrl} />
       <Row className={styles.toporginfo}>
         <p className={styles.toporgname}>{data.organizations[0].name}</p>
-        <p className={styles.toporgloc}>
-          {t('location')} : {data.organizations[0].location}
-        </p>
       </Row>
       <Row>
         <Col sm={3}>
@@ -93,6 +90,9 @@ function OrganizationDashboard(): JSX.Element {
             <div className={styles.sidebarsticky}>
               <h6 className={styles.titlename}>{t('about')}</h6>
               <p>{data.organizations[0].description}</p>
+              <p className={styles.toporgloc}>
+                {t('location')} : {data.organizations[0].location}
+              </p>
               {data.organizations[0].image ? (
                 <img
                   src={data.organizations[0].image}


### PR DESCRIPTION
What kind of change does this PR introduce?
feature

Issue Number:

Fixes: #572 

Did you add tests for your changes?
No

Snapshots/Videos:

If relevant, did you update the documentation?

Summary
I moved organization location rendered on the same row as company name to the about section as sugested on issue #572 

**Does this PR introduce a breaking change?
No

Other information

Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?
Yes
