### PR TITLE
fix: Moved organization location to about section

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -59,6 +59,22 @@ cd talawa-admin
 ## Setting up Yarn
 
 If you've followed the previous steps you should have already set up node.js on your system. [Click here](https://yarnpkg.com/getting-started/install) for the official setup guide for yarn.
+Please note that Talawa's admin system is only compatible with yarn version 1. Using versions 2 or 3 may cause errors.
+To install yarn version you can use following command:
+
+*Windows/ Mac-OS*
+```
+npm install -g yarn@1.22.17
+```
+*Linux*
+```
+sudo npm install -g yarn@1.22.17
+```
+
+To verify yarn is correctly installed in your system use:
+```
+yarn -v
+```
 
 ## Installing required packages/dependencies
 

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.module.css
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.module.css
@@ -3,16 +3,6 @@
   flex-direction: row;
 }
 
-.toporginfo {
-  justify-content: space-evenly;
-  text-align: center;
-}
-.toporgname {
-  font-size: 24px;
-  border-bottom: 3px solid #31bb6b;
-  color: #707070;
-  font-weight: 600;
-}
 .toporgloc {
   padding-top: 8px;
   font-size: 16px;

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
@@ -83,9 +83,6 @@ function OrganizationDashboard(): JSX.Element {
       <AdminNavbar targets={targets} url_1={configUrl} />
       <Row className={styles.toporginfo}>
         <p className={styles.toporgname}>{data.organizations[0].name}</p>
-        <p className={styles.toporgloc}>
-          {t('location')} : {data.organizations[0].location}
-        </p>
       </Row>
       <Row>
         <Col sm={3}>
@@ -93,6 +90,9 @@ function OrganizationDashboard(): JSX.Element {
             <div className={styles.sidebarsticky}>
               <h6 className={styles.titlename}>{t('about')}</h6>
               <p>{data.organizations[0].description}</p>
+              <p className={styles.toporgloc}>
+                {t('location')} : {data.organizations[0].location}
+              </p>
               {data.organizations[0].image ? (
                 <img
                   src={data.organizations[0].image}

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
@@ -81,9 +81,6 @@ function OrganizationDashboard(): JSX.Element {
   return (
     <>
       <AdminNavbar targets={targets} url_1={configUrl} />
-      <Row className={styles.toporginfo}>
-        <p className={styles.toporgname}>{data.organizations[0].name}</p>
-      </Row>
       <Row>
         <Col sm={3}>
           <div className={styles.sidebar}>


### PR DESCRIPTION
What kind of change does this PR introduce?
feature

Issue Number:

Fixes: #572

Did you add tests for your changes?
No

Snapshots/Videos:
before:
<img src="https://github.com/techfussion/placeholder/blob/main/mv-location1.png?raw=true">
after:
<img src="https://github.com/techfussion/placeholder/blob/main/mv-location2.png?raw=true">

UI before:
<img src="https://github.com/techfussion/placeholder/blob/main/loc1.png?raw=true">
UI after:
<img src="https://github.com/techfussion/placeholder/blob/main/loc2.png?raw=true">

If relevant, did you update the documentation?

Summary
I moved organization location rendered on the same row as company name to the about section as sugested on issue #572

**Does this PR introduce a breaking change?
No

Other information

Have you read the contributing guide?
Yes