### PR TITLE
rectified warnings for file `src/screens/OrgSettings/OrgSettings.test.tsx`

### DIFF
--- a/src/screens/OrgSettings/OrgSettings.test.tsx
+++ b/src/screens/OrgSettings/OrgSettings.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MockedProvider } from '@apollo/react-testing';
+import { MockedProvider, MockLink } from '@apollo/react-testing';
 import { act, render, screen } from '@testing-library/react';
 import { MEMBERSHIP_REQUEST } from 'GraphQl/Queries/Queries';
 import { Provider } from 'react-redux';
@@ -38,6 +38,7 @@ const MOCKS = [
   },
 ];
 
+const mocklink = new MockLink(MOCKS, false, { showWarnings: false });
 async function wait(ms = 0) {
   await act(() => {
     return new Promise((resolve) => {
@@ -67,7 +68,7 @@ describe('Organisation Settings Page', () => {
     window.location.assign('/orglist');
 
     const { container } = render(
-      <MockedProvider addTypename={false} mocks={MOCKS}>
+      <MockedProvider addTypename={false} link={mocklink}>
         <BrowserRouter>
           <Provider store={store}>
             <I18nextProvider i18n={i18nForTest}>


### PR DESCRIPTION
**What kind of change does this PR introduce?** This PR rectifies warning logs while testing for `src/screens/OrgSettings/OrgSettings.test.tsx`

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:** #558 

This PR Fixes #558

**Did you add tests for your changes? Yes**

**Snapshots/Videos:**
<img src="https://user-images.githubusercontent.com/65107474/225845637-73e6ff26-ee6b-46fe-8b05-799b42ffbf01.png" width=500/>

**Summary**
I tried to check for various methods but currently MockLink works best to suppress the warnings

**Does this PR introduce a breaking change? No**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)? Yes**

<!--Yes or No-->
