### PR TITLE
Fixes issue #599

### DIFF
--- a/src/components/AdminNavbar/AdminNavbar.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.tsx
@@ -9,6 +9,7 @@ import { useMutation, useQuery } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
 import Cookies from 'js-cookie';
 import i18next from 'i18next';
+import { useHistory } from 'react-router-dom';
 
 import styles from './AdminNavbar.module.css';
 import Logo from 'assets/talawa-logo-200x200.png';
@@ -40,6 +41,8 @@ function AdminNavbar({ targets, url_1 }: NavbarProps): JSX.Element {
     variables: { id: currentUrl },
   });
   const [updateSpam] = useMutation(UPDATE_SPAM_NOTIFICATION_MUTATION);
+
+  const history = useHistory();
 
   useEffect(() => {
     const handleUpdateSpam = async () => {
@@ -88,7 +91,7 @@ function AdminNavbar({ targets, url_1 }: NavbarProps): JSX.Element {
 
   /* istanbul ignore next */
   if (error) {
-    window.location.replace('/orglist');
+    history.push('/orglist');
   }
 
   let OrgName;

--- a/src/components/SuperDashListCard/SuperDashListCard.test.tsx
+++ b/src/components/SuperDashListCard/SuperDashListCard.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { I18nextProvider } from 'react-i18next';
+import { BrowserRouter } from 'react-router-dom';
 import 'jest-location-mock';
 
 import SuperDashListCard from './SuperDashListCard';
@@ -11,7 +12,7 @@ import i18nForTest from 'utils/i18nForTest';
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('Testing the Super Dash List', () => {
-  test('should render props and text elements test for the page component', () => {
+  test('should render props and text elements test for the page component', async () => {
     const props = {
       key: '123',
       id: '123',
@@ -34,18 +35,20 @@ describe('Testing the Super Dash List', () => {
     const clickButton = buttonInstance.find('button');
 
     render(
-      <I18nextProvider i18n={i18nForTest}>
-        <SuperDashListCard
-          key={props.key}
-          id={props.id}
-          image={props.image}
-          orgName={props.orgName}
-          orgLocation={props.orgLocation}
-          createdDate={props.createdDate}
-          admins={props.admins}
-          members={props.members}
-        />
-      </I18nextProvider>
+      <BrowserRouter>
+        <I18nextProvider i18n={i18nForTest}>
+          <SuperDashListCard
+            key={props.key}
+            id={props.id}
+            image={props.image}
+            orgName={props.orgName}
+            orgLocation={props.orgLocation}
+            createdDate={props.createdDate}
+            admins={props.admins}
+            members={props.members}
+          />
+        </I18nextProvider>
+      </BrowserRouter>
     );
 
     expect(screen.getByText('Admins:')).toBeInTheDocument();

--- a/src/components/SuperDashListCard/SuperDashListCard.test.tsx
+++ b/src/components/SuperDashListCard/SuperDashListCard.test.tsx
@@ -11,12 +11,6 @@ import i18nForTest from 'utils/i18nForTest';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-jest.mock('react-router-dom', () => ({
-  useHistory: () => ({
-    push: jest.fn(),
-  }),
-}));
-
 describe('Testing the Super Dash List', () => {
   test('should render props and text elements test for the page component', async () => {
     const props = {

--- a/src/components/SuperDashListCard/SuperDashListCard.tsx
+++ b/src/components/SuperDashListCard/SuperDashListCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import { useTranslation } from 'react-i18next';
@@ -20,10 +20,18 @@ interface SuperDashListCardProps {
 function SuperDashListCard(props: SuperDashListCardProps): JSX.Element {
   const userId = localStorage.getItem('id');
   const userType = localStorage.getItem('UserType');
+  const [clicked, setClicked] = useState(false);
   const history = useHistory();
 
+  useEffect(() => {
+    if (clicked) {
+      history.push('/orgdash/id=' + props.id);
+      setClicked(false);
+    }
+  }, [clicked]);
+
   function Click() {
-    history.push('/orgdash/id=' + props.id);
+    setClicked(true);
   }
 
   const { t } = useTranslation('translation', {

--- a/src/components/SuperDashListCard/SuperDashListCard.tsx
+++ b/src/components/SuperDashListCard/SuperDashListCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import { useTranslation } from 'react-i18next';
+import { useHistory } from 'react-router-dom';
 
 import styles from './SuperDashListCard.module.css';
 
@@ -19,10 +20,10 @@ interface SuperDashListCardProps {
 function SuperDashListCard(props: SuperDashListCardProps): JSX.Element {
   const userId = localStorage.getItem('id');
   const userType = localStorage.getItem('UserType');
+  const history = useHistory();
 
   function Click() {
-    const url = '/orgdash/id=' + props.id;
-    window.location.replace(url);
+    history.push('/orgdash/id=' + props.id);
   }
 
   const { t } = useTranslation('translation', {


### PR DESCRIPTION

**What kind of change does this PR introduce?**

bugfix

issue number: 599

Fixes #599


I updated the test cases for my changes. I noticed that on every render (even before component mount), the click function is being fired unexpectedly. I created a state that notifies us when the button is clicked (which ideally should be on mount of the component), and also wrapped the history.push function in a useEffect with the clicked state as a dependency to help us only fire the history.push when the button is clicked.


**Snapshots/Videos:**


https://user-images.githubusercontent.com/54279085/224116587-32ae504a-2e83-40c4-8215-f69eb7590a42.mov


**Summary**

I realized that when we click the back button on any individual organization information screen, we are taken to a completely different page rather than back to the list of organizations. Instead of directly manipulating the reassignment/navigation of the pages, i made use of react-router-dom's useHistory.  This is because useHistory provides a way to manipulate the browser history stack that is consistent with the React component lifecycle and the React Router API. Using window.location directly can lead to unexpected behavior and can break the React component lifecycle, which can cause issues with other parts of your application.

https://github.com/PalisadoesFoundation/talawa-admin/issues/599

**Does this PR introduce a breaking change?**
No, it doesn't





**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
Yes