### PR TITLE
Rectify Warnings: EventListCard.test.tsx [Fixes #569]

### DIFF
--- a/src/components/EventListCard/EventListCard.test.tsx
+++ b/src/components/EventListCard/EventListCard.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { act, render, screen } from '@testing-library/react';
-import { MockedProvider } from '@apollo/react-testing';
+import { MockedProvider, MockLink } from '@apollo/react-testing';
 import userEvent from '@testing-library/user-event';
 import { I18nextProvider } from 'react-i18next';
 
@@ -51,6 +51,8 @@ const MOCKS = [
   },
 ];
 
+const mocklink = new MockLink(MOCKS, false, { showWarnings: false });
+
 async function wait(ms = 0) {
   await act(() => {
     return new Promise((resolve) => {
@@ -82,7 +84,7 @@ describe('Testing Event List Card', () => {
     global.confirm = () => true;
 
     render(
-      <MockedProvider addTypename={false} mocks={MOCKS}>
+      <MockedProvider addTypename={false} link={mocklink}>
         <I18nextProvider i18n={i18nForTest}>
           <EventListCard {...props} />
         </I18nextProvider>
@@ -98,7 +100,7 @@ describe('Testing Event List Card', () => {
     global.confirm = () => false;
 
     render(
-      <MockedProvider addTypename={false} mocks={MOCKS}>
+      <MockedProvider addTypename={false} link={mocklink}>
         <I18nextProvider i18n={i18nForTest}>
           <EventListCard
             key="123"
@@ -126,7 +128,7 @@ describe('Testing Event List Card', () => {
 
   test('Testing event update functionality', async () => {
     render(
-      <MockedProvider addTypename={false} mocks={MOCKS}>
+      <MockedProvider addTypename={false} link={mocklink}>
         <I18nextProvider i18n={i18nForTest}>
           <EventListCard {...props} />
         </I18nextProvider>
@@ -153,7 +155,7 @@ describe('Testing Event List Card', () => {
 
   test('Testing if the event is not for all day', async () => {
     render(
-      <MockedProvider addTypename={false} mocks={MOCKS}>
+      <MockedProvider addTypename={false} link={mocklink}>
         <I18nextProvider i18n={i18nForTest}>
           <EventListCard {...props} />
         </I18nextProvider>
@@ -181,7 +183,7 @@ describe('Testing Event List Card', () => {
 
   test('Testing delete event funcationality', async () => {
     render(
-      <MockedProvider addTypename={false} mocks={MOCKS}>
+      <MockedProvider addTypename={false} link={mocklink}>
         <I18nextProvider i18n={i18nForTest}>
           <EventListCard {...props} />
         </I18nextProvider>


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Bug fix

**Issue Number:**

Fixes #569

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![test snapshot](https://user-images.githubusercontent.com/48069624/224005176-48ff7d74-649b-4c21-955c-567ddfb8c232.png)


**Summary**

This rectifies the warning generated when running tests for the `EventListCard` component.

**Does this PR introduce a breaking change?**

No

**Other information**
I got to find out that the warning from issue #569 is caused by `MockedProvider` because it renders the `MOCKS` twice. This causes the `No more mocked responses for the query` warning the second time it renders. This had been a recurring issue for apollo-client for a long time with no clear rectification. However, to stop the warning from showing up when running the test I used the `MockLink` class.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
