### PR TITLE
removed duplicate rows per page section in orgposts

### DIFF
--- a/src/screens/OrgPost/OrgPost.tsx
+++ b/src/screens/OrgPost/OrgPost.tsx
@@ -222,23 +222,6 @@ function OrgPost(): JSX.Element {
               </tbody>
             </table>
           </div>
-          <div>
-            <table>
-              <tbody>
-                <tr>
-                  <PaginationList
-                    count={
-                      data ? data.postsByOrganizationConnection.edges.length : 0
-                    }
-                    rowsPerPage={rowsPerPage}
-                    page={page}
-                    onPageChange={handleChangePage}
-                    onRowsPerPageChange={handleChangeRowsPerPage}
-                  />
-                </tr>
-              </tbody>
-            </table>
-          </div>
         </Col>
       </Row>
       <Modal


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

This pr was created to remove the duplicate rows per page section in orgposts.

**Issue Number:**

Fixes #544

**Did you add tests for your changes?**

No

**Snapshots/Videos:**


**If relevant, did you update the documentation?**

No

**Summary**

This issue was the duplication of pagination component. so my job was to remove the duplication of the component so that it doesn't confuses the users. 

**Does this PR introduce a breaking change?**

No

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
