### PR TITLE
fixes #553 : Register button to add a plugin doesn't work 

### DIFF
--- a/src/components/AddOn/core/AddOnRegister/AddOnRegister.tsx
+++ b/src/components/AddOn/core/AddOnRegister/AddOnRegister.tsx
@@ -42,11 +42,11 @@ function AddOnRegister({ createdBy }: AddOnRegisterProps): JSX.Element {
     console.log(formState);
     const { data } = await create({
       variables: {
-        $pluginName: formState.pluginName,
-        $pluginCreatedBy: formState.pluginCreatedBy,
-        $pluginDesc: formState.pluginDesc,
-        $pluginInstallStatus: formState.pluginInstallStatus,
-        $installedOrgs: formState.installedOrgs,
+        pluginName: formState.pluginName,
+        pluginCreatedBy: formState.pluginCreatedBy,
+        pluginDesc: formState.pluginDesc,
+        pluginInstallStatus: formState.pluginInstallStatus,
+        installedOrgs: formState.installedOrgs,
       },
     });
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Adds required Bugfix for the AddOnRegister.tsx file

**Issue Number:**

- Closes #553 
- Fixes #553 
- Resolves #553 


**Did you add tests for your changes?**

No

**Snapshots/Videos:**

https://user-images.githubusercontent.com/88336170/224000493-96527cdd-2f2c-4796-b5e2-28ec7d7997f5.mov


**Summary**

Previously, I encountered an issue where the registration of plugins was not successful even after inputting the necessary information. The "Register" button was unresponsive, and this was due to variables not being recognized. To resolve this issue, I removed the dollar sign in the variables section of the AddOnRegister.tsx file. The variables had already been defined as reusable keys in the mutations file, and this led to naming conflicts.
#553


**Does this PR introduce a breaking change?**

No

**Other information**


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

yes
