### PR TITLE
Organization Form Redirect Issue Prevents User Navigation, Affecting User Experience.  Issue #808

### DIFF
--- a/src/assets/images/close.svg
+++ b/src/assets/images/close.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>

--- a/src/assets/images/close.svg
+++ b/src/assets/images/close.svg
@@ -1,1 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="feather feather-x"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -322,13 +322,12 @@ function OrgList(): JSX.Element {
                 className={styles.cancel}
                 data-testid="closeOrganizationModal"
               >
-                <img
-                  src={close}
-                  alt="closing"
+                <i
+                  className="fa fa-times"
                   style={{
                     cursor: 'pointer',
                   }}
-                />
+                ></i>
               </a>
             </div>
             <Form onSubmitCapture={CreateOrg}>

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -23,8 +23,6 @@ import convertToBase64 from 'utils/convertToBase64';
 import AdminDashListCard from 'components/AdminDashListCard/AdminDashListCard';
 import PostNotFound from 'components/PostNotFound/PostNotFound';
 
-import close from 'assets/images/close.svg';
-
 function OrgList(): JSX.Element {
   const { t } = useTranslation('translation', { keyPrefix: 'orgList' });
 

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -23,6 +23,8 @@ import convertToBase64 from 'utils/convertToBase64';
 import AdminDashListCard from 'components/AdminDashListCard/AdminDashListCard';
 import PostNotFound from 'components/PostNotFound/PostNotFound';
 
+import close from 'assets/images/close.svg';
+
 function OrgList(): JSX.Element {
   const { t } = useTranslation('translation', { keyPrefix: 'orgList' });
 
@@ -304,6 +306,7 @@ function OrgList(): JSX.Element {
       </Row>
       <Modal
         isOpen={modalisOpen}
+        onRequestClose={() => setmodalIsOpen(false)}
         style={{
           overlay: { backgroundColor: 'grey' },
         }}
@@ -319,7 +322,13 @@ function OrgList(): JSX.Element {
                 className={styles.cancel}
                 data-testid="closeOrganizationModal"
               >
-                <i className="fa fa-times"></i>
+                <img
+                  src={close}
+                  alt="closing"
+                  style={{
+                    cursor: 'pointer',
+                  }}
+                />
               </a>
             </div>
             <Form onSubmitCapture={CreateOrg}>


### PR DESCRIPTION
**Description**

**This PR addresses issue #808 , which reported a bug where the organization creation form is displayed on the same URL as the organization list page when the "Create Organization" button is clicked, making it difficult for users to navigate back to the organization list page or leave the form with any routing from the page.**

**Approach**

**To solve this issue, I added a "Close" button to the organization creation modal, allowing users to easily close the modal and return to the organization list page. Additionally, I implemented a way to close the modal when the user clicks on the overlay, which is a common pattern in modal-based UIs.**

Fixes #808

<br />

![image](https://user-images.githubusercontent.com/108873224/228066304-ebc400ba-f475-469e-9e2b-0d1a293e9ce8.png)

<br />

**Changes Made**

- **Added a closing icon SVG in './src/assets/images/close'.**
- **Added that Closing button to the organization creation modal, which allows users to easily close the modal and return to the organization list page**
- **Implemented a way to close the modal when the user clicks on the overlay, which is a common pattern in modal-based UIs**

<br />

**Testing**

![image](https://user-images.githubusercontent.com/108873224/228065026-8e5b9f90-dbe8-4b30-8d3d-cfab6fbd1ef6.png)
