### PR TITLE
Fix:#641 Removed the Overlapping

### DIFF
--- a/src/components/AdminNavbar/AdminNavbar.module.css
+++ b/src/components/AdminNavbar/AdminNavbar.module.css
@@ -103,6 +103,7 @@ a {
 } */
 .dropdowns {
   text-decoration: none;
+  margin-bottom: 8px;
 }
 .dropdownMenu {
   transform: scale(0.85);

--- a/src/components/AdminNavbar/AdminNavbar.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.tsx
@@ -148,7 +148,7 @@ function AdminNavbar({ targets, url_1 }: NavbarProps): JSX.Element {
                       </Nav.Link>
                     </Dropdown.Toggle>
                     {subTargets && (
-                      <Dropdown.Menu>
+                      <Dropdown.Menu className={styles.dropdowns}>
                         {subTargets.map((subTarget: any, index: number) => (
                           <Dropdown.Item
                             key={index}


### PR DESCRIPTION

**What kind of change does this PR introduce?**

This change adds a clear spacing to a navbar dropdown item.

**Issue Number:**

Fixes #641 

**Did you add tests for your changes?**
Not required. Css style edits.

**Snapshots/Videos:**
![image](https://user-images.githubusercontent.com/112749383/224548860-0d2d30b5-8f38-44b0-a948-74ecaa471d04.png)






**Summary**

I have added the css style margin property for correcting the spacing between plugins dropdown and add organisation button in the navbar.

**Does this PR introduce a breaking change?**
No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes 
