### PR TITLE
Prevent Admins and Super Admins from downgrading their own roles

### DIFF
--- a/src/screens/Roles/Roles.test.tsx
+++ b/src/screens/Roles/Roles.test.tsx
@@ -475,4 +475,44 @@ describe('Testing Roles screen', () => {
       true
     );
   });
+
+  test('Should not disable select when user is not self', async () => {
+    const localStorageMock = (function () {
+      const store: any = {
+        UserType: 'SUPERADMIN',
+        id: '123',
+      };
+
+      return {
+        getItem: jest.fn((key: string) => store[key]),
+      };
+    })();
+
+    Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <ToastContainer />
+              <Roles />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+
+    expect(screen.getByTestId('changeRole456')).toHaveProperty(
+      'disabled',
+      false
+    );
+
+    expect(screen.getByTestId('changeRole789')).toHaveProperty(
+      'disabled',
+      false
+    );
+  });
 });

--- a/src/screens/Roles/Roles.test.tsx
+++ b/src/screens/Roles/Roles.test.tsx
@@ -125,6 +125,7 @@ const MOCKS = [
     },
   },
 ];
+
 const EMPTY_MOCKS = [
   {
     request: {
@@ -156,6 +157,7 @@ const EMPTY_MOCKS = [
     },
   },
 ];
+
 const link = new StaticMockLink(MOCKS, true);
 const link2 = new StaticMockLink(EMPTY_MOCKS, true);
 
@@ -436,6 +438,41 @@ describe('Testing Roles screen', () => {
 
     expect(container.textContent).not.toMatch(
       'Organizations not found, please create an organization through dashboard'
+    );
+  });
+
+  test('Should disable select when user is self', async () => {
+    const localStorageMock = (function () {
+      const store: any = {
+        UserType: 'SUPERADMIN',
+        id: '123',
+      };
+
+      return {
+        getItem: jest.fn((key: string) => store[key]),
+      };
+    })();
+
+    Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <ToastContainer />
+              <Roles />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+
+    expect(screen.getByTestId('changeRole123')).toHaveProperty(
+      'disabled',
+      true
     );
   });
 });

--- a/src/screens/Roles/Roles.tsx
+++ b/src/screens/Roles/Roles.tsx
@@ -188,23 +188,15 @@ const Roles = () => {
                                   data-testid={`changeRole${user._id}`}
                                   onChange={changeRole}
                                   disabled={user._id === userId}
+                                  defaultValue={`${user.userType}?${user._id}`}
                                 >
-                                  <option
-                                    value={`ADMIN?${user._id}`}
-                                    selected={user.userType === 'ADMIN'}
-                                  >
+                                  <option value={`ADMIN?${user._id}`}>
                                     {t('admin')}
                                   </option>
-                                  <option
-                                    value={`SUPERADMIN?${user._id}`}
-                                    selected={user.userType === 'SUPERADMIN'}
-                                  >
+                                  <option value={`SUPERADMIN?${user._id}`}>
                                     {t('superAdmin')}
                                   </option>
-                                  <option
-                                    value={`USER?${user._id}`}
-                                    selected={user.userType === 'USER'}
-                                  >
+                                  <option value={`USER?${user._id}`}>
                                     {t('user')}
                                   </option>
                                 </select>

--- a/src/screens/Roles/Roles.tsx
+++ b/src/screens/Roles/Roles.tsx
@@ -180,62 +180,31 @@ const Roles = () => {
                               <td>{`${user.firstName} ${user.lastName}`}</td>
                               <td>{user.email}</td>
                               <td>
-                                {user.userType === 'ADMIN' ? (
-                                  <select
-                                    className="form-control"
-                                    name={`role${user._id}`}
-                                    onChange={changeRole}
+                                <select
+                                  className="form-control"
+                                  name={`role${user._id}`}
+                                  data-testid={`changeRole${user._id}`}
+                                  onChange={changeRole}
+                                >
+                                  <option
+                                    value={`ADMIN?${user._id}`}
+                                    selected={user.userType === 'ADMIN'}
                                   >
-                                    <option
-                                      value={`ADMIN?${user._id}`}
-                                      selected
-                                    >
-                                      {t('admin')}
-                                    </option>
-                                    <option value={`SUPERADMIN?${user._id}`}>
-                                      {t('superAdmin')}
-                                    </option>
-                                    <option value={`USER?${user._id}`}>
-                                      {t('user')}
-                                    </option>
-                                  </select>
-                                ) : user.userType === 'SUPERADMIN' ? (
-                                  <select
-                                    className="form-control"
-                                    name={`role${user._id}`}
-                                    data-testid={`changeRole${user._id}`}
-                                    onChange={changeRole}
+                                    {t('admin')}
+                                  </option>
+                                  <option
+                                    value={`SUPERADMIN?${user._id}`}
+                                    selected={user.userType === 'SUPERADMIN'}
                                   >
-                                    <option value={`ADMIN?${user._id}`}>
-                                      {t('admin')}
-                                    </option>
-                                    <option
-                                      value={`SUPERADMIN?${user._id}`}
-                                      selected
-                                    >
-                                      {t('superAdmin')}
-                                    </option>
-                                    <option value={`USER?${user._id}`}>
-                                      {t('user')}
-                                    </option>
-                                  </select>
-                                ) : (
-                                  <select
-                                    className="form-control"
-                                    name={`role${user._id}`}
-                                    onChange={changeRole}
+                                    {t('superAdmin')}
+                                  </option>
+                                  <option
+                                    value={`USER?${user._id}`}
+                                    selected={user.userType === 'USER'}
                                   >
-                                    <option value={`ADMIN?${user._id}`}>
-                                      {t('admin')}
-                                    </option>
-                                    <option value={`SUPERADMIN?${user._id}`}>
-                                      {t('superAdmin')}
-                                    </option>
-                                    <option value={`USER?${user._id}`} selected>
-                                      {t('user')}
-                                    </option>
-                                  </select>
-                                )}
+                                    {t('user')}
+                                  </option>
+                                </select>
                               </td>
                             </tr>
                           );

--- a/src/screens/Roles/Roles.tsx
+++ b/src/screens/Roles/Roles.tsx
@@ -24,8 +24,10 @@ const Roles = () => {
   const [searchByName, setSearchByName] = useState('');
   const [count, setCount] = useState(0);
 
+  const userType = localStorage.getItem('UserType');
+  const userId = localStorage.getItem('id');
+
   useEffect(() => {
-    const userType = localStorage.getItem('UserType');
     if (userType != 'SUPERADMIN') {
       window.location.assign('/orglist');
     }
@@ -185,6 +187,7 @@ const Roles = () => {
                                   name={`role${user._id}`}
                                   data-testid={`changeRole${user._id}`}
                                   onChange={changeRole}
+                                  disabled={user._id === userId}
                                 >
                                   <option
                                     value={`ADMIN?${user._id}`}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix
**Issue Number:**

Fixes #764 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<img width="1904" alt="Screenshot 2023-04-04 at 2 21 13 AM" src="https://user-images.githubusercontent.com/28570857/229625106-7a6598a5-d8ef-460b-9283-faa540417c87.png">


**If relevant, did you update the documentation?**

Not Relevant

**Summary**

- There is a feature that allows `SUPERADMINS` and `ADMINS` to downgrade their roles
- This can be dangerous as they could get locked out of the system 
- If they are the only users with that high level of access
- Thus, I've disabled the users changing their own roles
- This ensures they don't get locked out of the system

**Does this PR introduce a breaking change?**

No

**Other information**

NA

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes