### PR TITLE
Move delete organization to settings page

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -102,10 +102,7 @@
     "events": "Events",
     "blockedUsers": "Blocked Users",
     "membershipRequests": "Membership Requests",
-    "deleteOrganization": "Delete Organization",
-    "deleteMsg": "Do you want to delete this organization?",
-    "no": "No",
-    "yes": "Yes"
+    "deleteOrganization": "Delete Organization"
   },
   "organizationPeople": {
     "title": "Talawa Members",
@@ -273,7 +270,10 @@
     "deleteOrganization": "Delete Organization",
     "seeRequest": "See Request",
     "settings": "Settings",
-    "noData": "No data"
+    "noData": "No data",
+    "deleteMsg": "Do you want to delete this organization?",
+    "no": "No",
+    "yes": "Yes"
   },
   "userUpdate": {
     "firstName": "First Name",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -102,10 +102,7 @@
     "events": "Événements",
     "blockedUsers": "Utilisateurs bloqués",
     "membershipRequests": "Demandes d'adhésion",
-    "deleteOrganization": "Supprimer l'organisation",
-    "deleteMsg": "Voulez-vous supprimer cette organisation ?",
-    "no": "Non",
-    "yes": "Oui"
+    "deleteOrganization": "Supprimer l'organisation"
   },
   "organizationPeople": {
     "title": "Membres Talawa",
@@ -273,7 +270,10 @@
     "deleteOrganization": "Supprimer l'organisation",
     "seeRequest": "Voir demande",
     "settings": "Réglages",
-    "noData": "Pas de données"
+    "noData": "Pas de données",
+    "deleteMsg": "Voulez-vous supprimer cette organisation?",
+    "no": "Non",
+    "yes": "Oui"
   },
   "userUpdate": {
     "firstName": "Prénom",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -102,10 +102,7 @@
     "events": "आयोजन",
     "blockedUsers": "रोके गए उपयोगकर्ता",
     "membershipRequests": "सदस्यता अनुरोध",
-    "deleteOrganization": "संगठन हटाएं",
-    "deleteMsg": "क्या आप इस संगठन को हटाना चाहते हैं?",
-    "no": "नहीं",
-    "yes": "हाँ"
+    "deleteOrganization": "संगठन हटाएं"
   },
   "organizationPeople": {
     "title": "तलावा सदस्य",
@@ -273,7 +270,10 @@
     "deleteOrganization": "संगठन हटाएं",
     "seeRequest": "अनुरोध देखें",
     "settings": "समायोजन",
-    "noData": "कोई डेटा नहीं"
+    "noData": "कोई डेटा नहीं",
+    "deleteMsg": "क्या आप इस संगठन को हटाना चाहते हैं?",
+    "no": "नहीं",
+    "yes": "हाँ"
   },
   "userUpdate": {
     "firstName": "पहला नाम",

--- a/public/locales/sp.json
+++ b/public/locales/sp.json
@@ -102,10 +102,7 @@
     "events": "Eventos",
     "blockedUsers": "Usuarios bloqueados",
     "membershipRequests": "Solicitudes de membresía",
-    "deleteOrganization": "Eliminar Organización",
-    "deleteMsg": "¿Desea eliminar esta organización?",
-    "no": "No",
-    "yes": "Sí"
+    "deleteOrganization": "Eliminar Organización"
   },
   "organizationPeople": {
     "title": "Miembros Talawa",
@@ -273,7 +270,10 @@
     "deleteOrganization": "Eliminar Organización",
     "seeRequest": "Ver Solicitud",
     "settings": "Ajustes",
-    "noData": "Sin datos"
+    "noData": "Sin datos",
+    "deleteMsg": "¿Desea eliminar esta organización?",
+    "no": "No",
+    "yes": "Sí"
   },
   "userUpdate": {
     "firstName": "Primer nombre",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -102,10 +102,7 @@
     "events": "事件",
     "blockedUsers": "被阻止的用戶",
     "membershipRequests": "會員申請",
-    "deleteOrganization": "刪除組織",
-    "deleteMsg": "您要刪除此組織嗎？",
-    "no": "不",
-    "yes": "是的"
+    "deleteOrganization": "刪除組織"
   },
   "organizationPeople": {
     "title": "塔拉瓦成員",
@@ -273,7 +270,10 @@
     "deleteOrganization": "刪除組織",
     "seeRequest": "查看請求",
     "settings": "設置",
-    "noData": "沒有數據"
+    "noData": "沒有數據",
+    "deleteMsg": "您要刪除此組織嗎？",
+    "no": "不",
+    "yes": "是的"
   },
   "userUpdate": {
     "firstName": "名",

--- a/src/screens/OrgSettings/OrgSettings.module.css
+++ b/src/screens/OrgSettings/OrgSettings.module.css
@@ -127,6 +127,25 @@
   cursor: pointer;
   transition: transform 0.2s, box-shadow 0.2s;
 }
+
+.btndanger {
+  margin: 1rem 0 0;
+  margin-top: 15px;
+  border: 1px solid #e8e5e5;
+  box-shadow: 0 2px 2px #e8e5e5;
+  padding: 6px 8px;
+  border-radius: 5px;
+  background-color: #dc3545;
+  border-color: #dc3545;
+  width: 70%;
+  font-size: 14px;
+  color: white;
+  outline: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
 .sidebarsticky > input {
   text-decoration: none;
   margin-bottom: 50px;

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
-import { useMutation, useQuery } from '@apollo/client';
+import { useQuery } from '@apollo/client';
 import { useSelector } from 'react-redux';
 import { RootState } from 'state/reducers';
 import { Container } from 'react-bootstrap';
-import { toast } from 'react-toastify';
 import { useTranslation } from 'react-i18next';
 
 import styles from './OrganizationDashboard.module.css';
@@ -16,7 +15,6 @@ import {
   ORGANIZATION_EVENT_LIST,
   ORGANIZATION_POST_LIST,
 } from 'GraphQl/Queries/Queries';
-import { DELETE_ORGANIZATION_MUTATION } from 'GraphQl/Mutations/mutations';
 
 function OrganizationDashboard(): JSX.Element {
   const { t } = useTranslation('translation', { keyPrefix: 'dashboard' });
@@ -44,26 +42,6 @@ function OrganizationDashboard(): JSX.Element {
   } = useQuery(ORGANIZATION_EVENT_LIST, {
     variables: { id: currentUrl },
   });
-
-  const [del] = useMutation(DELETE_ORGANIZATION_MUTATION);
-
-  const delete_org = async () => {
-    try {
-      const { data } = await del({
-        variables: {
-          id: currentUrl,
-        },
-      });
-
-      /* istanbul ignore next */
-      if (data) {
-        window.location.replace('/orglist');
-      }
-    } catch (error: any) {
-      /* istanbul ignore next */
-      toast.error(error.message);
-    }
-  };
 
   if (loading || loading_post || loading_event) {
     return (
@@ -106,17 +84,6 @@ function OrganizationDashboard(): JSX.Element {
                   data-testid="orgDashImgAbsent"
                 />
               )}
-              <p className={styles.tagdetailsGreen}>
-                <button
-                  type="button"
-                  className="mt-3"
-                  data-testid="deleteClick"
-                  data-toggle="modal"
-                  data-target="#deleteOrganizationModal"
-                >
-                  {t('deleteThisOrganization')}
-                </button>
-              </p>
             </div>
           </div>
         </Col>
@@ -238,51 +205,6 @@ function OrganizationDashboard(): JSX.Element {
           </Container>
         </Col>
       </Row>
-
-      <div
-        className="modal fade"
-        id="deleteOrganizationModal"
-        tabIndex={-1}
-        role="dialog"
-        aria-labelledby="deleteOrganizationModalLabel"
-        aria-hidden="true"
-      >
-        <div className="modal-dialog" role="document">
-          <div className="modal-content">
-            <div className="modal-header">
-              <h5 className="modal-title" id="deleteOrganizationModalLabel">
-                {t('deleteOrganization')}
-              </h5>
-              <button
-                type="button"
-                className="close"
-                data-dismiss="modal"
-                aria-label="Close"
-              >
-                <span aria-hidden="true">&times;</span>
-              </button>
-            </div>
-            <div className="modal-body">{t('deleteMsg')}</div>
-            <div className="modal-footer">
-              <button
-                type="button"
-                className="btn btn-danger"
-                data-dismiss="modal"
-              >
-                {t('no')}
-              </button>
-              <button
-                type="button"
-                className="btn btn-success"
-                onClick={delete_org}
-                data-testid="deleteOrganizationBtn"
-              >
-                {t('yes')}
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
     </>
   );
 }


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Feature

**Issue Number:**

Fixes #559 

**Did you add tests for your changes?**`
No

**Snapshots/Videos:**

![Capture](https://user-images.githubusercontent.com/42142223/224036378-f4433f5e-de57-4ab5-9bc4-d5dd73b2e96c.PNG)

![Capture1](https://user-images.githubusercontent.com/42142223/224036414-e579169e-6665-4849-a2f3-289ca3cece8d.PNG)

**Summary**
The delete organization button needed to be moved to the settings page to prevent users from mistakenly deleting an organization. This will improve the UX

**Does this PR introduce a breaking change?**
No


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
