### PR TITLE
remove redundancy from orgPostCard

### DIFF
--- a/src/components/OrgPostCard/OrgPostCard.test.tsx
+++ b/src/components/OrgPostCard/OrgPostCard.test.tsx
@@ -112,7 +112,7 @@ describe('Testing Organization Post Card', () => {
     expect(screen.getByText(props.postVideo)).toBeInTheDocument();
   });
 
-  test('Testing post update functionality', async () => {
+  test('Testing  post update functionality', async () => {
     render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
@@ -156,15 +156,15 @@ describe('Testing Organization Post Card', () => {
 
     const toggleButton = screen.getByTestId('toggleBtn');
 
-    expect(screen.getByText('Read more')).toBeInTheDocument();
+    expect(screen.getByText('Hide')).toBeInTheDocument();
 
     fireEvent.click(toggleButton);
 
-    expect(screen.getByText('hide')).toBeInTheDocument();
+    expect(screen.getByText('Read More')).toBeInTheDocument();
 
     fireEvent.click(toggleButton);
 
-    expect(screen.getByText('Read more')).toBeInTheDocument();
+    expect(screen.getByText('Hide')).toBeInTheDocument();
   });
 
   test('should toggle post content', () => {
@@ -191,15 +191,15 @@ describe('Testing Organization Post Card', () => {
     expect(
       screen.getByText('Lorem ipsum dolor sit amet, consectetur ...')
     ).toBeInTheDocument();
-    expect(toggleBtn).toHaveTextContent('Read more');
+    expect(toggleBtn).toHaveTextContent('Read More');
     expect(toggleBtn).toHaveClass(mockedStyles.toggleClickBtn);
 
     fireEvent.click(toggleBtn);
 
-    expect(screen.getByTestId('toggleContent').innerHTML).toEqual(
+    expect(screen.getByTestId('PostInfo').innerHTML).toEqual(
       'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
     );
-    expect(toggleBtn).toHaveTextContent('hide');
+    expect(toggleBtn).toHaveTextContent('Hide');
     expect(toggleBtn).toHaveClass(mockedStyles.toggleClickBtn);
   });
 

--- a/src/components/OrgPostCard/OrgPostCard.tsx
+++ b/src/components/OrgPostCard/OrgPostCard.tsx
@@ -8,7 +8,6 @@ import {
   UPDATE_POST_MUTATION,
 } from 'GraphQl/Mutations/mutations';
 import { useTranslation } from 'react-i18next';
-import defaultImg from 'assets/third_image.png';
 import { errorHandler } from 'utils/errorHandler';
 
 interface OrgPostCardProps {
@@ -27,14 +26,30 @@ function OrgPostCard(props: OrgPostCardProps): JSX.Element {
     postinfo: '',
   });
 
-  const [togglePost, setPostToggle] = useState('Read more');
+  const [showMoreInfo, setShowMoreInfo] = useState<boolean>(false);
+
+  const initialSlice = () => {
+    if (!props.postPhoto) {
+      // post photo do  not exist
+      setShowMoreInfo(true);
+      return props.postInfo;
+    } else if (props.postInfo.length > 50) {
+      return props.postInfo.substring(0, 40);
+    } else {
+      setShowMoreInfo(true);
+      return props.postInfo;
+    }
+  };
+
+  const [slicedMoreInfo, setSlicedMoreInfo] = useState<string>(initialSlice);
 
   function handletoggleClick() {
-    if (togglePost === 'Read more') {
-      setPostToggle('hide');
+    if (!showMoreInfo) {
+      setSlicedMoreInfo(props.postInfo);
     } else {
-      setPostToggle('Read more');
+      setSlicedMoreInfo(props.postInfo.substring(0, 40));
     }
+    setShowMoreInfo(!showMoreInfo);
   }
 
   useEffect(() => {
@@ -147,26 +162,14 @@ function OrgPostCard(props: OrgPostCardProps): JSX.Element {
                 />
               </span>
             </p>
-          ) : (
-            <img
-              src={defaultImg}
-              alt="image not found"
-              className={styles.postimage}
-            />
-          )}
+          ) : null}
           <p>
             {t('author')}:<span> {props.postAuthor}</span>
           </p>
           <div className={styles.infodiv}>
-            {togglePost === 'Read more' ? (
-              <p data-testid="toggleContent">
-                {props.postInfo.length > 43
-                  ? props.postInfo.substring(0, 40) + '...'
-                  : props.postInfo}
-              </p>
-            ) : (
-              <p data-testid="toggleContent">{props.postInfo}</p>
-            )}
+            <p data-testid="PostInfo">
+              {slicedMoreInfo.concat(!showMoreInfo ? '...' : '')}
+            </p>
             <button
               role="toggleBtn"
               data-testid="toggleBtn"
@@ -177,16 +180,19 @@ function OrgPostCard(props: OrgPostCardProps): JSX.Element {
               }`}
               onClick={handletoggleClick}
             >
-              {togglePost}
+              {showMoreInfo ? 'Hide' : 'Read More'}
             </button>
           </div>
-          <p>
-            {t('videoURL')}:
-            <span>
-              {' '}
-              <a href={props.postVideo}>{props.postVideo}</a>
-            </span>
-          </p>
+          {/* Check for video url and render video url */}
+          {props.postVideo ? (
+            <p>
+              {t('videoURL')}:
+              <span>
+                {' '}
+                <a href={props.postVideo}>{props.postVideo}</a>
+              </span>
+            </p>
+          ) : null}
         </div>
       </div>
 


### PR DESCRIPTION

**What kind of change does this PR introduce?**

Organization Post Card was rendering a empty box when there is no image for the post. 
Added Conditional logic for rendering organization post card
Improved the logic for [show more info] button 


**Issue Number:**

Fixes #886 

**Did you add tests for your changes?**

YES

**Snapshots/Videos:**
Feature : 

https://user-images.githubusercontent.com/103348863/234344847-c13631fd-6f90-4b3d-bca1-6f149d508000.mp4

**Tests**
![orgPostTestVSCode](https://user-images.githubusercontent.com/103348863/234346112-d68d9c05-b207-4587-acaf-f26d2b6ca609.png)
![orgPostTestIstanbul](https://user-images.githubusercontent.com/103348863/234346136-92d97834-3855-47db-8d48-9799261234e2.png)


**Does this PR introduce a breaking change?**
NO

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
YES

Thank You !

