### PR TITLE
User role ui not updating on change  - issue #551 resolved

### DIFF
--- a/src/screens/Roles/Roles.tsx
+++ b/src/screens/Roles/Roles.tsx
@@ -68,6 +68,7 @@ const Roles = () => {
       /* istanbul ignore next */
       if (data) {
         toast.success('Role Updated.');
+        refetch();
       }
     } catch (error: any) {
       /* istanbul ignore next */


### PR DESCRIPTION
What kind of change does this PR introduce?

Bugfix

Issue Number:

Fixes #551
Did you add tests for your changes?
No

Snapshots/Videos:

If relevant, did you update the documentation?

Summary
Summarily, whenever an user role update was performed by the superadmin, the role displayed remained the same whenever the he navigates out and back to the page, the replication procedure is detailed on issue #551

To solve this, i just added a refetch() expression after the success toast

Does this PR introduce a breaking change?
No


Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?
Yes