### PR TITLE
Super Admin Dashboard Error When Organizations Absent

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -36,7 +36,9 @@
     "isPublic": "Is Public",
     "visibleInSearch": "Visible In Search",
     "displayImage": "Display Image",
-    "enterName": "Enter Name"
+    "enterName": "Enter Name",
+    "noOrgErrorTitle": "Organizations Not Found",
+    "noOrgErrorDescription": "Please create an organization through dashboard"
   },
   "superDashListCard": {
     "created": "Created",

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -60,7 +60,8 @@
     "admin": "ADMIN",
     "superAdmin": "SUPERADMIN",
     "user": "USER",
-    "enterName": "Enter Name"
+    "enterName": "Enter Name",
+    "noOrgError": "Organizations not found, please create an organization through dashboard"
   },
   "requests": {
     "title": "Talawa Requests",
@@ -70,7 +71,8 @@
     "email": "Email",
     "accept": "Accept",
     "reject": "Reject",
-    "enterName": "Enter Name"
+    "enterName": "Enter Name",
+    "noOrgError": "Organizations not found, please create an organization through dashboard"
   },
   "adminNavbar": {
     "talawa_portal": "Talawa Portal",

--- a/src/screens/OrgList/OrgList.test.tsx
+++ b/src/screens/OrgList/OrgList.test.tsx
@@ -78,6 +78,11 @@ const MOCKS_EMPTY = [
     request: {
       query: ORGANIZATION_CONNECTION_LIST,
     },
+    result: {
+      data: {
+        organizationsConnection: [],
+      },
+    },
   },
   {
     request: {
@@ -110,6 +115,30 @@ describe('Organisation List Page', () => {
   };
 
   global.alert = jest.fn();
+
+  test('Should render no organisation warning alert when there are no organization', async () => {
+    window.location.assign('/');
+
+    const { container } = render(
+      <MockedProvider addTypename={false} link={link2}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <OrgList />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+
+    expect(container.textContent).toMatch('Organizations Not Found');
+    expect(container.textContent).toMatch(
+      'Please create an organization through dashboard'
+    );
+    expect(window.location).toBeAt('/');
+  });
 
   test('Correct mock data should be queried', async () => {
     const dataQuery1 = MOCKS[0]?.result?.data?.organizationsConnection;

--- a/src/screens/OrgList/OrgList.test.tsx
+++ b/src/screens/OrgList/OrgList.test.tsx
@@ -140,6 +140,30 @@ describe('Organisation List Page', () => {
     expect(window.location).toBeAt('/');
   });
 
+  test('Should not render no organisation warning alert when there are no organization', async () => {
+    window.location.assign('/');
+
+    const { container } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <OrgList />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+
+    expect(container.textContent).not.toMatch('Organizations Not Found');
+    expect(container.textContent).not.toMatch(
+      'Please create an organization through dashboard'
+    );
+    expect(window.location).toBeAt('/');
+  });
+
   test('Correct mock data should be queried', async () => {
     const dataQuery1 = MOCKS[0]?.result?.data?.organizationsConnection;
 

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -21,7 +21,7 @@ import PaginationList from 'components/PaginationList/PaginationList';
 import debounce from 'utils/debounce';
 import convertToBase64 from 'utils/convertToBase64';
 import AdminDashListCard from 'components/AdminDashListCard/AdminDashListCard';
-import PostNotFound from 'components/PostNotFound/PostNotFound';
+import { Alert, AlertTitle } from '@mui/material';
 
 function OrgList(): JSX.Element {
   const { t } = useTranslation('translation', { keyPrefix: 'orgList' });
@@ -224,7 +224,7 @@ function OrgList(): JSX.Element {
               />
             </div>
             <div className={styles.list_box}>
-              {data && data.organizationsConnection.length > 0 ? (
+              {data.organizationsConnection.length < 0 ? (
                 (rowsPerPage > 0
                   ? dataRevOrg.slice(
                       page * rowsPerPage,
@@ -275,7 +275,12 @@ function OrgList(): JSX.Element {
                   }
                 )
               ) : (
-                <PostNotFound title="organization" />
+                <div>
+                  <Alert variant="filled" severity="error">
+                    <AlertTitle>{t('noOrgErrorTitle')}</AlertTitle>
+                    {t('noOrgErrorDescription')}
+                  </Alert>
+                </div>
               )}
             </div>
             <div>

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -224,7 +224,7 @@ function OrgList(): JSX.Element {
               />
             </div>
             <div className={styles.list_box}>
-              {data.organizationsConnection.length > 0 ? (
+              {data?.organizationsConnection.length > 0 ? (
                 (rowsPerPage > 0
                   ? dataRevOrg.slice(
                       page * rowsPerPage,

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -224,7 +224,7 @@ function OrgList(): JSX.Element {
               />
             </div>
             <div className={styles.list_box}>
-              {data.organizationsConnection.length < 0 ? (
+              {data.organizationsConnection.length > 0 ? (
                 (rowsPerPage > 0
                   ? dataRevOrg.slice(
                       page * rowsPerPage,

--- a/src/screens/Requests/Requests.tsx
+++ b/src/screens/Requests/Requests.tsx
@@ -6,7 +6,10 @@ import { useTranslation } from 'react-i18next';
 
 import styles from './Requests.module.css';
 import ListNavbar from 'components/ListNavbar/ListNavbar';
-import { USER_LIST } from 'GraphQl/Queries/Queries';
+import {
+  ORGANIZATION_CONNECTION_LIST,
+  USER_LIST,
+} from 'GraphQl/Queries/Queries';
 import {
   ACCPET_ADMIN_MUTATION,
   REJECT_ADMIN_MUTATION,
@@ -37,6 +40,18 @@ const Requests = () => {
 
   const [acceptAdminFunc] = useMutation(ACCPET_ADMIN_MUTATION);
   const [rejectAdminFunc] = useMutation(REJECT_ADMIN_MUTATION);
+
+  const { data: dataOrgs } = useQuery(ORGANIZATION_CONNECTION_LIST);
+
+  useEffect(() => {
+    if (!dataOrgs) {
+      return;
+    }
+
+    if (dataOrgs.organizationsConnection.length > 0) {
+      toast.warning(t('noOrgError'));
+    }
+  }, [dataOrgs]);
 
   useEffect(() => {
     if (data) {

--- a/src/screens/Requests/Requests.tsx
+++ b/src/screens/Requests/Requests.tsx
@@ -48,7 +48,7 @@ const Requests = () => {
       return;
     }
 
-    if (dataOrgs.organizationsConnection.length > 0) {
+    if (dataOrgs.organizationsConnection.length === 0) {
       toast.warning(t('noOrgError'));
     }
   }, [dataOrgs]);

--- a/src/screens/Roles/Roles.test.tsx
+++ b/src/screens/Roles/Roles.test.tsx
@@ -9,11 +9,15 @@ import 'jest-location-mock';
 
 import Roles from './Roles';
 import { UPDATE_USERTYPE_MUTATION } from 'GraphQl/Mutations/mutations';
-import { USER_LIST } from 'GraphQl/Queries/Queries';
+import {
+  ORGANIZATION_CONNECTION_LIST,
+  USER_LIST,
+} from 'GraphQl/Queries/Queries';
 import { store } from 'state/store';
 import userEvent from '@testing-library/user-event';
 import i18nForTest from 'utils/i18nForTest';
 import { StaticMockLink } from 'utils/StaticMockLink';
+import { ToastContainer } from 'react-toastify';
 
 const MOCKS = [
   {
@@ -89,6 +93,36 @@ const MOCKS = [
       },
     },
   },
+  {
+    request: {
+      query: ORGANIZATION_CONNECTION_LIST,
+    },
+    result: {
+      data: {
+        organizationsConnection: [
+          {
+            _id: 1,
+            image: '',
+            name: 'Akatsuki',
+            creator: {
+              firstName: 'John',
+              lastName: 'Doe',
+            },
+            admins: [
+              {
+                _id: '123',
+              },
+            ],
+            members: {
+              _id: '234',
+            },
+            createdAt: '02/02/2022',
+            location: 'Washington DC',
+          },
+        ],
+      },
+    },
+  },
 ];
 const EMPTY_MOCKS = [
   {
@@ -107,6 +141,16 @@ const EMPTY_MOCKS = [
     result: {
       data: {
         updateUserType: false,
+      },
+    },
+  },
+  {
+    request: {
+      query: ORGANIZATION_CONNECTION_LIST,
+    },
+    result: {
+      data: {
+        organizationsConnection: [],
       },
     },
   },
@@ -213,5 +257,47 @@ describe('Testing Roles screen', () => {
     );
 
     await wait();
+  });
+
+  test('Should render warning alert when there are no organizations', async () => {
+    const { container } = render(
+      <MockedProvider addTypename={false} link={link2}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <ToastContainer />
+              <Roles />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+
+    expect(container.textContent).toMatch(
+      'Organizations not found, please create an organization through dashboard'
+    );
+  });
+
+  test('Should not render warning alert when there are organizations present', async () => {
+    const { container } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <ToastContainer />
+              <Roles />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+
+    expect(container.textContent).not.toMatch(
+      'Organizations not found, please create an organization through dashboard'
+    );
   });
 });

--- a/src/screens/Roles/Roles.tsx
+++ b/src/screens/Roles/Roles.tsx
@@ -6,7 +6,10 @@ import { useTranslation } from 'react-i18next';
 
 import styles from './Roles.module.css';
 import ListNavbar from 'components/ListNavbar/ListNavbar';
-import { USER_LIST } from 'GraphQl/Queries/Queries';
+import {
+  ORGANIZATION_CONNECTION_LIST,
+  USER_LIST,
+} from 'GraphQl/Queries/Queries';
 import { UPDATE_USERTYPE_MUTATION } from 'GraphQl/Mutations/mutations';
 import PaginationList from 'components/PaginationList/PaginationList';
 
@@ -31,6 +34,18 @@ const Roles = () => {
   const { data, loading: users_loading, refetch } = useQuery(USER_LIST);
 
   const [updateUserType] = useMutation(UPDATE_USERTYPE_MUTATION);
+
+  const { data: dataOrgs } = useQuery(ORGANIZATION_CONNECTION_LIST);
+
+  useEffect(() => {
+    if (!dataOrgs) {
+      return;
+    }
+
+    if (dataOrgs.organizationsConnection.length > 0) {
+      toast.warning(t('noOrgError'));
+    }
+  }, [dataOrgs]);
 
   if (componentLoader || users_loading) {
     return <div className="loader"></div>;
@@ -116,6 +131,7 @@ const Roles = () => {
             <Row className={styles.justifysp}>
               <p className={styles.logintitle}>{t('usersList')}</p>
             </Row>
+
             <div className={styles.list_box}>
               <div className="table-responsive">
                 <table className={`table table-hover ${styles.userListTable}`}>

--- a/src/screens/Roles/Roles.tsx
+++ b/src/screens/Roles/Roles.tsx
@@ -42,7 +42,7 @@ const Roles = () => {
       return;
     }
 
-    if (dataOrgs.organizationsConnection.length > 0) {
+    if (dataOrgs.organizationsConnection.length === 0) {
       toast.warning(t('noOrgError'));
     }
   }, [dataOrgs]);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Feature/Refactoring

**Issue Number:**

Fixes #533 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

`OrgList` Page -
<img width="1904" alt="Screenshot 2023-03-18 at 7 44 35 PM" src="https://user-images.githubusercontent.com/28570857/226111455-fb0fde2a-1136-4900-b8f2-a9908995510b.png">

`Roles` Page -
<img width="1904" alt="Screenshot 2023-03-18 at 7 44 57 PM" src="https://user-images.githubusercontent.com/28570857/226111473-7c7a3a4d-e63e-4fff-a535-85e4c755fd70.png">

`Request` Page -
<img width="1904" alt="Screenshot 2023-03-18 at 7 45 13 PM" src="https://user-images.githubusercontent.com/28570857/226111487-3c1b74ad-d19b-41e2-8521-3f2498a472ef.png">

**If relevant, did you update the documentation?**

Not Relevant

**Summary**

- The `SUPERADMIN` pages did not give any error or warning when organizations were absent
- This caused bad UX on Talawa mobile app
- Added a persistent alert on the `OrgList` page 
- And warning toasts in the `Roles` and `Request` pages
- Added Tests for new changes

**Does this PR introduce a breaking change?**

No

**Other information**

NA

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes