### PR TITLE
Add delete organization confirmation input field

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -109,6 +109,7 @@
     "membershipRequests": "Membership Requests",
     "deleteOrganization": "Delete Organization",
     "deleteMsg": "Do you want to delete this organization?",
+    "confirmDeleteText": "Please type <bold>{{orgName}}</bold> to confirm",
     "no": "No",
     "yes": "Yes"
   },

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -105,6 +105,7 @@
     "membershipRequests": "Demandes d'adhésion",
     "deleteOrganization": "Supprimer l'organisation",
     "deleteMsg": "Voulez-vous supprimer cette organisation ?",
+    "confirmDeleteText": "Veuillez saisir <bold>{{orgName}}</bold> pour confirmer",
     "no": "Non",
     "yes": "Oui"
   },

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -105,6 +105,7 @@
     "membershipRequests": "सदस्यता अनुरोध",
     "deleteOrganization": "संगठन हटाएं",
     "deleteMsg": "क्या आप इस संगठन को हटाना चाहते हैं?",
+    "confirmDeleteText": "कृपया पुष्टि करने के लिए <bold>{{orgName}}</bold> टाइप करें",
     "no": "नहीं",
     "yes": "हाँ"
   },

--- a/public/locales/sp.json
+++ b/public/locales/sp.json
@@ -105,6 +105,7 @@
     "membershipRequests": "Solicitudes de membresía",
     "deleteOrganization": "Eliminar Organización",
     "deleteMsg": "¿Desea eliminar esta organización?",
+    "confirmDeleteText": "Escriba <bold>{{orgName}}</bold> para confirmar",
     "no": "No",
     "yes": "Sí"
   },

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -105,6 +105,7 @@
     "membershipRequests": "會員申請",
     "deleteOrganization": "刪除組織",
     "deleteMsg": "您要刪除此組織嗎？",
+    "confirmDeleteText": "請鍵入 <bold>{{orgName}}</bold> 進行確認",
     "no": "不",
     "yes": "是的"
   },

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.module.css
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.module.css
@@ -196,7 +196,7 @@
   margin-bottom: 0rem !important;
 }
 
-.orgDeleteInput  {
+.orgDeleteInput {
   text-decoration: none;
   border-color: #dbd7d7;
   border-style: solid;

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.module.css
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.module.css
@@ -43,8 +43,8 @@
   padding-bottom: 5px;
   width: 26%;
 }
-.tagdetailsGreen > button {
-  background-color: #31bb6b;
+.tagdetailsRed > button {
+  background-color: #dc3545;
   color: white;
   outline: none;
   cursor: pointer;
@@ -194,4 +194,28 @@
 .counterHead {
   color: #99abb4;
   margin-bottom: 0rem !important;
+}
+
+.orgDeleteInput  {
+  text-decoration: none;
+  border-color: #dbd7d7;
+  border-style: solid;
+  border-radius: 5px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  padding-right: 10px;
+  padding-left: 10px;
+  box-shadow: none;
+  width: 100%;
+}
+
+.orgDeleteInput:focus {
+  border-color: #fff;
+  box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
+  outline: none;
+}
+
+.orgDelConfirmText {
+  margin-top: 10px;
+  margin-bottom: 10px;
 }

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.test.tsx
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.test.tsx
@@ -5,6 +5,7 @@ import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import 'jest-location-mock';
 import { I18nextProvider } from 'react-i18next';
+import userEvent from '@testing-library/user-event';
 
 import OrganizationDashboard from './OrganizationDashboard';
 import {
@@ -65,6 +66,7 @@ describe('Organisation Dashboard Page', () => {
     fireEvent.click(screen.getByTestId(/deleteOrganizationBtn/i));
     expect(window.location).not.toBeNull();
   });
+
   test('Should check if organisation image is present', async () => {
     const { container } = render(
       <MockedProvider addTypename={false} mocks={MOCKS_WITH_IMAGE}>
@@ -83,6 +85,7 @@ describe('Organisation Dashboard Page', () => {
     const image = screen.getByTestId(/orgDashImgPresent/i);
     expect(image).toBeInTheDocument();
   });
+
   test('Should check if organisation image is not present', async () => {
     const { container } = render(
       <MockedProvider addTypename={false} mocks={MOCKS_WITHOUT_IMAGE}>
@@ -100,5 +103,37 @@ describe('Organisation Dashboard Page', () => {
     await wait();
     const image = screen.getByTestId(/orgDashImgAbsent/i);
     expect(image).toBeInTheDocument();
+  });
+
+  test('should check organization delete call', async () => {
+    const { container } = render(
+      <MockedProvider addTypename={false} mocks={MOCKS_WITHOUT_IMAGE}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <OrganizationDashboard />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    expect(container.textContent).not.toBe('Loading data...');
+    await wait();
+    fireEvent.click(screen.getByText('Delete This Organization'));
+    const orgInput = screen.getByTestId(/orgName/i);
+    userEvent.type(orgInput, 'bar');
+    expect(screen.getByTestId(/deleteOrganizationBtn/i)).toHaveProperty(
+      'disabled',
+      true
+    );
+
+    userEvent.clear(orgInput);
+    userEvent.type(orgInput, 'Dummy Organization');
+    userEvent.tab();
+    expect(screen.getByTestId(/deleteOrganizationBtn/i)).toHaveProperty(
+      'disabled',
+      false
+    );
   });
 });

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
@@ -76,7 +76,8 @@ function OrganizationDashboard(): JSX.Element {
   };
 
   function handleConfirmDeleteOrg(e: any) {
-    const isMatchingOrgName = e.target.value === data.organizations[0].name;
+    const { value } = e.target;
+    const isMatchingOrgName = value === data.organizations[0].name;
     setIsDisabled(!isMatchingOrgName);
   }
 
@@ -332,7 +333,7 @@ function OrganizationDashboard(): JSX.Element {
             </div>
             <div className="modal-body">
               {t('deleteMsg')}
-              <p className={styles.orgDelConfirmTex}>
+              <p className={styles.orgDelConfirmText}>
                 <Trans
                   i18nKey="dashboard.confirmDeleteText"
                   values={{

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Row from 'react-bootstrap/Row';
 import Col from 'react-bootstrap/Col';
 import { useMutation, useQuery } from '@apollo/client';
@@ -8,6 +8,7 @@ import { Container } from 'react-bootstrap';
 import { toast } from 'react-toastify';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
+import { Trans } from 'react-i18next';
 
 import styles from './OrganizationDashboard.module.css';
 import AdminNavbar from 'components/AdminNavbar/AdminNavbar';
@@ -48,6 +49,8 @@ function OrganizationDashboard(): JSX.Element {
 
   const [del] = useMutation(DELETE_ORGANIZATION_MUTATION);
 
+  const [isDisabled, setIsDisabled] = useState(true);
+
   const delete_org = async () => {
     try {
       const { data } = await del({
@@ -71,6 +74,11 @@ function OrganizationDashboard(): JSX.Element {
       }
     }
   };
+
+  function handleConfirmDeleteOrg(e: any) {
+    const isMatchingOrgName = e.target.value === data.organizations[0].name;
+    setIsDisabled(!isMatchingOrgName);
+  }
 
   if (loading || loading_post || loading_event) {
     return (
@@ -112,7 +120,7 @@ function OrganizationDashboard(): JSX.Element {
                   data-testid="orgDashImgAbsent"
                 />
               )}
-              <p className={styles.tagdetailsGreen}>
+              <p className={styles.tagdetailsRed}>
                 <button
                   type="button"
                   className="mt-3"
@@ -320,20 +328,42 @@ function OrganizationDashboard(): JSX.Element {
                 <span aria-hidden="true">&times;</span>
               </button>
             </div>
-            <div className="modal-body">{t('deleteMsg')}</div>
+            <div className="modal-body">
+              {t('deleteMsg')}
+              <p className={styles.orgDelConfirmTex}>
+                <Trans
+                  i18nKey="dashboard.confirmDeleteText"
+                  values={{
+                    orgName: data.organizations[0].name,
+                  }}
+                  components={{ bold: <strong /> }}
+                />
+              </p>
+              <input
+                className={styles.orgDeleteInput}
+                type="text"
+                id="orginput"
+                data-testid="orgName"
+                autoComplete="off"
+                required
+                onChange={handleConfirmDeleteOrg}
+              />
+            </div>
+
             <div className="modal-footer">
               <button
                 type="button"
-                className="btn btn-danger"
+                className="btn btn-success"
                 data-dismiss="modal"
               >
                 {t('no')}
               </button>
               <button
                 type="button"
-                className="btn btn-success"
+                className="btn btn-danger"
                 onClick={delete_org}
                 data-testid="deleteOrganizationBtn"
+                disabled={isDisabled}
               >
                 {t('yes')}
               </button>

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
@@ -6,9 +6,9 @@ import { useSelector } from 'react-redux';
 import { RootState } from 'state/reducers';
 import { Container } from 'react-bootstrap';
 import { toast } from 'react-toastify';
-import { useTranslation } from 'react-i18next';
+import { useTranslation, Trans } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { Trans } from 'react-i18next';
+import debounce from 'utils/debounce';
 
 import styles from './OrganizationDashboard.module.css';
 import AdminNavbar from 'components/AdminNavbar/AdminNavbar';
@@ -79,6 +79,8 @@ function OrganizationDashboard(): JSX.Element {
     const isMatchingOrgName = e.target.value === data.organizations[0].name;
     setIsDisabled(!isMatchingOrgName);
   }
+
+  const debouncedHandleConfirmDeleteOrg = debounce(handleConfirmDeleteOrg);
 
   if (loading || loading_post || loading_event) {
     return (
@@ -346,7 +348,7 @@ function OrganizationDashboard(): JSX.Element {
                 data-testid="orgName"
                 autoComplete="off"
                 required
-                onChange={handleConfirmDeleteOrg}
+                onChange={debouncedHandleConfirmDeleteOrg}
               />
             </div>
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

A feature
Change the delete button to Red.
Created an input field to confirm the organization name before deleting.

![dashboard delete button](https://user-images.githubusercontent.com/78965090/226729476-da6b9258-4eb7-479c-ac8b-e5db0b267275.JPG)
![dashboard delete confirmation](https://user-images.githubusercontent.com/78965090/226729492-b60be794-50b8-4489-aa75-0ff6ccf7b7c3.JPG)


Fixes #765

**Did you add tests for your changes?**

 No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
