### PR TITLE
changed the handleSearchByName function in searchByName in Roles page

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "scripts": {
     "serve": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --coverage",
     "eject": "react-scripts eject",
     "lint:check": "eslint \"**/*.{ts,tsx}\" --max-warnings=0",
     "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "scripts": {
     "serve": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --coverage",
+    "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint:check": "eslint \"**/*.{ts,tsx}\" --max-warnings=0",
     "lint:fix": "eslint \"**/*.{ts,tsx}\" --fix",

--- a/src/components/PaginationList/PaginationList.tsx
+++ b/src/components/PaginationList/PaginationList.tsx
@@ -51,11 +51,13 @@ const PaginationList = (props: PropsInterface) => {
       <Hidden smDown>
         <TablePagination
           rowsPerPageOptions={[
+            -1,
             5,
             10,
             30,
             { label: t('all'), value: Number.MAX_SAFE_INTEGER },
           ]}
+          data-testid={'table-pagination'}
           colSpan={4}
           count={props.count}
           rowsPerPage={props.rowsPerPage}

--- a/src/screens/Roles/Roles.test.tsx
+++ b/src/screens/Roles/Roles.test.tsx
@@ -154,11 +154,14 @@ describe('Testing Roles screen', () => {
 
     await wait();
 
-    const search1 = 'Jo\b\bS\b';
+    const search1 = 'John{backspace}{backspace}{backspace}{backspace}';
     userEvent.type(screen.getByTestId(/searchByName/i), search1);
 
-    const search2 = 'Peter';
+    const search2 = 'Pete{backspace}{backspace}{backspace}{backspace}';
     userEvent.type(screen.getByTestId(/searchByName/i), search2);
+
+    const search3 = 'John{backspace}{backspace}{backspace}{backspace}Sam';
+    userEvent.type(screen.getByTestId(/searchByName/i), search3);
   });
 
   test('Testing change role functionality', async () => {

--- a/src/screens/Roles/Roles.test.tsx
+++ b/src/screens/Roles/Roles.test.tsx
@@ -154,7 +154,11 @@ describe('Testing Roles screen', () => {
 
     await wait();
 
-    userEvent.type(screen.getByTestId(/searchByName/i), 'John');
+    const search1 = 'Jo\b\bS\b';
+    userEvent.type(screen.getByTestId(/searchByName/i), search1);
+
+    const search2 = 'Peter';
+    userEvent.type(screen.getByTestId(/searchByName/i), search2);
   });
 
   test('Testing change role functionality', async () => {

--- a/src/screens/Roles/Roles.test.tsx
+++ b/src/screens/Roles/Roles.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MockedProvider } from '@apollo/react-testing';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
@@ -12,6 +12,7 @@ import { UPDATE_USERTYPE_MUTATION } from 'GraphQl/Mutations/mutations';
 import { USER_LIST } from 'GraphQl/Queries/Queries';
 import { store } from 'state/store';
 import userEvent from '@testing-library/user-event';
+import { within } from '@testing-library/react';
 import i18nForTest from 'utils/i18nForTest';
 
 const MOCKS = [
@@ -121,6 +122,46 @@ describe('Testing Roles screen', () => {
     expect(window.location).toBeAt('/orglist');
   });
 
+  test('Roles renders a <PaginationList /> and tests changing rowsPerPage in the select', () => {
+    render(
+      <MockedProvider addTypename={false} mocks={MOCKS}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <Roles />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    const appHeader = screen.queryByTestId('roles-header');
+    const function_when_appHeader_isNotNull = (app: any) => {
+      const paginationList = within(app).getByTestId('something');
+      const tablePagination =
+        within(paginationList).getByTestId('table-pagination');
+
+      expect(tablePagination).toBeInTheDocument();
+
+      const rowsPerPageSelect = within(tablePagination).getByTestId(
+        'rows-per-page-select'
+      );
+      fireEvent.change(rowsPerPageSelect, { target: { value: '-1' } });
+      expect(rowsPerPageSelect).toHaveValue('-1');
+    };
+
+    const function_when_appHeader_isNull = () => {
+      expect(appHeader).toBeNull();
+    };
+
+    const assertion =
+      appHeader !== null
+        ? function_when_appHeader_isNotNull(appHeader)
+        : function_when_appHeader_isNull();
+
+    assertion;
+  });
+
   test('Testing, If userType is not SUPERADMIN', async () => {
     localStorage.setItem('UserType', 'USER');
 
@@ -160,8 +201,12 @@ describe('Testing Roles screen', () => {
     const search2 = 'Pete{backspace}{backspace}{backspace}{backspace}';
     userEvent.type(screen.getByTestId(/searchByName/i), search2);
 
-    const search3 = 'John{backspace}{backspace}{backspace}{backspace}Sam';
+    const search3 =
+      'John{backspace}{backspace}{backspace}{backspace}Sam{backspace}{backspace}{backspace}';
     userEvent.type(screen.getByTestId(/searchByName/i), search3);
+
+    const search4 = 'Sam{backspace}{backspace}P';
+    userEvent.type(screen.getByTestId(/searchByName/i), search4);
   });
 
   test('Testing change role functionality', async () => {

--- a/src/screens/Roles/Roles.tsx
+++ b/src/screens/Roles/Roles.tsx
@@ -19,6 +19,7 @@ const Roles = () => {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
   const [searchByName, setSearchByName] = useState('');
+  const [count, setCount] = useState(0);
 
   useEffect(() => {
     const userType = localStorage.getItem('UserType');
@@ -27,6 +28,20 @@ const Roles = () => {
     }
     setComponentLoader(false);
   }, []);
+
+  useEffect(() => {
+    if (searchByName !== '') {
+      refetch({
+        filter: searchByName,
+      });
+    } else {
+      if (count !== 0) {
+        refetch({
+          filter: searchByName,
+        });
+      }
+    }
+  }, [count, searchByName]);
 
   const { data, loading: users_loading, refetch } = useQuery(USER_LIST);
 
@@ -85,10 +100,7 @@ const Roles = () => {
   const handleSearchByName = (e: any) => {
     const { value } = e.target;
     setSearchByName(value);
-
-    refetch({
-      filter: value,
-    });
+    setCount((prev) => prev + 1);
   };
 
   return (

--- a/src/screens/Roles/Roles.tsx
+++ b/src/screens/Roles/Roles.tsx
@@ -87,7 +87,7 @@ const Roles = () => {
     setSearchByName(value);
 
     refetch({
-      filter: searchByName,
+      filter: value,
     });
   };
 

--- a/src/screens/Roles/Roles.tsx
+++ b/src/screens/Roles/Roles.tsx
@@ -104,7 +104,7 @@ const Roles = () => {
   };
 
   return (
-    <>
+    <div data-testid="roles-header">
       <ListNavbar />
       <Row>
         <Col sm={3}>
@@ -243,6 +243,7 @@ const Roles = () => {
                       count={data ? data.users.length : 0}
                       rowsPerPage={rowsPerPage}
                       page={page}
+                      data-testid="something"
                       onPageChange={handleChangePage}
                       onRowsPerPageChange={handleChangeRowsPerPage}
                     />
@@ -253,7 +254,7 @@ const Roles = () => {
           </div>
         </Col>
       </Row>
-    </>
+    </div>
   );
 };
 


### PR DESCRIPTION

**What kind of change does this PR introduce?**
While searching for users by their first name in the Roles page, it will show the appropriate results instead of showing results for the previous input. ( it was giving results an input variable behind )

**Issue Number:**

Fixes #716 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

https://user-images.githubusercontent.com/97829544/225826006-9d54dda3-a849-4cb6-aa2c-9cceac6f02d8.mp4

**If relevant, did you update the documentation?**

Not Relevant.

**Summary**
While searching for users by their first names in the Roles section of talawa admin app, whenever we used to type input, it was showing the relevant results one step afterwards.

for example, If we typed 'f' , it wouldn't show the  users whose names have 'f' in their first name but would only show those results when we type one more letter , say 'fa' - where the results would be shown for users having 'f' in their first names.

It happens because of the useState hook taking time to update. So filtering with event.target.value instead solves this issue.

**Does this PR introduce a breaking change?**

It's not a breaking change but a small change that makes user experience better.

**Other information**

None.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
