### PR TITLE
Align superadmin navbar

### DIFF
--- a/src/components/AdminNavbar/AdminNavbar.test.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.test.tsx
@@ -189,4 +189,24 @@ describe('Testing Admin Navbar', () => {
 
     await wait();
   });
+  test('Should check if organisation image is not present', async () => {
+    const { container } = render(
+      <MockedProvider addTypename={false} link={link1}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <AdminNavbar {...props} />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    expect(container.textContent).not.toBe('Loading data...');
+    await wait();
+    const imageOptions = screen.getByTestId(/navbarOrgImageAbsent/i);
+    const imageLogo = screen.getByTestId(/orgLogoAbsent/i);
+    expect(imageLogo).toBeInTheDocument();
+    expect(imageOptions).toBeInTheDocument();
+  });
 });

--- a/src/components/AdminNavbar/AdminNavbar.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.tsx
@@ -8,7 +8,7 @@ import { useTranslation } from 'react-i18next';
 import Cookies from 'js-cookie';
 import i18next from 'i18next';
 import { toast } from 'react-toastify';
-
+import MenuIcon from '@mui/icons-material/Menu';
 import styles from './AdminNavbar.module.css';
 import AboutImg from 'assets/images/defaultImg.png';
 import { ORGANIZATIONS_LIST } from 'GraphQl/Queries/Queries';
@@ -188,8 +188,19 @@ function AdminNavbar({ targets, url_1 }: NavbarProps): JSX.Element {
                 variant="white"
                 id="dropdown-basic"
                 data-testid="logoutDropdown"
-                className="navbar-toggler-icon"
-              ></Dropdown.Toggle>
+              >
+                {data?.organizations[0].image ? (
+                  <span>
+                    <MenuIcon></MenuIcon>
+                  </span>
+                ) : (
+                  <img
+                    src={AboutImg}
+                    className={styles.roundedcircle}
+                    data-testid="navbarOrgImageAbsent"
+                  />
+                )}
+              </Dropdown.Toggle>
               <Dropdown.Menu className={styles.dropdownMenu}>
                 <Dropdown.Item
                   data-toggle="modal"

--- a/src/components/ListNavbar/ListNavbar.module.css
+++ b/src/components/ListNavbar/ListNavbar.module.css
@@ -116,7 +116,21 @@
 }
 
 @media only screen and (max-width: 1200px) {
+  .navitems > .navlinks {
+    display: flex;
+    justify-content: center;
+    margin: 0;
+  }
+
+  .languageBtn {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    margin-left: 1rem;
+  }
+
   .logoutbtn {
-    margin-bottom: 10px;
+    margin: 10px auto;
+    min-width: 10rem;
   }
 }


### PR DESCRIPTION


**What kind of change does this PR introduce?**

Eliminate huge white space on the super admin navbar by aligning all nav items to the center when the screen size is <=1199px, This white space makes the navbar look incomplete, It can lead to poor user experience.

**Issue Number:**

Fixes  
- #757 

**Did you add tests for your changes?**
No.


**Snapshots/Videos:**

![superadmin nav](https://user-images.githubusercontent.com/104039356/226219688-b624ac17-4cd8-4be2-b4f5-6d7a0d17cbf8.jpg)



**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
