### PR TITLE
Move maximum rating in feedback from 10 to 5 [Fixes #990]

### DIFF
--- a/src/components/EventStats/Statistics/AverageRating.test.tsx
+++ b/src/components/EventStats/Statistics/AverageRating.test.tsx
@@ -52,7 +52,7 @@ describe('Testing Average Rating Card', () => {
     );
 
     await waitFor(() =>
-      expect(queryByText('Rated 5.00 / 10')).toBeInTheDocument()
+      expect(queryByText('Rated 5.00 / 5')).toBeInTheDocument()
     );
   });
 });

--- a/src/components/EventStats/Statistics/AverageRating.tsx
+++ b/src/components/EventStats/Statistics/AverageRating.tsx
@@ -10,7 +10,7 @@ type ModalPropType = {
   data: {
     event: {
       _id: string;
-      averageFeedbackScore: number | null;
+      averageFeedbackScore: number;
       feedback: FeedbackType[];
     };
   };
@@ -41,12 +41,12 @@ export const AverageRating = ({ data }: ModalPropType): JSX.Element => {
             <h4>Average Review Score</h4>
           </Card.Title>
           <Typography component="legend">
-            Rated {(data.event.averageFeedbackScore || 0).toFixed(2)} / 10
+            Rated {data.event.averageFeedbackScore.toFixed(2)} / 5
           </Typography>
           <StyledRating
             name="customized-color"
             precision={0.5}
-            max={10}
+            max={5}
             readOnly
             value={data.event.averageFeedbackScore}
             icon={<FavoriteIcon fontSize="inherit" />}

--- a/src/components/EventStats/Statistics/Feedback.tsx
+++ b/src/components/EventStats/Statistics/Feedback.tsx
@@ -25,15 +25,10 @@ type FeedbackType = {
 export const FeedbackStats = ({ data }: ModalPropType): JSX.Element => {
   const ratingColors = [
     '#57bb8a', // Green
-    '#73b87e',
     '#94bd77',
-    '#b0be6e',
     '#d4c86a',
-    '#f5ce62',
     '#e9b861',
-    '#ecac67',
     '#e79a69',
-    '#e2886c',
     '#dd776e', // Red
   ];
 
@@ -45,13 +40,13 @@ export const FeedbackStats = ({ data }: ModalPropType): JSX.Element => {
   });
 
   const chartData = [];
-  for (let rating = 0; rating <= 10; rating++) {
+  for (let rating = 0; rating <= 5; rating++) {
     if (rating in count)
       chartData.push({
         id: rating,
         value: count[rating],
         label: `${rating} (${count[rating]})`,
-        color: ratingColors[10 - rating],
+        color: ratingColors[5 - rating],
       });
   }
 

--- a/src/components/EventStats/Statistics/Review.tsx
+++ b/src/components/EventStats/Statistics/Review.tsx
@@ -42,7 +42,7 @@ export const ReviewStats = ({ data }: ModalPropType): JSX.Element => {
             reviews.map((review) => (
               <div className="card user-review m-1" key={review._id}>
                 <div className="card-body">
-                  <Rating name="read-only" value={review.rating / 2} readOnly />
+                  <Rating name="read-only" value={review.rating} readOnly />
                   <p className="card-text">{review.review}</p>
                 </div>
               </div>


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Bugfix
Fixes #990 
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Did you add tests for your changes?**
Yes
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
NA
<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
NA
<!--Add link to Talawa-Docs.-->

**Summary**
As discussed with @palisadoes, the maximum feedback rating in event management should be `5` to maintain consistency. This PR updates the same to be 5 instead of 10. 
 
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
NA
<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-api/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->
