### PR TITLE
Organization People Filters Improved

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -144,7 +144,9 @@
     "admins": "Admins",
     "users": "Users",
     "searchName": "Enter Name",
-    "searchevent": "Enter Event"
+    "searchevent": "Enter Event",
+    "searchFirstName": "Enter First Name",
+    "searchLastName": "Enter Last Name"
   },
   "userListCard": {
     "joined": "Joined",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -140,7 +140,9 @@
     "admins": "Administrateurs",
     "users": "Utilisateurs",
     "searchName": "Entrez le nom",
-    "searchevent": "Entrez l'événement"
+    "searchevent": "Entrez l'événement",
+    "searchFirstName": "Entrez votre prénom",
+    "searchLastName": "Entrer le nom de famille"
   },
   "userListCard": {
     "joined": "Inscrit",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -140,7 +140,9 @@
     "admins": "व्यवस्थापक",
     "users": "उपयोगकर्ता",
     "searchName": "नाम दर्ज करें",
-    "searchevent": "घटना दर्ज करें"
+    "searchevent": "घटना दर्ज करें",
+    "searchFirstName": "प्रथम नाम दर्ज करें",
+    "searchLastName": "अंतिम नाम दर्ज करो"
   },
   "userListCard": {
     "joined": "में शामिल हो गए",

--- a/public/locales/sp.json
+++ b/public/locales/sp.json
@@ -140,7 +140,9 @@
     "admins": "Administradores",
     "users": "Usuarios",
     "searchName": "Ingrese su nombre",
-    "searchevent": "Ingresar evento"
+    "searchevent": "Ingresar evento",
+    "searchFirstName": "Ingrese el nombre",
+    "searchLastName": "Introduzca el apellido"
   },
   "userListCard": {
     "joined": "Unido",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -140,7 +140,9 @@
     "admins": "管理員",
     "users": "用戶",
     "searchName": "輸入名字",
-    "searchevent": "輸入事件"
+    "searchevent": "輸入事件",
+    "searchFirstName": "输入名字",
+    "searchLastName": "输入姓氏"
   },
   "userListCard": {
     "joined": "加入",

--- a/src/GraphQl/Queries/Queries.ts
+++ b/src/GraphQl/Queries/Queries.ts
@@ -66,8 +66,13 @@ export const ORGANIZATION_CONNECTION_LIST = gql`
 // Query to take the User list
 
 export const USER_LIST = gql`
-  query Users($filter: String) {
-    users(where: { firstName_contains: $filter }) {
+  query Users($firstName_contains: String, $lastName_contains: String) {
+    users(
+      where: {
+        firstName_contains: $firstName_contains
+        lastName_contains: $lastName_contains
+      }
+    ) {
       firstName
       lastName
       image
@@ -152,6 +157,7 @@ export const ORGANIZATIONS_MEMBER_CONNECTION_LIST = gql`
   query Organizations(
     $orgId: ID!
     $firstName_contains: String
+    $lastName_contains: String
     $admin_for: ID
     $event_title_contains: String
   ) {
@@ -159,6 +165,7 @@ export const ORGANIZATIONS_MEMBER_CONNECTION_LIST = gql`
       orgId: $orgId
       where: {
         firstName_contains: $firstName_contains
+        lastName_contains: $lastName_contains
         admin_for: $admin_for
         event_title_contains: $event_title_contains
       }

--- a/src/screens/OrganizationPeople/OrganizationPeople.test.tsx
+++ b/src/screens/OrganizationPeople/OrganizationPeople.test.tsx
@@ -254,6 +254,59 @@ const MOCKS = [
       },
     },
   },
+
+  {
+    request: {
+      query: ORGANIZATIONS_LIST,
+      variables: {
+        id: 'orgid',
+      },
+    },
+    result: {
+      data: {
+        organizations: [
+          {
+            _id: 'orgid',
+            image: '',
+            creator: {
+              firstName: 'firstName',
+              lastName: 'lastName',
+              email: 'email',
+            },
+            name: 'name',
+            description: 'description',
+            location: 'location',
+            members: {
+              _id: 'id',
+              firstName: 'firstName',
+              lastName: 'lastName',
+              email: 'email',
+            },
+            admins: {
+              _id: 'id',
+              firstName: 'firstName',
+              lastName: 'lastName',
+              email: 'email',
+            },
+            membershipRequests: {
+              _id: 'id',
+              user: {
+                firstName: 'firstName',
+                lastName: 'lastName',
+                email: 'email',
+              },
+            },
+            blockedUsers: {
+              _id: 'id',
+              firstName: 'firstName',
+              lastName: 'lastName',
+              email: 'email',
+            },
+          },
+        ],
+      },
+    },
+  },
 ];
 
 const link = new StaticMockLink(MOCKS, true);
@@ -568,6 +621,7 @@ describe('Organisation People Page', () => {
 
   test('Testing ADMIN LIST', async () => {
     window.location.assign('/orgpeople/id=orgid');
+
     render(
       <MockedProvider
         addTypename={true}

--- a/src/screens/OrganizationPeople/OrganizationPeople.test.tsx
+++ b/src/screens/OrganizationPeople/OrganizationPeople.test.tsx
@@ -20,6 +20,7 @@ import { StaticMockLink } from 'utils/StaticMockLink';
 const members: any[] = [];
 const admins: any[] = [];
 const users: any[] = [];
+
 for (let i = 0; i < 100; i++) {
   members.push({
     __typename: 'User',
@@ -108,6 +109,7 @@ const MOCKS = [
       },
     },
   },
+
   {
     //These are mocks for 1st query (member list)
     request: {
@@ -115,7 +117,7 @@ const MOCKS = [
       variables: {
         orgId: undefined,
         firstName_contains: '',
-        event_title_contains: '',
+        lastName_contains: '',
       },
     },
     result: {
@@ -164,9 +166,10 @@ const MOCKS = [
     request: {
       query: ORGANIZATIONS_MEMBER_CONNECTION_LIST,
       variables: {
-        orgId: undefined,
+        orgId: 'orgid',
         firstName_contains: '',
-        admin_for: undefined,
+        lastName_contains: '',
+        admin_for: 'orgid',
       },
     },
     result: {
@@ -201,6 +204,7 @@ const MOCKS = [
               image: null,
               email: 'admin@gmail.com',
               createdAt: '2023-03-02T03:22:08.101Z',
+              lol: true,
             },
             ...admins,
           ],
@@ -213,6 +217,10 @@ const MOCKS = [
     //This is mock for user list
     request: {
       query: USER_LIST,
+      variables: {
+        firstName_contains: '',
+        lastName_contains: '',
+      },
     },
     result: {
       data: {
@@ -247,6 +255,7 @@ const MOCKS = [
     },
   },
 ];
+
 const link = new StaticMockLink(MOCKS, true);
 async function wait(ms = 2) {
   await act(() => {
@@ -295,6 +304,7 @@ describe('Organisation People Page', () => {
     await screen.findByTestId('rowsPPSelect');
 
     // Get the reference to all userTypes through the radio buttons in the DOM
+    // => users, members, admins
     const allPeopleTypes = Array.from(
       screen.getByTestId('usertypelist').querySelectorAll('input[type="radio"]')
     ).map((radioButton: HTMLInputElement | any) => radioButton.dataset?.testid);
@@ -316,13 +326,14 @@ describe('Organisation People Page', () => {
       }
 
       // Get all possible dropdown options
+      // => -1, 5, 10, 30
       const rowsPerPageOptions: any[] = Array.from(
         rowsPerPageSelect?.querySelectorAll('option')
       );
 
       const peopleListContainer = screen.getByTestId('orgpeoplelist');
 
-      //Change the selected option of dropdown to the value of the current option
+      // Change the selected option of dropdown to the value of the current option
       userEvent.selectOptions(
         rowsPerPageSelect,
         rowsPerPageOptions[currRowPPindex].textContent
@@ -478,22 +489,28 @@ describe('Organisation People Page', () => {
       </MockedProvider>
     );
     await wait();
+
     userEvent.click(screen.getByLabelText(/Members/i));
     await wait();
     expect(screen.getByLabelText(/Members/i)).toBeChecked();
     await wait();
+
     const findtext = screen.getByText(/Aditya Memberguy/i);
     await wait();
     expect(findtext).toBeInTheDocument();
-    userEvent.type(screen.getByPlaceholderText(/Enter Name/i), searchData.name);
+
+    userEvent.type(
+      screen.getByPlaceholderText(/Enter First Name/i),
+      searchData.name
+    );
     await wait();
-    expect(screen.getByPlaceholderText(/Enter Name/i)).toHaveValue(
+    expect(screen.getByPlaceholderText(/Enter First Name/i)).toHaveValue(
       searchData.name
     );
   });
 
   test('Testing ADMIN LIST', async () => {
-    window.location.assign('/orgpeople/id=6401ff65ce8e8406b8f07af1');
+    window.location.assign('/orgpeople/id=orgid');
     render(
       <MockedProvider
         addTypename={true}
@@ -512,24 +529,29 @@ describe('Organisation People Page', () => {
         </BrowserRouter>
       </MockedProvider>
     );
+
     await wait();
+
     userEvent.click(screen.getByLabelText(/Admins/i));
     await wait();
     expect(screen.getByLabelText(/Admins/i)).toBeChecked();
     await wait();
+
     const findtext = screen.getByText('Aditya Adminguy');
     expect(findtext).toBeInTheDocument();
 
-    userEvent.type(screen.getByPlaceholderText(/Enter Name/i), searchData.name);
+    userEvent.type(
+      screen.getByPlaceholderText(/Enter First Name/i),
+      searchData.name
+    );
     await wait();
-    expect(screen.getByPlaceholderText(/Enter Name/i)).toHaveValue(
+    expect(screen.getByPlaceholderText(/Enter First Name/i)).toHaveValue(
       searchData.name
     );
     await wait();
   });
 
   test('Testing USERS list', async () => {
-    window.location.assign('/orgpeople/id=6401ff65ce8e8406b8f07af1');
     render(
       <MockedProvider
         addTypename={true}

--- a/src/screens/OrganizationPeople/OrganizationPeople.test.tsx
+++ b/src/screens/OrganizationPeople/OrganizationPeople.test.tsx
@@ -56,7 +56,155 @@ for (let i = 0; i < 100; i++) {
   });
 }
 
-const MOCKS = [
+const createMemberMock = (
+  orgId = '',
+  firstName_contains = '',
+  lastName_contains = ''
+) => ({
+  request: {
+    query: ORGANIZATIONS_MEMBER_CONNECTION_LIST,
+    variables: {
+      orgId: orgId,
+      firstName_contains,
+      lastName_contains,
+    },
+  },
+  result: {
+    data: {
+      organizationsMemberConnection: {
+        __typename: 'UserConnection',
+        edges: [
+          {
+            __typename: 'User',
+            _id: '64001660a711c62d5b4076a2',
+            firstName: 'Aditya',
+            lastName: 'Memberguy',
+            image: null,
+            email: 'member@gmail.com',
+            createdAt: '2023-03-02T03:22:08.101Z',
+          },
+          ...members,
+        ],
+      },
+    },
+  },
+  newData: () => ({
+    data: {
+      organizationsMemberConnection: {
+        __typename: 'UserConnection',
+        edges: [
+          {
+            __typename: 'User',
+            _id: '64001660a711c62d5b4076a2',
+            firstName: 'Aditya',
+            lastName: 'Memberguy',
+            image: null,
+            email: 'member@gmail.com',
+            createdAt: '2023-03-02T03:22:08.101Z',
+          },
+          ...members,
+        ],
+      },
+    },
+  }),
+});
+
+const createAdminMock = (
+  orgId = '',
+  firstName_contains = '',
+  lastName_contains = '',
+  admin_for = ''
+) => ({
+  request: {
+    query: ORGANIZATIONS_MEMBER_CONNECTION_LIST,
+    variables: {
+      orgId,
+      firstName_contains,
+      lastName_contains,
+      admin_for,
+    },
+  },
+  result: {
+    data: {
+      organizationsMemberConnection: {
+        __typename: 'UserConnection',
+        edges: [
+          {
+            __typename: 'User',
+            _id: '64001660a711c62d5b4076a2',
+            firstName: 'Aditya',
+            lastName: 'Adminguy',
+            image: null,
+            email: 'admin@gmail.com',
+            createdAt: '2023-03-02T03:22:08.101Z',
+          },
+          ...admins,
+        ],
+      },
+    },
+  },
+  newData: () => ({
+    data: {
+      organizationsMemberConnection: {
+        __typename: 'UserConnection',
+        edges: [
+          {
+            __typename: 'User',
+            _id: '64001660a711c62d5b4076a2',
+            firstName: 'Aditya',
+            lastName: 'Adminguy',
+            image: null,
+            email: 'admin@gmail.com',
+            createdAt: '2023-03-02T03:22:08.101Z',
+            lol: true,
+          },
+        ],
+      },
+    },
+  }),
+});
+
+const createUserMock = (firstName_contains = '', lastName_contains = '') => ({
+  request: {
+    query: USER_LIST,
+    variables: {
+      firstName_contains,
+      lastName_contains,
+    },
+  },
+  result: {
+    data: {
+      users: [
+        {
+          __typename: 'User',
+          firstName: 'Aditya',
+          lastName: 'Userguy',
+          image: null,
+          _id: '64001660a711c62d5b4076a2',
+          email: 'adidacreator1@gmail.com',
+          userType: 'SUPERADMIN',
+          adminApproved: true,
+          organizationsBlockedBy: [],
+          createdAt: '2023-03-02T03:22:08.101Z',
+        },
+        {
+          __typename: 'User',
+          firstName: 'Aditya',
+          lastName: 'Userguytwo',
+          image: null,
+          _id: '6402030dce8e8406b8f07b0e',
+          email: 'adi1@gmail.com',
+          userType: 'USER',
+          adminApproved: true,
+          organizationsBlockedBy: [],
+          createdAt: '2023-03-03T14:24:13.084Z',
+        },
+      ],
+    },
+  },
+});
+
+const MOCKS: any[] = [
   {
     request: {
       query: ORGANIZATIONS_LIST,
@@ -115,7 +263,7 @@ const MOCKS = [
     request: {
       query: ORGANIZATIONS_MEMBER_CONNECTION_LIST,
       variables: {
-        orgId: undefined,
+        orgId: 'orgid',
         firstName_contains: '',
         lastName_contains: '',
       },
@@ -162,7 +310,6 @@ const MOCKS = [
   },
 
   {
-    //This is mock for Admin list
     request: {
       query: ORGANIZATIONS_MEMBER_CONNECTION_LIST,
       variables: {
@@ -307,6 +454,18 @@ const MOCKS = [
       },
     },
   },
+
+  createMemberMock('orgid', 'Aditya', ''),
+  createMemberMock('orgid', '', 'Memberguy'),
+  createMemberMock('orgid', 'Aditya', 'Memberguy'),
+
+  createAdminMock('orgid', 'Aditya', '', 'orgid'),
+  createAdminMock('orgid', '', 'Adminguy', 'orgid'),
+  createAdminMock('orgid', 'Aditya', 'Adminguy', 'orgid'),
+
+  createUserMock('Aditya', ''),
+  createUserMock('', 'Userguytwo'),
+  createUserMock('Aditya', 'Userguytwo'),
 ];
 
 const link = new StaticMockLink(MOCKS, true);
@@ -332,7 +491,7 @@ const getTotalNumPeople = (userType: string) => {
   }
 };
 
-describe('Organisation People Page', () => {
+describe('Organization People Page', () => {
   const searchData = {
     firstName: 'Aditya',
     lastNameMember: 'Memberguy',
@@ -445,6 +604,7 @@ describe('Organisation People Page', () => {
       MOCKS[1]?.result?.data?.organizationsMemberConnection?.edges;
     const dataQuery2 =
       MOCKS[2]?.result?.data?.organizationsMemberConnection?.edges;
+
     const dataQuery3 = MOCKS[3]?.result?.data?.users;
 
     expect(dataQuery1).toEqual([
@@ -526,6 +686,7 @@ describe('Organisation People Page', () => {
   });
 
   test('Testing MEMBERS list', async () => {
+    window.location.assign('/orgpeople/id=orgid');
     render(
       <MockedProvider
         addTypename={true}
@@ -563,9 +724,13 @@ describe('Organisation People Page', () => {
     expect(screen.getByPlaceholderText(/Enter First Name/i)).toHaveValue(
       searchData.firstName
     );
+
+    await wait();
+    expect(window.location).toBeAt('/orgpeople/id=orgid');
   });
 
   test('Testing MEMBERS list with filters', async () => {
+    window.location.assign('/orgpeople/id=orgid');
     render(
       <MockedProvider
         addTypename={true}
@@ -617,6 +782,9 @@ describe('Organisation People Page', () => {
     findtext = screen.getByText(/Aditya Memberguy/i);
     await wait();
     expect(findtext).toBeInTheDocument();
+
+    await wait();
+    expect(window.location).toBeAt('/orgpeople/id=orgid');
   });
 
   test('Testing ADMIN LIST', async () => {
@@ -660,6 +828,9 @@ describe('Organisation People Page', () => {
       searchData.firstName
     );
     await wait();
+
+    await wait();
+    expect(window.location).toBeAt('/orgpeople/id=orgid');
   });
 
   test('Testing ADMIN list with filters', async () => {
@@ -716,9 +887,14 @@ describe('Organisation People Page', () => {
     findtext = screen.getByText(/Aditya Adminguy/i);
     await wait();
     expect(findtext).toBeInTheDocument();
+
+    await wait();
+    expect(window.location).toBeAt('/orgpeople/id=orgid');
   });
 
   test('Testing USERS list', async () => {
+    window.location.assign('/orgpeople/id=orgid');
+
     render(
       <MockedProvider
         addTypename={true}
@@ -744,9 +920,14 @@ describe('Organisation People Page', () => {
     await wait();
     const findtext = screen.getByText('Aditya Userguy');
     expect(findtext).toBeInTheDocument();
+
+    await wait();
+    expect(window.location).toBeAt('/orgpeople/id=orgid');
   });
 
   test('Testing USERS list with filters', async () => {
+    window.location.assign('/orgpeople/id=orgid');
+
     render(
       <MockedProvider
         addTypename={true}
@@ -797,6 +978,9 @@ describe('Organisation People Page', () => {
     findtext = screen.getByText(/Aditya Userguytwo/i);
     await wait();
     expect(findtext).toBeInTheDocument();
+
+    await wait();
+    expect(window.location).toBeAt('/orgpeople/id=orgid');
   });
 
   test('No Mock Data test', async () => {

--- a/src/screens/OrganizationPeople/OrganizationPeople.test.tsx
+++ b/src/screens/OrganizationPeople/OrganizationPeople.test.tsx
@@ -83,7 +83,6 @@ const createMemberMock = (
             email: 'member@gmail.com',
             createdAt: '2023-03-02T03:22:08.101Z',
           },
-          ...members,
         ],
       },
     },
@@ -102,7 +101,6 @@ const createMemberMock = (
             email: 'member@gmail.com',
             createdAt: '2023-03-02T03:22:08.101Z',
           },
-          ...members,
         ],
       },
     },
@@ -209,7 +207,7 @@ const MOCKS: any[] = [
     request: {
       query: ORGANIZATIONS_LIST,
       variables: {
-        id: undefined,
+        id: 'orgid',
       },
     },
     result: {
@@ -402,59 +400,6 @@ const MOCKS: any[] = [
     },
   },
 
-  {
-    request: {
-      query: ORGANIZATIONS_LIST,
-      variables: {
-        id: 'orgid',
-      },
-    },
-    result: {
-      data: {
-        organizations: [
-          {
-            _id: 'orgid',
-            image: '',
-            creator: {
-              firstName: 'firstName',
-              lastName: 'lastName',
-              email: 'email',
-            },
-            name: 'name',
-            description: 'description',
-            location: 'location',
-            members: {
-              _id: 'id',
-              firstName: 'firstName',
-              lastName: 'lastName',
-              email: 'email',
-            },
-            admins: {
-              _id: 'id',
-              firstName: 'firstName',
-              lastName: 'lastName',
-              email: 'email',
-            },
-            membershipRequests: {
-              _id: 'id',
-              user: {
-                firstName: 'firstName',
-                lastName: 'lastName',
-                email: 'email',
-              },
-            },
-            blockedUsers: {
-              _id: 'id',
-              firstName: 'firstName',
-              lastName: 'lastName',
-              email: 'email',
-            },
-          },
-        ],
-      },
-    },
-  },
-
   createMemberMock('orgid', 'Aditya', ''),
   createMemberMock('orgid', '', 'Memberguy'),
   createMemberMock('orgid', 'Aditya', 'Memberguy'),
@@ -502,6 +447,8 @@ describe('Organization People Page', () => {
   };
 
   test('The number of organizations people rendered on the DOM should be equal to the rowsPerPage state value', async () => {
+    window.location.assign('orgpeople/id=orgid');
+
     render(
       <MockedProvider addTypename={false} link={link}>
         <BrowserRouter>
@@ -597,9 +544,13 @@ describe('Organization People Page', () => {
     };
 
     await changePeopleType();
+
+    expect(window.location).toBeAt('orgpeople/id=orgid');
   }, 15000);
 
   test('Correct mock data should be queried', async () => {
+    window.location.assign('/orgpeople/id=orgid');
+
     const dataQuery1 =
       MOCKS[1]?.result?.data?.organizationsMemberConnection?.edges;
     const dataQuery2 =
@@ -660,9 +611,13 @@ describe('Organization People Page', () => {
       },
       ...users,
     ]);
+
+    expect(window.location).toBeAt('/orgpeople/id=orgid');
   });
 
   test('It is necessary to query the correct mock data.', async () => {
+    window.location.assign('/orgpeople/id=orgid');
+
     const { container } = render(
       <MockedProvider addTypename={false} link={link}>
         <BrowserRouter>
@@ -681,8 +636,8 @@ describe('Organization People Page', () => {
 
     expect(container.textContent).toMatch('Members');
     expect(container.textContent).toMatch('Filter by Name');
-    window.location.assign('/orgpeople/id=6401ff65ce8e8406b8f07af1');
-    expect(window.location).toBeAt('/orgpeople/id=6401ff65ce8e8406b8f07af1');
+
+    expect(window.location).toBeAt('/orgpeople/id=orgid');
   });
 
   test('Testing MEMBERS list', async () => {
@@ -984,6 +939,8 @@ describe('Organization People Page', () => {
   });
 
   test('No Mock Data test', async () => {
+    window.location.assign('/orgpeople/id=orgid');
+
     render(
       <MockedProvider addTypename={false} link={link}>
         <BrowserRouter>
@@ -1005,5 +962,6 @@ describe('Organization People Page', () => {
     userEvent.click(screen.getByLabelText(/Users/i));
 
     await wait();
+    expect(window.location).toBeAt('/orgpeople/id=orgid');
   });
 });

--- a/src/screens/OrganizationPeople/OrganizationPeople.test.tsx
+++ b/src/screens/OrganizationPeople/OrganizationPeople.test.tsx
@@ -281,7 +281,10 @@ const getTotalNumPeople = (userType: string) => {
 
 describe('Organisation People Page', () => {
   const searchData = {
-    name: 'Aditya',
+    firstName: 'Aditya',
+    lastNameMember: 'Memberguy',
+    lastNameAdmin: 'Adminguy',
+    lastNameUser: 'Userguytwo',
     location: 'Delhi, India',
     event: 'Event',
   };
@@ -501,12 +504,66 @@ describe('Organisation People Page', () => {
 
     userEvent.type(
       screen.getByPlaceholderText(/Enter First Name/i),
-      searchData.name
+      searchData.firstName
     );
     await wait();
     expect(screen.getByPlaceholderText(/Enter First Name/i)).toHaveValue(
-      searchData.name
+      searchData.firstName
     );
+  });
+
+  test('Testing MEMBERS list with filters', async () => {
+    render(
+      <MockedProvider
+        addTypename={true}
+        link={link}
+        defaultOptions={{
+          watchQuery: { fetchPolicy: 'no-cache' },
+          query: { fetchPolicy: 'no-cache' },
+        }}
+      >
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <OrganizationPeople />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+    await wait();
+
+    userEvent.click(screen.getByLabelText(/Members/i));
+    await wait();
+    expect(screen.getByLabelText(/Members/i)).toBeChecked();
+    await wait();
+
+    const firstNameInput = screen.getByPlaceholderText(/Enter First Name/i);
+    const lastNameInput = screen.getByPlaceholderText(/Enter Last Name/i);
+
+    // Only First Name
+    userEvent.type(firstNameInput, searchData.firstName);
+    await wait();
+
+    let findtext = screen.getByText(/Aditya Memberguy/i);
+    await wait();
+    expect(findtext).toBeInTheDocument();
+
+    // First & Last Name
+    userEvent.type(lastNameInput, searchData.lastNameMember);
+    await wait();
+
+    findtext = screen.getByText(/Aditya Memberguy/i);
+    await wait();
+    expect(findtext).toBeInTheDocument();
+
+    // Only Last Name
+    userEvent.type(firstNameInput, '');
+    await wait();
+
+    findtext = screen.getByText(/Aditya Memberguy/i);
+    await wait();
+    expect(findtext).toBeInTheDocument();
   });
 
   test('Testing ADMIN LIST', async () => {
@@ -542,13 +599,69 @@ describe('Organisation People Page', () => {
 
     userEvent.type(
       screen.getByPlaceholderText(/Enter First Name/i),
-      searchData.name
+      searchData.firstName
     );
     await wait();
     expect(screen.getByPlaceholderText(/Enter First Name/i)).toHaveValue(
-      searchData.name
+      searchData.firstName
     );
     await wait();
+  });
+
+  test('Testing ADMIN list with filters', async () => {
+    window.location.assign('/orgpeople/id=orgid');
+    render(
+      <MockedProvider
+        addTypename={true}
+        link={link}
+        defaultOptions={{
+          watchQuery: { fetchPolicy: 'no-cache' },
+          query: { fetchPolicy: 'no-cache' },
+        }}
+      >
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <OrganizationPeople />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+
+    userEvent.click(screen.getByLabelText(/Admins/i));
+    await wait();
+    expect(screen.getByLabelText(/Admins/i)).toBeChecked();
+    await wait();
+
+    const firstNameInput = screen.getByPlaceholderText(/Enter First Name/i);
+    const lastNameInput = screen.getByPlaceholderText(/Enter Last Name/i);
+
+    // Only First Name
+    userEvent.type(firstNameInput, searchData.firstName);
+    await wait();
+
+    let findtext = screen.getByText(/Aditya Adminguy/i);
+    await wait();
+    expect(findtext).toBeInTheDocument();
+
+    // First & Last Name
+    userEvent.type(lastNameInput, searchData.lastNameAdmin);
+    await wait();
+
+    findtext = screen.getByText(/Aditya Adminguy/i);
+    await wait();
+    expect(findtext).toBeInTheDocument();
+
+    // Only Last Name
+    userEvent.type(firstNameInput, '');
+    await wait();
+
+    findtext = screen.getByText(/Aditya Adminguy/i);
+    await wait();
+    expect(findtext).toBeInTheDocument();
   });
 
   test('Testing USERS list', async () => {
@@ -576,6 +689,59 @@ describe('Organisation People Page', () => {
     expect(screen.getByLabelText(/Users/i)).toBeChecked();
     await wait();
     const findtext = screen.getByText('Aditya Userguy');
+    expect(findtext).toBeInTheDocument();
+  });
+
+  test('Testing USERS list with filters', async () => {
+    render(
+      <MockedProvider
+        addTypename={true}
+        link={link}
+        defaultOptions={{
+          watchQuery: { fetchPolicy: 'no-cache' },
+          query: { fetchPolicy: 'no-cache' },
+        }}
+      >
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <OrganizationPeople />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+    await wait();
+    userEvent.click(screen.getByLabelText(/Users/i));
+    await wait();
+    expect(screen.getByLabelText(/Users/i)).toBeChecked();
+    await wait();
+
+    const firstNameInput = screen.getByPlaceholderText(/Enter First Name/i);
+    const lastNameInput = screen.getByPlaceholderText(/Enter Last Name/i);
+
+    // Only First Name
+    userEvent.type(firstNameInput, searchData.firstName);
+    await wait();
+
+    let findtext = screen.getByText(/Aditya Userguytwo/i);
+    await wait();
+    expect(findtext).toBeInTheDocument();
+
+    // First & Last Name
+    userEvent.type(lastNameInput, searchData.lastNameUser);
+    await wait();
+
+    findtext = screen.getByText(/Aditya Userguytwo/i);
+    await wait();
+    expect(findtext).toBeInTheDocument();
+
+    // Only Last Name
+    userEvent.type(firstNameInput, '');
+    await wait();
+
+    findtext = screen.getByText(/Aditya Userguytwo/i);
+    await wait();
     expect(findtext).toBeInTheDocument();
   });
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug Fix

**Issue Number:**

Fixes #730 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<img width="1883" alt="Screenshot 2023-04-07 at 9 06 58 PM" src="https://user-images.githubusercontent.com/28570857/230636487-eea7e1ff-ffcf-4316-a831-15c832676950.png">


<img width="1883" alt="Screenshot 2023-04-07 at 9 07 55 PM" src="https://user-images.githubusercontent.com/28570857/230636644-9e6bf493-4722-46da-a383-3fda97717e4a.png">

**If relevant, did you update the documentation?**

Not Relevant

**Summary**

The problem -

- The Organization People's page filter didn't work as intended
- The user couldn't search by `lastName`
- The filters didn't work for `users` and `admins`
- The page unnecessarily reloaded after a change in the search query

Changes -

- Added a new field to search by `lastName`
- Added filters to `users` and `admins` as well
- The complete page no longer reloads
- Only the table reloads  

**Does this PR introduce a breaking change?**

No

**Other information**

NA

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes