### PR TITLE
Add today functionality in calendar

### DIFF
--- a/src/components/EventCalendar/Calendar.module.css
+++ b/src/components/EventCalendar/Calendar.module.css
@@ -39,10 +39,44 @@
   grid-template-rows: repeat(6, 1fr);
 }
 .day {
-  background-color: #fff;
-  border: 1px solid black;
+  background-color: #ffffff;
+  border: 1px solid rgb(0, 0, 0);
+  padding-bottom: 4rem;
+  padding-left: 0.3rem;
+  padding-right: 0.3rem;
+  background-color: white;
+  border: 1px solid #707070;
+  color: #212121;
 }
-.day--selected {
+.day__outside {
+  background-color: #eeeded;
+  color: #898989;
+}
+.day__selected {
   background-color: #007bff;
   color: #707070;
+}
+.day__today {
+  background-color: #def6e1;
+  font-weight: 700;
+  text-decoration: underline;
+  color: #006000;
+}
+.btn__today {
+  background: #06960f;
+  transition: ease-in all 200ms;
+  border-radius: 11px;
+  box-shadow: 0px 1px 3px #666666;
+  font-family: Arial;
+  color: #ffffff;
+  font-size: 20px;
+  padding: 10px 20px 10px 20px;
+  text-decoration: none;
+  margin-left: 20px;
+  border: none;
+}
+
+.btn__today:hover {
+  background: #006000;
+  text-decoration: none;
 }

--- a/src/components/EventCalendar/Calendar.test.tsx
+++ b/src/components/EventCalendar/Calendar.test.tsx
@@ -10,6 +10,7 @@ import {
 } from 'GraphQl/Mutations/mutations';
 import i18nForTest from 'utils/i18nForTest';
 import { StaticMockLink } from 'utils/StaticMockLink';
+import styles from './Calendar.module.css';
 
 const eventData = [
   {
@@ -128,7 +129,7 @@ describe('Calendar', () => {
     const { getByText } = render(<Calendar eventData={eventData} />);
     const selectedDate = getByText('15');
     fireEvent.click(selectedDate);
-    expect(selectedDate).toHaveClass('day');
+    expect(selectedDate).toHaveClass(styles.day);
   });
 
   it('Should show prev and next month on clicking < & > buttons', () => {
@@ -177,5 +178,44 @@ describe('Calendar', () => {
         </I18nextProvider>
       </MockedProvider>
     );
+  });
+  it('Test for superadmin case', () => {
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <I18nextProvider i18n={i18nForTest}>
+          <Calendar eventData={eventData} userRole={'SUPERADMIN'} />
+        </I18nextProvider>
+      </MockedProvider>
+    );
+  });
+  it('Today Cell is having correct styles', () => {
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <I18nextProvider i18n={i18nForTest}>
+          <Calendar eventData={eventData} userRole={'SUPERADMIN'} />
+        </I18nextProvider>
+      </MockedProvider>
+    );
+    const todayDate = new Date().getDate();
+    const todayElement = screen.getByText(todayDate.toString());
+    expect(todayElement).toHaveClass(styles.day__today);
+  });
+  it('Today button should show today cell', () => {
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <I18nextProvider i18n={i18nForTest}>
+          <Calendar eventData={eventData} userRole={'SUPERADMIN'} />
+        </I18nextProvider>
+      </MockedProvider>
+    );
+    //Changing the month
+    const prevButton = screen.getByText('<');
+    fireEvent.click(prevButton);
+
+    // Clicking today button
+    const todayButton = screen.getByText('Today');
+    fireEvent.click(todayButton);
+    const todayCell = screen.getByText(new Date().getDate().toString());
+    expect(todayCell).toHaveClass(styles.day__today);
   });
 });

--- a/src/components/EventCalendar/Calendar.tsx
+++ b/src/components/EventCalendar/Calendar.tsx
@@ -83,6 +83,8 @@ const Calendar: React.FC<CalendarProps> = ({
   ) => {
     const data: Event[] = [];
     if (userRole === Role.SUPERADMIN) return eventData;
+    // Hard to test all the cases
+    /* istanbul ignore next */
     if (userRole === Role.ADMIN) {
       eventData?.forEach((event) => {
         if (event.isPublic) data.push(event);
@@ -132,6 +134,10 @@ const Calendar: React.FC<CalendarProps> = ({
       setCurrentMonth(currentMonth + 1);
     }
   };
+  const handleTodayButton = () => {
+    setCurrentYear(today.getFullYear());
+    setCurrentMonth(today.getMonth());
+  };
   const renderDays = () => {
     const monthStart = new Date(currentYear, currentMonth, 1);
     const monthEnd = new Date(currentYear, currentMonth + 1, 0);
@@ -157,26 +163,15 @@ const Calendar: React.FC<CalendarProps> = ({
     }
     return days.map((date, index) => {
       const className = [
-        'day',
-        date.getMonth() !== currentMonth ? 'day--outside' : '',
-        selectedDate && selectedDate.getTime() === date.getTime()
-          ? 'day--selected'
+        date.toLocaleDateString() === today.toLocaleDateString() //Styling for today day cell
+          ? styles.day__today
           : '',
+        date.getMonth() !== currentMonth ? styles.day__outside : '', //Styling for days outside the current month
+        selectedDate?.getTime() === date.getTime() ? styles.day__selected : '',
+        styles.day,
       ].join(' ');
       return (
-        <div
-          style={{
-            paddingBottom: '4rem',
-            paddingLeft: '0.3rem',
-            paddingRight: '0.3rem',
-            backgroundColor: 'white',
-            border: '1px solid #707070',
-            color: '#707070',
-          }}
-          key={index}
-          className={className}
-          data-testid="day"
-        >
+        <div style={{}} key={index} className={className} data-testid="day">
           {date.getDate()}
           <div className={styles.list_box}>
             {events
@@ -224,6 +219,11 @@ const Calendar: React.FC<CalendarProps> = ({
         <button className={styles.button} onClick={handleNextMonth}>
           {'>'}
         </button>
+        <div>
+          <button className={styles.btn__today} onClick={handleTodayButton}>
+            Today
+          </button>
+        </div>
       </div>
 
       <div className={styles.calendar__weekdays}>


### PR DESCRIPTION

**What kind of change does this PR introduce?**

Features : 
- A today button in calendar on clicking it the calendar will  focus on today's date.
- User can go to current month with single click  instead of manually switching months
- Highlighting of today's date in month
- Shadowing of days which are not in the month

**Issue Number:**

Fixes #883 

**Did you add tests for your changes?**
YES

![Screenshot from 2023-04-20 19-54-35](https://user-images.githubusercontent.com/103348863/233396548-de9a4609-af19-4cfd-9237-970d5a68fedf.png)



**Snapshots/Videos:**
## Before
![before](https://user-images.githubusercontent.com/103348863/233394607-f3a655d4-645a-4bf9-853a-75990d13fdf8.png)

## After

https://user-images.githubusercontent.com/103348863/233394659-b9669b25-6e90-47ae-9597-731cd3b3115f.mp4



<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
N/A

**Does this PR introduce a breaking change?**
N/A

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

YES