### PR TITLE
Modify event visibility for non-admins

### DIFF
--- a/src/components/EventCalendar/Calendar.test.tsx
+++ b/src/components/EventCalendar/Calendar.test.tsx
@@ -179,3 +179,119 @@ describe('Calendar', () => {
     );
   });
 });
+
+describe('Events rendered depending on User Type', () => {
+  const currentDayEventMock = [
+    {
+      _id: '0',
+      title: 'demo',
+      description: 'agrsg',
+      startDate: new Date().toISOString().split('T')[0],
+      endDate: new Date().toISOString().split('T')[0],
+      location: 'delhi',
+      startTime: '10:00',
+      endTime: '12:00',
+      allDay: false,
+      recurring: false,
+      isPublic: false,
+      registrants: [{ userId: '222' }],
+      isRegisterable: true,
+    },
+  ];
+  it('Should render private event for super admin', () => {
+    const userRole = 'SUPERADMIN';
+
+    const { getByTestId } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <I18nextProvider i18n={i18nForTest}>
+          <Calendar eventData={currentDayEventMock} userRole={userRole} />
+        </I18nextProvider>
+      </MockedProvider>
+    );
+
+    const childElement = getByTestId('deleteEventModalBtn');
+    expect(childElement).toBeInTheDocument();
+  });
+  it('Should render private event for organization admin', () => {
+    const userId = '222';
+    const userRole = 'ADMIN';
+    const orgData = {
+      admins: [
+        {
+          _id: userId,
+        },
+      ],
+    };
+
+    const { getByTestId } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <I18nextProvider i18n={i18nForTest}>
+          <Calendar
+            eventData={currentDayEventMock}
+            orgData={orgData}
+            userRole={userRole}
+            userId={userId}
+          />
+        </I18nextProvider>
+      </MockedProvider>
+    );
+
+    const childElement = getByTestId('deleteEventModalBtn');
+    expect(childElement).toBeInTheDocument();
+  });
+  it('Should render private event for registered user', () => {
+    const userId = '222';
+    const userRole = 'USER';
+    const orgData = {
+      admins: [
+        {
+          _id: userId,
+        },
+      ],
+    };
+
+    const { getByTestId } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <I18nextProvider i18n={i18nForTest}>
+          <Calendar
+            eventData={currentDayEventMock}
+            orgData={orgData}
+            userRole={userRole}
+            userId={userId}
+          />
+        </I18nextProvider>
+      </MockedProvider>
+    );
+
+    const childElement = getByTestId('deleteEventModalBtn');
+    expect(childElement).toBeInTheDocument();
+  });
+  it('Should not private render event for unregistered user', () => {
+    const userRole = 'USER';
+    const userId = '221';
+    const orgData = {
+      admins: [
+        {
+          _id: '333',
+        },
+      ],
+    };
+
+    const { getByTestId } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <I18nextProvider i18n={i18nForTest}>
+          <Calendar
+            eventData={currentDayEventMock}
+            orgData={orgData}
+            userRole={userRole}
+            userId={userId}
+          />
+        </I18nextProvider>
+      </MockedProvider>
+    );
+
+    expect(() => getByTestId('deleteEventModalBtn')).toThrowError(
+      'Unable to find an element by: [data-testid="deleteEventModalBtn"]'
+    );
+  });
+});

--- a/src/components/EventCalendar/Calendar.tsx
+++ b/src/components/EventCalendar/Calendar.tsx
@@ -1,6 +1,6 @@
 import EventListCard from 'components/EventListCard/EventListCard';
 import dayjs from 'dayjs';
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import styles from './Calendar.module.css';
 
 interface Event {
@@ -22,6 +22,8 @@ interface Event {
 interface CalendarProps {
   eventData: Event[];
   orgData?: IOrgList;
+  userRole?: string;
+  userId?: string;
 }
 
 enum Status {
@@ -29,17 +31,28 @@ enum Status {
   BLOCKED = 'BLOCKED',
   DELETED = 'DELETED',
 }
+
+enum Role {
+  USER = 'USER',
+  SUPERADMIN = 'SUPERADMIN',
+  ADMIN = 'ADMIN',
+}
 interface IEventAttendees {
   userId: string;
-  user: string;
-  status: Status;
-  createdAT: Date;
+  user?: string;
+  status?: Status;
+  createdAt?: Date;
 }
 
 interface IOrgList {
   admins: { _id: string }[];
 }
-const Calendar: React.FC<CalendarProps> = ({ eventData, orgData }) => {
+const Calendar: React.FC<CalendarProps> = ({
+  eventData,
+  orgData,
+  userRole,
+  userId,
+}) => {
   const [selectedDate] = useState<Date | null>(null);
   const weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
   const months = [
@@ -60,6 +73,47 @@ const Calendar: React.FC<CalendarProps> = ({ eventData, orgData }) => {
   const today = new Date();
   const [currentMonth, setCurrentMonth] = useState(today.getMonth());
   const [currentYear, setCurrentYear] = useState(today.getFullYear());
+  const [events, setEvents] = useState<Event[] | null>(null);
+
+  const filterData = (
+    eventData: Event[],
+    orgData?: IOrgList,
+    userRole?: string,
+    userId?: string
+  ) => {
+    const data: Event[] = [];
+    if (userRole === Role.SUPERADMIN) return eventData;
+    if (userRole === Role.ADMIN) {
+      eventData?.forEach((event) => {
+        if (event.isPublic) data.push(event);
+        if (!event.isPublic) {
+          const filteredOrg: boolean | undefined = orgData?.admins?.some(
+            (data) => data._id === userId
+          );
+
+          if (filteredOrg) {
+            data.push(event);
+          }
+        }
+      });
+    } else {
+      eventData?.forEach((event) => {
+        if (event.isPublic) data.push(event);
+        const userAttending = event.registrants?.some(
+          (data) => data.userId === userId
+        );
+        if (userAttending) {
+          data.push(event);
+        }
+      });
+    }
+    return data;
+  };
+
+  useEffect(() => {
+    const data = filterData(eventData, orgData, userRole, userId);
+    setEvents(data);
+  }, []);
 
   const handlePrevMonth = () => {
     if (currentMonth === 0) {
@@ -125,58 +179,30 @@ const Calendar: React.FC<CalendarProps> = ({ eventData, orgData }) => {
         >
           {date.getDate()}
           <div className={styles.list_box}>
-            {eventData &&
-              eventData
-                .filter((datas) => {
-                  if (datas.startDate == dayjs(date).format('YYYY-MM-DD'))
-                    return datas;
-                })
-                .filter((datas: Event) => {
-                  const userId: string | null = localStorage.getItem('id');
-                  const userRole: string | null =
-                    localStorage.getItem('UserType');
-                  const data: Event[] = [];
-                  if (userRole === 'SUPERADMIN') return datas;
-                  if (datas.isPublic) data.push(datas);
-                  if (!datas.isPublic) {
-                    if (userRole === 'ADMIN') {
-                      const filteredOrg: boolean | undefined =
-                        orgData &&
-                        orgData.admins?.some(
-                          (data: { _id: string }) =>
-                            userId && data._id === JSON.parse(userId)
-                        );
-                      if (filteredOrg) data.push(datas);
-                    } else {
-                      const userAttending = datas.registrants?.some(
-                        (data) => userId && data.userId === JSON.parse(userId)
-                      );
-                      if (userAttending) {
-                        data.push(datas);
-                      }
-                    }
-                  }
-                  return data;
-                })
-                .map((datas: Event) => {
-                  return (
-                    <EventListCard
-                      key={datas._id}
-                      id={datas._id}
-                      eventLocation={datas.location}
-                      eventName={datas.title}
-                      eventDescription={datas.description}
-                      regDate={datas.startDate}
-                      regEndDate={datas.endDate}
-                      startTime={datas.startTime}
-                      endTime={datas.endTime}
-                      allDay={datas.allDay}
-                      recurring={datas.recurring}
-                      isPublic={datas.isPublic}
-                      isRegisterable={datas.isRegisterable}
-                    />
-                  );
-                })}
+            {events
+              ?.filter((datas) => {
+                if (datas.startDate == dayjs(date).format('YYYY-MM-DD'))
+                  return datas;
+              })
+              .map((datas: Event) => {
+                return (
+                  <EventListCard
+                    key={datas._id}
+                    id={datas._id}
+                    eventLocation={datas.location}
+                    eventName={datas.title}
+                    eventDescription={datas.description}
+                    regDate={datas.startDate}
+                    regEndDate={datas.endDate}
+                    startTime={datas.startTime}
+                    endTime={datas.endTime}
+                    allDay={datas.allDay}
+                    recurring={datas.recurring}
+                    isPublic={datas.isPublic}
+                    isRegisterable={datas.isRegisterable}
+                  />
+                );
+              })}
           </div>
         </div>
       );

--- a/src/screens/OrganizationEvents/OrganizationEvents.tsx
+++ b/src/screens/OrganizationEvents/OrganizationEvents.tsx
@@ -75,6 +75,9 @@ function OrganizationEvents(): JSX.Element {
     variables: { id: currentUrl },
   });
 
+  const userId = localStorage.getItem('id') as string;
+  const userRole = localStorage.getItem('UserType') as string;
+
   const [create, { loading: loading_2 }] = useMutation(CREATE_EVENT_MUTATION);
 
   const CreateEvent = async (e: ChangeEvent<HTMLFormElement>) => {
@@ -225,6 +228,8 @@ function OrganizationEvents(): JSX.Element {
           <Calendar
             eventData={data?.eventsByOrganizationConnection}
             orgData={orgData}
+            userRole={userRole}
+            userId={userId}
           />
         </Col>
       </Row>

--- a/src/screens/OrganizationEvents/OrganizationEvents.tsx
+++ b/src/screens/OrganizationEvents/OrganizationEvents.tsx
@@ -13,7 +13,10 @@ import Calendar from 'components/EventCalendar/Calendar';
 
 import styles from './OrganizationEvents.module.css';
 import AdminNavbar from 'components/AdminNavbar/AdminNavbar';
-import { ORGANIZATION_EVENT_CONNECTION_LIST } from 'GraphQl/Queries/Queries';
+import {
+  ORGANIZATION_EVENT_CONNECTION_LIST,
+  ORGANIZATIONS_LIST,
+} from 'GraphQl/Queries/Queries';
 import { CREATE_EVENT_MUTATION } from 'GraphQl/Mutations/mutations';
 import { RootState } from 'state/reducers';
 import debounce from 'utils/debounce';
@@ -67,6 +70,10 @@ function OrganizationEvents(): JSX.Element {
       },
     }
   );
+
+  const { data: orgData } = useQuery(ORGANIZATIONS_LIST, {
+    variables: { id: currentUrl },
+  });
 
   const [create, { loading: loading_2 }] = useMutation(CREATE_EVENT_MUTATION);
 
@@ -215,7 +222,10 @@ function OrganizationEvents(): JSX.Element {
               </Button>
             </Row>
           </div>
-          <Calendar eventData={data?.eventsByOrganizationConnection} />
+          <Calendar
+            eventData={data?.eventsByOrganizationConnection}
+            orgData={orgData}
+          />
         </Col>
       </Row>
       <Modal


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR Fixes:
- The ability to make events private where only participants can see who is attending
- The optional ability to make private events invisible to persons not attending

**Issue Number:**
Fixes #795 

**Did you add tests for your changes?**
Yes

**Snapshots/Videos:**
N/A

**If relevant, did you update the documentation?**
N/A

**Summary**
The participants in all events are publicly visible to everyone. There need to be options for more privacy.

**Does this PR introduce a breaking change?**
No


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes
