### PR TITLE
fixed:move orgLocation & remove duplicate orgName

### DIFF
--- a/src/screens/OrganizationDashboard/OrganizationDashboard.module.css
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.module.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: row;
 }
+
 .toporgloc {
   padding-top: 8px;
   font-size: 16px;

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.module.css
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.module.css
@@ -2,17 +2,6 @@
   display: flex;
   flex-direction: row;
 }
-
-.toporginfo {
-  justify-content: space-evenly;
-  text-align: center;
-}
-.toporgname {
-  font-size: 24px;
-  border-bottom: 3px solid #31bb6b;
-  color: #707070;
-  font-weight: 600;
-}
 .toporgloc {
   padding-top: 8px;
   font-size: 16px;

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
@@ -82,12 +82,6 @@ function OrganizationDashboard(): JSX.Element {
   return (
     <>
       <AdminNavbar targets={targets} url_1={configUrl} />
-      <Row className={styles.toporginfo}>
-        <p className={styles.toporgname}>{data.organizations[0].name}</p>
-        <p className={styles.toporgloc}>
-          {t('location')} : {data.organizations[0].location}
-        </p>
-      </Row>
       <Row>
         <Col sm={3}>
           <div className={styles.sidebar}>
@@ -95,6 +89,9 @@ function OrganizationDashboard(): JSX.Element {
               <h6 className={styles.titlename}>{t('about')}</h6>
               <p className={styles.description}>
                 {data.organizations[0].description}
+              </p>
+              <p className={styles.toporgloc}>
+                {t('location')} : {data.organizations[0].location}
               </p>
               {data.organizations[0].image ? (
                 <img


### PR DESCRIPTION
What kind of change does this PR introduce?
feature

Issue Number:

Fixes: #572

Did you add tests for your changes?
No

Snapshots/Videos:
before:
<img src="https://github.com/techfussion/placeholder/blob/main/newmv1.png?raw=true">
<img src="https://github.com/techfussion/placeholder/blob/main/mvcss1.png?raw=true">
after:
<img src="https://github.com/techfussion/placeholder/blob/main/newmv2.png?raw=true">
<img src="https://github.com/techfussion/placeholder/blob/main/mvcss2.png?raw=true">

UI before:
<img src="https://github.com/techfussion/placeholder/blob/main/dis5.png?raw=true">
UI after:
<img src="https://github.com/techfussion/placeholder/blob/main/dis4.png?raw=true">

If relevant, did you update the documentation?

Summary
I moved organization location rendered on the same row as company name to the about section as sugested on issue #572
and removed duplicate orgName as instructed.

**Does this PR introduce a breaking change?
No

Other information

Have you read the contributing guide?
Yes