### PR TITLE
fix organization search input box location

### DIFF
--- a/src/screens/OrgList/OrgList.module.css
+++ b/src/screens/OrgList/OrgList.module.css
@@ -18,11 +18,6 @@
   left: 94%;
   display: block;
 }
-.sidebarsticky {
-  padding-left: 45px;
-  text-overflow: ellipsis;
-  /* overflow-x: hidden; */
-}
 
 /* .sidebarsticky:hover{
   overflow-x:visible;
@@ -32,6 +27,22 @@
 } */
 .sidebarsticky > p {
   margin-top: -10px;
+}
+
+.search {
+  display: flex;
+  margin-bottom: 2rem;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+@media screen and (min-width: 468px) {
+  .search {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    padding-right: 40px;
+  }
 }
 
 .navitem {
@@ -52,18 +63,21 @@
   width: 60%;
 }
 
-.justifysp > input {
+.search > input {
   text-decoration: none;
-  margin-bottom: 50px;
   border-color: #dbd7d7;
   border-style: solid;
-  width: 35%;
   border-radius: 5px;
   padding-top: 5px;
   padding-bottom: 5px;
   padding-right: 10px;
   padding-left: 10px;
   box-shadow: none;
+}
+.search input:focus {
+  border-color: #fff;
+  box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+  outline: none;
 }
 
 .logintitle {
@@ -72,9 +86,10 @@
   font-size: 20px;
   margin-bottom: 30px;
   padding-bottom: 5px;
-  border-bottom: 3px solid #31bb6b;
   width: 30%;
+  border-bottom: 3px solid #31bb6b;
 }
+
 .logintitleadmin {
   color: #707070;
   font-weight: 600;
@@ -103,21 +118,28 @@
 .justifysp {
   display: flex;
   justify-content: space-between;
+  width: 100%;
 }
-@media screen and (max-width: 1200px) {
+
+.mainpageright {
+  width: 100%;
+  margin: 0 auto;
+  max-width: 92vw;
+}
+
+@media screen and (min-width: 1200px) {
   .justifysp {
-    padding-left: 55px;
     display: flex;
     justify-content: space-between;
-    width: 100%;
   }
-
-  .mainpageright {
-    width: 100%;
-  }
-  .invitebtn {
+  /* .invitebtn {
     position: relative;
     right: 15px;
+  } */
+  .sidebarsticky {
+    padding-left: 30px;
+    text-overflow: ellipsis;
+    /* overflow-x: hidden; */
   }
 }
 .invitebtn {
@@ -132,7 +154,6 @@
   cursor: pointer;
   transition: transform 0.2s, box-shadow 0.2s;
   background-color: #31bb6b;
-  margin-right: 13px;
 }
 
 .flexdir {
@@ -286,7 +307,8 @@ form > input {
   height: 70vh;
   overflow-y: auto;
   width: auto;
-  padding-right: 50px;
+  padding-right: 40px;
+  /* padding: 2rem; */
 }
 
 /* width */
@@ -329,11 +351,11 @@ form > input {
     position: relative;
     bottom: 18px;
   }
-  .invitebtn {
+  /* .invitebtn {
     width: 135px;
     position: relative;
     right: 10px;
-  }
+  } */
   .form_wrapper {
     width: 90%;
   }

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -162,7 +162,7 @@ function OrgList(): JSX.Element {
       <Row>
         <Col xl={3}>
           <div className={styles.sidebar}>
-            <div className={styles.sidebarsticky}>
+            <div className={`${styles.mainpageright} ${styles.sidebarsticky}`}>
               <h6 className={styles.logintitle}>{t('you')}</h6>
               <p>
                 {t('name')}:
@@ -193,17 +193,10 @@ function OrgList(): JSX.Element {
         </Col>
         <Col xl={8}>
           <div className={styles.mainpageright}>
-            <Row className={styles.justifysp}>
+            <div className={styles.justifysp}>
               <p className={styles.logintitle}>{t('organizationList')}</p>
-              <input
-                type="name"
-                id="orgname"
-                placeholder="Search Organization"
-                data-testid="searchByName"
-                autoComplete="off"
-                required
-                onChange={debouncedHandleSearchByName}
-              />
+            </div>
+            <div className={styles.search}>
               <Button
                 variant="success"
                 className={styles.invitebtn}
@@ -213,7 +206,16 @@ function OrgList(): JSX.Element {
               >
                 + {t('createOrganization')}
               </Button>
-            </Row>
+              <input
+                type="name"
+                id="orgname"
+                placeholder="Search Organization"
+                data-testid="searchByName"
+                autoComplete="off"
+                required
+                onChange={debouncedHandleSearchByName}
+              />
+            </div>
             <div className={styles.list_box}>
               {data &&
                 (rowsPerPage > 0


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This Pull request moves the search and the create organization button below the header

**Issue Number:**
Fixes #633 

**Did you add tests for your changes?**`
No, it was a UI adjustment.

**Snapshots/Videos:**
### **Before the change**:

![Capture](https://user-images.githubusercontent.com/42142223/224585746-ed0c430f-64d5-45e1-a754-41600833943b.PNG)
![Capture](https://user-images.githubusercontent.com/42142223/224585790-43266675-3dda-4729-afce-687ec0848786.PNG)
![Capture](https://user-images.githubusercontent.com/42142223/224585825-584c7de9-09a6-40e3-8b66-2a4fb992e686.PNG)


### **After the change**:
![Capture](https://user-images.githubusercontent.com/42142223/224585917-3c52c0b1-2a3a-4ad4-9f7f-f999fd70946f.PNG)
![Capture](https://user-images.githubusercontent.com/42142223/224586049-e9356dee-db2a-4d75-8db8-0e8e56b02c78.PNG)



**Summary**
The Search organization input was moved to the top of the organization list header which wasn't aligned. This looked bad for UI and UX. I moved it under the Organization list header alongside the create organization button to favor UI and UX as well as made them responsive for mobile.

**Does this PR introduce a breaking change?**
No


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes

