### PR TITLE
Fix Password validation on the Login/Signup Page [Fixes #720]

### DIFF
--- a/src/screens/LoginPage/LoginPage.test.tsx
+++ b/src/screens/LoginPage/LoginPage.test.tsx
@@ -24,7 +24,7 @@ const MOCKS = [
       query: LOGIN_MUTATION,
       variables: {
         email: 'johndoe@gmail.com',
-        password: 'johndoe',
+        password: 'Johndoe@1',
       },
     },
     result: {
@@ -48,7 +48,7 @@ const MOCKS = [
         firstName: 'John',
         lastName: 'Doe',
         email: 'johndoe@gmail.com',
-        password: 'johnDoe',
+        password: 'Johndoe@1',
       },
     },
     result: {
@@ -176,8 +176,8 @@ describe('Testing Login Page Screen', () => {
       firstName: 'John',
       lastName: 'Doe',
       email: 'johndoe@gmail.com',
-      password: 'johndoe',
-      confirmPassword: 'johndoe',
+      password: 'Johndoe@1',
+      confirmPassword: 'Johndoe@1',
     };
 
     render(
@@ -258,8 +258,8 @@ describe('Testing Login Page Screen', () => {
       firstName: 'J',
       lastName: 'D',
       email: 'johndoe@gmail.com',
-      password: 'joe',
-      confirmPassword: 'joe',
+      password: 'Johndoe@2',
+      confirmPassword: 'Johndoe@2',
     };
 
     render(
@@ -319,7 +319,7 @@ describe('Testing Login Page Screen', () => {
   test('Testing login functionality', async () => {
     const formData = {
       email: 'johndoe@gmail.com',
-      password: 'johndoe',
+      password: 'Johndoe@1',
     };
 
     render(

--- a/src/screens/LoginPage/LoginPage.tsx
+++ b/src/screens/LoginPage/LoginPage.tsx
@@ -136,7 +136,10 @@ function LoginPage(): JSX.Element {
       signfirstName.length > 1 &&
       signlastName.length > 1 &&
       signEmail.length >= 8 &&
-      signPassword.length > 1
+      signPassword.length >= 8 &&
+      (/[A-Z]/.test(signPassword)) &&
+      (/[0-9]/.test(signPassword)) &&
+      (/[^A-Za-z0-9]/.test(signPassword))
     ) {
       if (cPassword == signPassword) {
         try {


### PR DESCRIPTION

**What kind of change does this PR introduce?** 
It is a bug fix; the password validation during the signup only constrain the password on being non-empty but now it will ensure that it is at least 8 characters long and has at least one capital letter, one number and one special character.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
#720 

Fixes #720 <!--Add related issue number here.-->

**Did you add tests for your changes?**
Yes
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->


