### PR TITLE
Redirect to dashboard on organization update

### DIFF
--- a/src/components/OrgUpdate/OrgUpdate.tsx
+++ b/src/components/OrgUpdate/OrgUpdate.tsx
@@ -60,10 +60,9 @@ function OrgUpdate(props: OrgUpdateProps): JSX.Element {
       });
       /* istanbul ignore next */
       if (data) {
+        window.location.assign(`/orgdash/id=${props.orgid}`);
+
         toast.success('Successful updated');
-        setTimeout(() => {
-          window.location.reload();
-        }, 2000);
       }
     } catch (error: any) {
       /* istanbul ignore next */

--- a/src/components/OrgUpdate/OrgUpdate.tsx
+++ b/src/components/OrgUpdate/OrgUpdate.tsx
@@ -62,7 +62,7 @@ function OrgUpdate(props: OrgUpdateProps): JSX.Element {
       if (data) {
         window.location.assign(`/orgdash/id=${props.orgid}`);
 
-        toast.success('Successful updated');
+        toast.success('Successfully updated');
       }
     } catch (error: any) {
       /* istanbul ignore next */


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix 

**Issue Number:**

Fixes #594 

**Did you add tests for your changes?**

Not needed

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

Not Relevant

**Summary**

- The `OrgUpdate` page just refreshed when the user updated an organization
- The expected behavior is that the user should be redirected to the `OrgDashboard` page
- So that they can view their updates

**Does this PR introduce a breaking change?**

No

**Other information**

NA

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes