### PR TITLE
Added Whitespace Validation to Organization and Post create forms

### DIFF
--- a/src/screens/OrgList/OrgList.test.tsx
+++ b/src/screens/OrgList/OrgList.test.tsx
@@ -17,6 +17,7 @@ import { I18nextProvider } from 'react-i18next';
 import { StaticMockLink } from 'utils/StaticMockLink';
 import SuperDashListCard from 'components/SuperDashListCard/SuperDashListCard';
 import AdminDashListCard from 'components/AdminDashListCard/AdminDashListCard';
+import { ToastContainer } from 'react-toastify';
 
 type Organization = {
   _id: string;
@@ -166,6 +167,13 @@ describe('Organisation List Page', () => {
     name: 'Dummy Organization',
     description: 'This is a dummy organization',
     location: 'Delhi, India',
+    image: new File(['hello'], 'hello.png', { type: 'image/png' }),
+  };
+
+  const formDataEmpty = {
+    name: '   ',
+    description: '   ',
+    location: '   ',
     image: new File(['hello'], 'hello.png', { type: 'image/png' }),
   };
 
@@ -415,6 +423,61 @@ describe('Organisation List Page', () => {
     expect(screen.getByLabelText(/Display Image:/i)).toBeTruthy();
 
     userEvent.click(screen.getByTestId(/submitOrganizationForm/i));
+  });
+
+  test('Create organization should throw error when empty strings have been entered', async () => {
+    localStorage.setItem('UserType', 'SUPERADMIN');
+
+    const { container } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <ToastContainer />
+            <OrgList />
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+
+    expect(localStorage.setItem).toHaveBeenLastCalledWith(
+      'UserType',
+      'SUPERADMIN'
+    );
+
+    userEvent.click(screen.getByTestId(/createOrganizationBtn/i));
+
+    userEvent.type(
+      screen.getByTestId(/modalOrganizationName/i),
+      formDataEmpty.name
+    );
+    userEvent.type(
+      screen.getByPlaceholderText(/Description/i),
+      formDataEmpty.description
+    );
+    userEvent.type(
+      screen.getByPlaceholderText(/Location/i),
+      formDataEmpty.location
+    );
+
+    expect(screen.getByTestId(/modalOrganizationName/i)).toHaveValue(
+      formDataEmpty.name
+    );
+    expect(screen.getByPlaceholderText(/Description/i)).toHaveValue(
+      formDataEmpty.description
+    );
+    expect(screen.getByPlaceholderText(/Location/i)).toHaveValue(
+      formDataEmpty.location
+    );
+
+    userEvent.click(screen.getByTestId(/submitOrganizationForm/i));
+
+    await wait();
+
+    expect(container.textContent).toMatch(
+      'Text fields cannot be empty strings'
+    );
   });
 });
 

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -92,9 +92,24 @@ function OrgList(): JSX.Element {
   const CreateOrg = async (e: ChangeEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    const { name, descrip, location, visible, ispublic, image } = formState;
+    const {
+      name: _name,
+      descrip: _descrip,
+      location: _location,
+      visible,
+      ispublic,
+      image,
+    } = formState;
+
+    const name = _name.trim();
+    const descrip = _descrip.trim();
+    const location = _location.trim();
 
     try {
+      if (!name || !descrip || !location) {
+        throw new Error('Text fields cannot be empty strings');
+      }
+
       const { data } = await create({
         variables: {
           name: name,

--- a/src/screens/OrgPost/OrgPost.test.tsx
+++ b/src/screens/OrgPost/OrgPost.test.tsx
@@ -13,6 +13,7 @@ import { ORGANIZATION_POST_CONNECTION_LIST } from 'GraphQl/Queries/Queries';
 import { CREATE_POST_MUTATION } from 'GraphQl/Mutations/mutations';
 import i18nForTest from 'utils/i18nForTest';
 import { StaticMockLink } from 'utils/StaticMockLink';
+import { ToastContainer } from 'react-toastify';
 
 const MOCKS = [
   {
@@ -112,6 +113,12 @@ describe('Organisation Post Page', () => {
     postImage: new File(['hello'], 'hello.png', { type: 'image/png' }),
   };
 
+  const formDataEmpty = {
+    posttitle: '   ',
+    postinfo: '   ',
+    postImage: new File(['hello'], 'hello.png', { type: 'image/png' }),
+  };
+
   test('correct mock data should be queried', async () => {
     const dataQuery1 =
       MOCKS[0]?.result?.data?.postsByOrganizationConnection.edges[0];
@@ -207,6 +214,48 @@ describe('Organisation Post Page', () => {
     await wait();
 
     userEvent.click(screen.getByTestId('closePostModalBtn'));
+  }, 15000);
+
+  test('Create Post should throw error when empty strings have been entered', async () => {
+    const { container } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <ToastContainer />
+              <OrgPost />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+
+    userEvent.click(screen.getByTestId('createPostModalBtn'));
+
+    userEvent.type(
+      screen.getByPlaceholderText(/Post Title/i),
+      formDataEmpty.posttitle
+    );
+
+    userEvent.type(
+      screen.getByPlaceholderText(/What do you to talk about?/i),
+      formDataEmpty.postinfo
+    );
+
+    userEvent.upload(
+      screen.getByLabelText(/Post Image:/i),
+      formDataEmpty.postImage
+    );
+
+    userEvent.click(screen.getByTestId('createPostBtn'));
+
+    await wait();
+
+    expect(container.textContent).toMatch(
+      'Text fields cannot be empty strings'
+    );
   }, 15000);
 
   test('Testing search functionality', async () => {

--- a/src/screens/OrgPost/OrgPost.tsx
+++ b/src/screens/OrgPost/OrgPost.tsx
@@ -64,13 +64,27 @@ function OrgPost(): JSX.Element {
 
   const CreatePost = async (e: ChangeEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    const {
+      posttitle: _posttitle,
+      postinfo: _postinfo,
+      postImage,
+    } = postformState;
+
+    const posttitle = _posttitle.trim();
+    const postinfo = _postinfo.trim();
+
     try {
+      if (!posttitle || !postinfo) {
+        throw new Error('Text fields cannot be empty strings');
+      }
+
       const { data } = await create({
         variables: {
-          title: postformState.posttitle,
-          text: postformState.postinfo,
+          title: posttitle,
+          text: postinfo,
           organizationId: currentUrl,
-          file: postformState.postImage,
+          file: postImage,
         },
       });
       /* istanbul ignore next */


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**

Fixes #834 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

Create Org -

<img width="1904" alt="Screenshot 2023-04-02 at 1 53 55 PM" src="https://user-images.githubusercontent.com/28570857/229341256-27eb2a14-b4d5-422c-915b-edb0fe1ffa0c.png">

Create Post -

<img width="1904" alt="Screenshot 2023-04-02 at 1 54 36 PM" src="https://user-images.githubusercontent.com/28570857/229341312-ef9c1280-c82c-47a0-8e77-b60d34297239.png">


**If relevant, did you update the documentation?**

Not Relevant

**Summary**

- The Organization and Post create forms had compulsory text fields
- But the user could simply add empty strings (`"    "`)  and bypass the `required` validation
- I've fixed this issue by giving an error message on submit


**Does this PR introduce a breaking change?**

No

**Other information**

NA

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes