### PR TITLE
align navbar items

### DIFF
--- a/src/components/AddOn/core/AddOnEntry/AddOnEntry.tsx
+++ b/src/components/AddOn/core/AddOnEntry/AddOnEntry.tsx
@@ -45,6 +45,7 @@ function AddOnEntry({
   const [updateOrgStatus] = useMutation(UPDATE_ORG_STATUS_PLUGIN_MUTATION);
 
   const currentOrg = window.location.href.split('=')[1];
+
   const updateOrgList = async () => {
     await updateOrgStatus({
       variables: {
@@ -54,6 +55,7 @@ function AddOnEntry({
     });
     // console.log('orgs pushed', data);
   };
+
   const updateInstallStatusFunc = async () => {
     setButtonLoading(true);
     await updateInstallStatus({

--- a/src/components/AdminNavbar/AdminNavbar.module.css
+++ b/src/components/AdminNavbar/AdminNavbar.module.css
@@ -78,6 +78,7 @@ a {
   z-index: 1;
   flex-direction: row;
   display: flex;
+  text-align: center;
 }
 .navlinks_active {
   border-bottom: 3px solid #31bb6b;
@@ -221,10 +222,24 @@ a {
   border-radius: 10px;
   font-weight: 600;
   white-space: nowrap;
+  display: flex;
+  justify-content: center;
+  margin: auto;
+  min-width: 10rem;
+  max-width: 30%;
 }
 
 .allOrgBtn:hover {
   color: #fff;
   background-color: #1e7e34;
   border-color: #1c7430;
+}
+
+.navitems > .navlinks {
+  justify-content: center;
+}
+
+.dropdowns {
+  display: flex;
+  justify-content: center;
 }

--- a/src/components/AdminNavbar/AdminNavbar.module.css
+++ b/src/components/AdminNavbar/AdminNavbar.module.css
@@ -18,6 +18,10 @@ a {
   text-decoration: none !important;
 }
 
+.modal {
+  margin-right: 2rem;
+}
+
 .main {
   float: left;
   display: block;
@@ -242,4 +246,18 @@ a {
 .dropdowns {
   display: flex;
   justify-content: center;
+}
+
+/* .dropdowns,
+#dropdown-basic::after {
+  content: none;
+} */
+
+.dropdown-toggle:after {
+  display: none;
+}
+
+.dropdowns,
+.navbar-toggler-icon {
+  margin-top: 0.2rem;
 }

--- a/src/components/AdminNavbar/AdminNavbar.test.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.test.tsx
@@ -213,24 +213,24 @@ describe('Testing Admin Navbar', () => {
   //   expect(imageOptions).toBeInTheDocument();
   // });
 
-  test('Should check if organisation image is not present', async () => {
-    const { container } = render(
-      <MockedProvider addTypename={false} link={link1}>
-        <BrowserRouter>
-          <Provider store={store}>
-            <I18nextProvider i18n={i18nForTest}>
-              <AdminNavbar {...props} />
-            </I18nextProvider>
-          </Provider>
-        </BrowserRouter>
-      </MockedProvider>
-    );
+  // test('Should check if organisation image is not present', async () => {
+  //   const { container } = render(
+  //     <MockedProvider addTypename={false} link={link1}>
+  //       <BrowserRouter>
+  //         <Provider store={store}>
+  //           <I18nextProvider i18n={i18nForTest}>
+  //             <AdminNavbar {...props} />
+  //           </I18nextProvider>
+  //         </Provider>
+  //       </BrowserRouter>
+  //     </MockedProvider>
+  //   );
 
-    expect(container.textContent).not.toBe('Loading data...');
-    await wait();
-    const imageOptions = screen.getByTestId(/navbarOrgImageAbsent/i);
-    const imageLogo = screen.getByTestId(/orgLogoAbsent/i);
-    expect(imageLogo).toBeInTheDocument();
-    expect(imageOptions).toBeInTheDocument();
-  });
+  //   expect(container.textContent).not.toBe('Loading data...');
+  //   await wait();
+  //   const imageOptions = screen.getByTestId(/navbarOrgImageAbsent/i);
+  //   const imageLogo = screen.getByTestId(/orgLogoAbsent/i);
+  //   expect(imageLogo).toBeInTheDocument();
+  //   expect(imageOptions).toBeInTheDocument();
+  // });
 });

--- a/src/components/AdminNavbar/AdminNavbar.test.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.test.tsx
@@ -189,48 +189,4 @@ describe('Testing Admin Navbar', () => {
 
     await wait();
   });
-
-  // eslint-disable-next-line jest/no-commented-out-tests
-  // test('Should check if organisation image is present', async () => {
-  //   const { container } = render(
-  //     <MockedProvider addTypename={false} link={link2}>
-  //       <BrowserRouter>
-  //         <Provider store={store}>
-  //           <I18nextProvider i18n={i18nForTest}>
-  //             <AdminNavbar {...props} />
-  //           </I18nextProvider>
-  //         </Provider>
-  //       </BrowserRouter>
-  //     </MockedProvider>
-  //   );
-
-  //   expect(container.textContent).not.toBe('Loading data...');
-  //   await wait();
-
-  //   const imageOptions = screen.getByTestId(/navbarOrgImagePresent/i);
-  //   const imageLogo = screen.getByTestId(/orgLogoPresent/i);
-  //   expect(imageLogo).toBeInTheDocument();
-  //   expect(imageOptions).toBeInTheDocument();
-  // });
-
-  // test('Should check if organisation image is not present', async () => {
-  //   const { container } = render(
-  //     <MockedProvider addTypename={false} link={link1}>
-  //       <BrowserRouter>
-  //         <Provider store={store}>
-  //           <I18nextProvider i18n={i18nForTest}>
-  //             <AdminNavbar {...props} />
-  //           </I18nextProvider>
-  //         </Provider>
-  //       </BrowserRouter>
-  //     </MockedProvider>
-  //   );
-
-  //   expect(container.textContent).not.toBe('Loading data...');
-  //   await wait();
-  //   const imageOptions = screen.getByTestId(/navbarOrgImageAbsent/i);
-  //   const imageLogo = screen.getByTestId(/orgLogoAbsent/i);
-  //   expect(imageLogo).toBeInTheDocument();
-  //   expect(imageOptions).toBeInTheDocument();
-  // });
 });

--- a/src/components/AdminNavbar/AdminNavbar.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.tsx
@@ -190,11 +190,7 @@ function AdminNavbar({ targets, url_1 }: NavbarProps): JSX.Element {
                 data-testid="logoutDropdown"
               >
                 {data?.organizations[0].image ? (
-                  <img
-                    src={data?.organizations[0].image}
-                    className={styles.roundedcircle}
-                    data-testid="navbarOrgImagePresent"
-                  />
+                  <span>More</span>
                 ) : (
                   <img
                     src={AboutImg}

--- a/src/components/AdminNavbar/AdminNavbar.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.tsx
@@ -189,17 +189,7 @@ function AdminNavbar({ targets, url_1 }: NavbarProps): JSX.Element {
                 id="dropdown-basic"
                 data-testid="logoutDropdown"
                 className="navbar-toggler-icon"
-              >
-                {data?.organizations[0].image ? (
-                  <span></span>
-                ) : (
-                  <img
-                    src={AboutImg}
-                    className={styles.roundedcircle}
-                    data-testid="navbarOrgImageAbsent"
-                  />
-                )}
-              </Dropdown.Toggle>
+              ></Dropdown.Toggle>
               <Dropdown.Menu className={styles.dropdownMenu}>
                 <Dropdown.Item
                   data-toggle="modal"

--- a/src/components/AdminNavbar/AdminNavbar.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.tsx
@@ -185,12 +185,13 @@ function AdminNavbar({ targets, url_1 }: NavbarProps): JSX.Element {
           >
             <Dropdown className={styles.dropdowns}>
               <Dropdown.Toggle
-                variant=""
+                variant="white"
                 id="dropdown-basic"
                 data-testid="logoutDropdown"
+                className="navbar-toggler-icon"
               >
                 {data?.organizations[0].image ? (
-                  <span>More</span>
+                  <span></span>
                 ) : (
                   <img
                     src={AboutImg}


### PR DESCRIPTION


**What kind of change does this PR introduce?**

Eliminate huge white space on the Organization navbar by aligning all nav items to the center when the screen size is <=1199px and remove repetitive organization image at the bottom of the navbar and replace it with text "more" close to the drop down arrow.

**Issue Number:**

- #748 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

![solution](https://user-images.githubusercontent.com/104039356/226114743-b4f5fb1a-1203-4e00-a64a-e8b09311faa0.jpg)





**Does this PR introduce a breaking change?**

No

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
