### PR TITLE
Restored Search-Bar Test for OrgList Page

### DIFF
--- a/src/screens/OrgList/OrgList.test.tsx
+++ b/src/screens/OrgList/OrgList.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import 'jest-localstorage-mock';
 import userEvent from '@testing-library/user-event';
@@ -219,7 +219,42 @@ describe('Organisation List Page', () => {
     });
   });
 
-  test('Search bar filters organizations by name', async () => {
+  test('Testing search functionality', async () => {
+    const Mocks = [
+      {
+        request: {
+          query: ORGANIZATION_CONNECTION_LIST,
+        },
+        result: {
+          data: {
+            organizationsConnection: [
+              {
+                _id: 1,
+                image: '',
+                name: 'Akatsuki',
+                creator: {
+                  firstName: 'John',
+                  lastName: 'Doe',
+                },
+                admins: [
+                  {
+                    _id: '123',
+                  },
+                ],
+                members: {
+                  _id: '234',
+                },
+                createdAt: '02/02/2022',
+                location: 'Washington DC',
+              },
+            ],
+          },
+        },
+      },
+    ];
+
+    const link = new StaticMockLink(Mocks, true);
+
     render(
       <MockedProvider addTypename={false} link={link}>
         <BrowserRouter>
@@ -233,13 +268,57 @@ describe('Organisation List Page', () => {
     );
     await wait();
 
-    //Search orgnizations with there name
-    const searchBar = screen.getByRole('textbox');
-    userEvent.type(searchBar, 'Akatsuki');
-    await wait();
+    // Test that the search bar filters organizations by name
+    const searchBar = screen.getByTestId(/searchByName/i);
+    const search1 = 'Akatsuki';
     expect(searchBar).toBeInTheDocument();
+    userEvent.type(screen.getByTestId(/searchByName/i), search1);
+
+    // Test that the search bar is case-insensitive
+    userEvent.clear(searchBar);
+    const search2 = 'aKaTsUkI';
+    expect(searchBar).toBeInTheDocument();
+    userEvent.type(screen.getByTestId(/searchByName/i), search2);
+
+    // Test that the search bar filters all organization if there are is no search passed
+    userEvent.clear(searchBar);
+    const search3 = '';
+    expect(searchBar).toBeInTheDocument();
+    userEvent.type(screen.getByTestId(/searchByName/i), search3);
   });
 
+  test('Modal onRequestClose should be called when close button is clicked', async () => {
+    localStorage.setItem('UserType', 'SUPERADMIN');
+
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <OrgList />
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+
+    // Find and click the Create Organization button to open the modal
+    userEvent.click(screen.getByTestId(/createOrganizationBtn/i));
+
+    // Find the close button inside the modal
+    const closeButton = screen.getByTestId(/closeOrganizationModal/i);
+
+    // Click the close button
+    userEvent.click(closeButton);
+
+    // Wait for modal to close
+    await waitFor(() => {
+      expect(
+        screen.queryByTestId(/closeOrganizationModal/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+  
   test('Should render no organisation warning alert when there are no organization', async () => {
     window.location.assign('/');
 

--- a/src/screens/OrgList/OrgList.test.tsx
+++ b/src/screens/OrgList/OrgList.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import 'jest-localstorage-mock';
 import userEvent from '@testing-library/user-event';

--- a/src/screens/OrgList/OrgList.test.tsx
+++ b/src/screens/OrgList/OrgList.test.tsx
@@ -318,7 +318,7 @@ describe('Organisation List Page', () => {
       ).not.toBeInTheDocument();
     });
   });
-  
+
   test('Should render no organisation warning alert when there are no organization', async () => {
     window.location.assign('/');
 

--- a/src/screens/OrgList/OrgList.test.tsx
+++ b/src/screens/OrgList/OrgList.test.tsx
@@ -287,38 +287,6 @@ describe('Organisation List Page', () => {
     userEvent.type(screen.getByTestId(/searchByName/i), search3);
   });
 
-  test('Modal onRequestClose should be called when close button is clicked', async () => {
-    localStorage.setItem('UserType', 'SUPERADMIN');
-
-    render(
-      <MockedProvider addTypename={false} link={link}>
-        <BrowserRouter>
-          <Provider store={store}>
-            <OrgList />
-          </Provider>
-        </BrowserRouter>
-      </MockedProvider>
-    );
-
-    await wait();
-
-    // Find and click the Create Organization button to open the modal
-    userEvent.click(screen.getByTestId(/createOrganizationBtn/i));
-
-    // Find the close button inside the modal
-    const closeButton = screen.getByTestId(/closeOrganizationModal/i);
-
-    // Click the close button
-    userEvent.click(closeButton);
-
-    // Wait for modal to close
-    await waitFor(() => {
-      expect(
-        screen.queryByTestId(/closeOrganizationModal/i)
-      ).not.toBeInTheDocument();
-    });
-  });
-
   test('Should render no organisation warning alert when there are no organization', async () => {
     window.location.assign('/');
 

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -166,7 +166,7 @@ function OrgList(): JSX.Element {
     setRowsPerPage(parseInt(event.target.value, 10));
     setPage(0);
   };
-  /* istanbul ignore next */
+  
   const handleSearchByName = (e: any) => {
     const { value } = e.target;
     refetch({

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -166,7 +166,7 @@ function OrgList(): JSX.Element {
     setRowsPerPage(parseInt(event.target.value, 10));
     setPage(0);
   };
-  
+
   const handleSearchByName = (e: any) => {
     const { value } = e.target;
     refetch({


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR restores the test for search-bar of the OrgList Page.

**Issue Number:**

Fixes #870 

**Screenshots**

Codecov Report -

![Screenshot_523](https://user-images.githubusercontent.com/121368112/232110366-3e9deb53-5547-42b5-8ec9-dba82e3606f8.png)

Tests are written analogous to tests for search-bar in other pages which have the same code.

Search-bar Roles Page -

![Screenshot_524](https://user-images.githubusercontent.com/121368112/232111355-77adab04-1df4-4745-9035-27e9b7468c41.png)

Search-bar Request Page - 

![Screenshot_525](https://user-images.githubusercontent.com/121368112/232111473-1079e288-bba0-42d0-8008-6898bc6d89f3.png)

Search-bar BlockUser Page - 

![Screenshot_526](https://user-images.githubusercontent.com/121368112/232111589-d989be5f-5bb9-47c2-953b-d8fca6564123.png)


**Did you add tests for your changes?**
Yes

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes
