### PR TITLE
Make Talawa-Admin mutations in sync with the backend

### DIFF
--- a/src/GraphQl/Mutations/mutations.ts
+++ b/src/GraphQl/Mutations/mutations.ts
@@ -352,7 +352,7 @@ export const REJECT_ADMIN_MUTATION = gql`
  */
 export const UPDATE_INSTALL_STATUS_PLUGIN_MUTATION = gql`
   mutation update_install_status_plugin_mutation($id: ID!, $status: Boolean!) {
-    updateTempPluginStatus(id: $id, status: $status) {
+    updatePluginStatus(id: $id, status: $status) {
       _id
       pluginName
       pluginCreatedBy
@@ -364,11 +364,11 @@ export const UPDATE_INSTALL_STATUS_PLUGIN_MUTATION = gql`
 
 /**
  * @name UPDATE_ORG_STATUS_PLUGIN_MUTATION
- * @description used  `updateTempPluginInstalledOrgs`to add or remove the current Organization the in the plugin list `installedOrgs`
+ * @description used  `updatePluginInstalledOrgs`to add or remove the current Organization the in the plugin list `installedOrgs`
  */
 export const UPDATE_ORG_STATUS_PLUGIN_MUTATION = gql`
   mutation update_install_status_plugin_mutation($id: ID!, $orgId: ID!) {
-    updateTempPluginInstalledOrgs(id: $id, orgId: $orgId) {
+    updatePluginInstalledOrgs(id: $id, orgId: $orgId) {
       _id
       pluginName
       pluginCreatedBy

--- a/src/GraphQl/Mutations/mutations.ts
+++ b/src/GraphQl/Mutations/mutations.ts
@@ -447,17 +447,3 @@ export const UPDATE_EVENT_MUTATION = gql`
     }
   }
 `;
-
-export const UPDATE_SPAM_NOTIFICATION_MUTATION = gql`
-  mutation UpdateSpamNotification(
-    $orgId: ID!
-    $spamId: ID!
-    $isReaded: Boolean
-  ) {
-    updateSpamNotification(
-      data: { orgId: $orgId, spamId: $spamId, isReaded: $isReaded }
-    ) {
-      _id
-    }
-  }
-`;

--- a/src/components/AdminNavbar/AdminNavbar.test.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.test.tsx
@@ -206,9 +206,7 @@ describe('Testing Admin Navbar', () => {
 
     expect(container.textContent).not.toBe('Loading data...');
     await wait();
-    const imageOptions = screen.getByTestId(/navbarOrgImageAbsent/i);
     const imageLogo = screen.getByTestId(/orgLogoAbsent/i);
     expect(imageLogo).toBeInTheDocument();
-    expect(imageOptions).toBeInTheDocument();
   });
 });

--- a/src/components/AdminNavbar/AdminNavbar.test.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.test.tsx
@@ -1,19 +1,19 @@
-import React from 'react';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { render, screen, fireEvent, act } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
-import { BrowserRouter } from 'react-router-dom';
-import { Provider } from 'react-redux';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import 'jest-localstorage-mock';
 import 'jest-location-mock';
 import { I18nextProvider } from 'react-i18next';
+import { Provider } from 'react-redux';
+import { BrowserRouter } from 'react-router-dom';
 
-import AdminNavbar from './AdminNavbar';
 import { store } from 'state/store';
-import i18nForTest from 'utils/i18nForTest';
-import { MOCKS } from './AdminNavbarMocks';
 import { StaticMockLink } from 'utils/StaticMockLink';
+import i18nForTest from 'utils/i18nForTest';
+import AdminNavbar from './AdminNavbar';
+import { MOCKS } from './AdminNavbarMocks';
 const link1 = new StaticMockLink(MOCKS, true);
 async function wait(ms = 100): Promise<void> {
   await act(() => {
@@ -89,7 +89,6 @@ describe('Testing Admin Navbar', () => {
     expect(screen.getByTestId('dropdownIcon')).toBeTruthy();
     expect(screen.getByText('Plugin Store')).toBeInTheDocument();
     expect(screen.getByTestId('logoutDropdown')).toBeTruthy();
-    expect(screen.getByText('Notification')).toBeInTheDocument();
     expect(screen.getByText('Settings')).toBeInTheDocument();
     expect(screen.getByText('Logout')).toBeInTheDocument();
 

--- a/src/components/AdminNavbar/AdminNavbar.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.tsx
@@ -55,34 +55,6 @@ function adminNavbar({ targets, url1 }: InterfaceNavbarProps): JSX.Element {
   const isSuperAdmin = data2?.user.userType === 'SUPERADMIN';
 
   useEffect(() => {
-    const handleUpdateSpam = async (): Promise<void> => {
-      const spamId = localStorage.getItem('spamId');
-      if (spamId) {
-        try {
-          const { data } = await updateSpam({
-            variables: {
-              orgId: currentUrl,
-              spamId,
-              isReaded: true,
-            },
-          });
-
-          /* istanbul ignore next */
-          if (data) {
-            localStorage.removeItem('spamId');
-            orgRefetch();
-          }
-        } catch (error: any) {
-          /* istanbul ignore next */
-          errorHandler(t, error);
-        }
-      }
-    };
-
-    handleUpdateSpam();
-  }, []);
-
-  useEffect(() => {
     if (orgData && orgData?.organizations[0].spamCount) {
       setSpamCountData(
         orgData?.organizations[0].spamCount.filter(

--- a/src/components/AdminNavbar/AdminNavbar.tsx
+++ b/src/components/AdminNavbar/AdminNavbar.tsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Navbar from 'react-bootstrap/Navbar';
 import Dropdown from 'react-bootstrap/Dropdown';
 import Button from 'react-bootstrap/Button';
-import { Nav, Modal } from 'react-bootstrap';
+import { Nav } from 'react-bootstrap';
 import { Link, NavLink } from 'react-router-dom';
-import { useMutation, useQuery } from '@apollo/client';
+import { useQuery } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
 import Cookies from 'js-cookie';
 import i18next from 'i18next';
@@ -15,9 +15,7 @@ import {
   ORGANIZATIONS_LIST,
   USER_ORGANIZATION_LIST,
 } from 'GraphQl/Queries/Queries';
-import { UPDATE_SPAM_NOTIFICATION_MUTATION } from 'GraphQl/Mutations/mutations';
 import { languages } from 'utils/languages';
-import { errorHandler } from 'utils/errorHandler';
 
 interface InterfaceNavbarProps {
   targets: {
@@ -34,43 +32,18 @@ interface InterfaceNavbarProps {
 
 function adminNavbar({ targets, url1 }: InterfaceNavbarProps): JSX.Element {
   const { t } = useTranslation('translation', { keyPrefix: 'adminNavbar' });
-
-  const [spamCountData, setSpamCountData] = useState([]);
-  const [showNotifModal, setShowNotifModal] = useState(false);
-
   const currentUrl = window.location.href.split('=')[1];
 
-  const {
-    data: orgData,
-    error: orgError,
-    refetch: orgRefetch,
-  } = useQuery(ORGANIZATIONS_LIST, {
+  const { data: orgData, error: orgError } = useQuery(ORGANIZATIONS_LIST, {
     variables: { id: currentUrl },
   });
-  const [updateSpam] = useMutation(UPDATE_SPAM_NOTIFICATION_MUTATION);
+
   const { data: data2 } = useQuery(USER_ORGANIZATION_LIST, {
     variables: { id: localStorage.getItem('id') },
   });
 
   const isSuperAdmin = data2?.user.userType === 'SUPERADMIN';
-
-  useEffect(() => {
-    if (orgData && orgData?.organizations[0].spamCount) {
-      setSpamCountData(
-        orgData?.organizations[0].spamCount.filter(
-          (spam: any) => spam.isReaded === false
-        )
-      );
-    }
-  }, [orgData]);
-
   const currentLanguageCode = Cookies.get('i18next') || 'en';
-  const toggleNotifModal = (): void => setShowNotifModal(!showNotifModal);
-
-  const handleSpamNotification = (spamId: string): void => {
-    localStorage.setItem('spamId', spamId);
-    window.location.assign(`/blockuser/id=${url1}`);
-  };
 
   /* istanbul ignore next */
   if (orgError) {
@@ -123,7 +96,7 @@ function adminNavbar({ targets, url1 }: InterfaceNavbarProps): JSX.Element {
                 <Nav.Item key={name} className={styles.navitems}>
                   <Dropdown className={styles.dropdowns}>
                     <Dropdown.Toggle
-                      variant=""
+                      variant="light"
                       id={name}
                       className={`${styles.dropdowntoggle} ${styles.navlinks_dropdown}`}
                     >
@@ -165,25 +138,9 @@ function adminNavbar({ targets, url1 }: InterfaceNavbarProps): JSX.Element {
                 id="dropdown-basic"
                 data-testid="logoutDropdown"
               >
-                {orgData?.organizations[0].image ? (
-                  <span>
-                    <MenuIcon></MenuIcon>
-                  </span>
-                ) : (
-                  <img
-                    src={AboutImg}
-                    className={styles.roundedcircle}
-                    data-testid="navbarOrgImageAbsent"
-                  />
-                )}
+                <MenuIcon />
               </Dropdown.Toggle>
               <Dropdown.Menu className={styles.dropdownMenu}>
-                <Dropdown.Item onClick={toggleNotifModal}>
-                  <i className="fa fa-bell"></i>&ensp; {t('notification')}{' '}
-                  <span className="badge text-bg-success">
-                    {spamCountData.length}
-                  </span>
-                </Dropdown.Item>
                 <Dropdown.Item as={Link} to={`/orgsetting/id=${url1}`}>
                   <i className="fa fa-cogs"></i>&ensp; {t('settings')}
                 </Dropdown.Item>
@@ -229,38 +186,6 @@ function adminNavbar({ targets, url1 }: InterfaceNavbarProps): JSX.Element {
           </Nav>
         </Navbar.Collapse>
       </Navbar>
-
-      {/* Notification Modal */}
-      <Modal show={showNotifModal} onHide={toggleNotifModal}>
-        <Modal.Header>
-          <h5 id="notificationModalLabel">{t('notifications')}</h5>
-          <Button variant="danger" onClick={toggleNotifModal}>
-            <i className="fa fa-times"></i>
-          </Button>
-        </Modal.Header>
-        <Modal.Body>
-          {spamCountData.length > 0 ? (
-            spamCountData.map((spam: any) => (
-              <div
-                className={`border rounded p-3 mb-2 ${styles.notificationList}`}
-                onClick={(): void => handleSpamNotification(spam._id)}
-                key={spam._id}
-                data-testid={`spamNotification${spam._id}`}
-              >
-                {`${spam.user.firstName} ${spam.user.lastName}`} {t('spamsThe')}{' '}
-                {spam.groupchat.title} {t('group')}.
-              </div>
-            ))
-          ) : (
-            <p className="text-center">{t('noNotifications')}</p>
-          )}
-        </Modal.Body>
-        <Modal.Footer>
-          <Button variant="danger" onClick={toggleNotifModal}>
-            {t('close')}
-          </Button>
-        </Modal.Footer>
-      </Modal>
     </>
   );
 }

--- a/src/components/AdminNavbar/AdminNavbarMocks.ts
+++ b/src/components/AdminNavbar/AdminNavbarMocks.ts
@@ -1,5 +1,4 @@
 import { ORGANIZATIONS_LIST } from 'GraphQl/Queries/Queries';
-import { UPDATE_SPAM_NOTIFICATION_MUTATION } from 'GraphQl/Mutations/mutations';
 
 // Has no placeholder image
 export const MOCKS = [
@@ -68,19 +67,6 @@ export const MOCKS = [
             ],
           },
         ],
-      },
-    },
-  },
-  {
-    request: {
-      query: UPDATE_SPAM_NOTIFICATION_MUTATION,
-      variables: { orgId: undefined, spamId: '6954', isReaded: true },
-    },
-    result: {
-      data: {
-        updateSpamNotification: {
-          _id: '900',
-        },
       },
     },
   },
@@ -153,19 +139,6 @@ export const MOCKS_WITH_IMAGE = [
             ],
           },
         ],
-      },
-    },
-  },
-  {
-    request: {
-      query: UPDATE_SPAM_NOTIFICATION_MUTATION,
-      variables: { orgId: undefined, spamId: '6954', isReaded: true },
-    },
-    result: {
-      data: {
-        updateSpamNotification: {
-          _id: '900',
-        },
       },
     },
   },


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**

Fixes #945 

**Did you add tests for your changes?**
Not required

**Snapshots/Videos:**

Not applicable

**If relevant, did you update the documentation?**


Not applicable

**Summary**
Keeping our frontend mutations in sync is necessary.
- `updateSpamNotification` mutation was not in `talawa-api` and notification modal was not working, so i have removed them in order to make the backend in sync with `talawa-admin`

**Does this PR introduce a breaking change?**

No

**Other information**

None

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
