### PR TITLE
Added check for filtered list of organization

### DIFF
--- a/src/screens/OrgList/OrgList.module.css
+++ b/src/screens/OrgList/OrgList.module.css
@@ -36,6 +36,11 @@
   gap: 0.7rem;
 }
 
+.noResult {
+  color: #707070;
+  font-size: 20px;
+}
+
 @media screen and (min-width: 468px) {
   .search {
     display: flex;

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -37,6 +37,7 @@ function OrgList(): JSX.Element {
     image: '',
   });
   const [, setSearchByName] = useState('');
+  const [noResult, setNoResult] = useState(false);
 
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(5);
@@ -148,6 +149,12 @@ function OrgList(): JSX.Element {
       setSearchByName(value);
       refetch({
         filter: value,
+      }).then((response) => {
+        if (response.data.organizationsConnection.length === 0) {
+          setNoResult(true);
+        } else {
+          setNoResult(false);
+        }
       });
     }
   };
@@ -217,7 +224,10 @@ function OrgList(): JSX.Element {
               />
             </div>
             <div className={styles.list_box}>
-              {data &&
+              {noResult ? (
+                <p className={styles.noResult}> No Organization found! </p>
+              ) : (
+                data &&
                 (rowsPerPage > 0
                   ? dataRevOrg.slice(
                       page * rowsPerPage,
@@ -266,7 +276,8 @@ function OrgList(): JSX.Element {
                       );
                     }
                   }
-                )}
+                )
+              )}
             </div>
             <div>
               <table


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

While searching for an organization, if there is no organization with the searched name, then it will alert the user by displaying 'No Organization found!'

**Issue Number:**

Fixes #692 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

![p4](https://user-images.githubusercontent.com/75970868/225556902-0c212ff9-7f63-47fa-9243-b70b2b180ace.jpg)


**If relevant, did you update the documentation?**

Not Relevant

**Summary**

While searching for organizations in case the user has a huge list of organizations, a query with no indicator acts as a degrading factor in terms of user experience. Adding an indicator that alerts users whether there is any organization that they queried for solves this issue.

**Does this PR introduce a breaking change?**

No

**Other information**

Null

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
