### PR TITLE
Fix modal closing and automatically updating events without refresh.

### DIFF
--- a/src/components/EventCalendar/EventCalendar.tsx
+++ b/src/components/EventCalendar/EventCalendar.tsx
@@ -116,7 +116,7 @@ const Calendar: React.FC<InterfaceCalendarProps> = ({
   useEffect(() => {
     const data = filterData(eventData, orgData, userRole, userId);
     setEvents(data);
-  }, []);
+  }, [eventData, orgData, userRole, userId]);
 
   const handlePrevMonth = (): void => {
     if (currentMonth === 0) {

--- a/src/screens/OrganizationEvents/OrganizationEvents.tsx
+++ b/src/screens/OrganizationEvents/OrganizationEvents.tsx
@@ -105,6 +105,7 @@ function organizationEvents(): JSX.Element {
       if (createEventData) {
         toast.success(t('eventCreated'));
         refetch();
+        hideInviteModal();
         setFormState({
           title: '',
           eventdescrip: '',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Now the modal is automatically closed after the successful creation of the event and also the events are automatically updated in the calendar. I have attached a video demonstrating the flow.

**Issue Number:**

Fixes #1011 

**Did you add tests for your changes?**

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**

https://github.com/PalisadoesFoundation/talawa-admin/assets/109683163/e6d1cc6c-d260-4b58-a701-e1f44c967509

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

Previously, upon successful event creation, the modal wouldn't close automatically, requiring manual closing of the modal. Additionally, events weren't reflected in real-time, we need to refresh to view newly added events.These issues are now solved. I've fixed the modal closing issue and updating the newly added events at real time. I have added a video showing the flow.

**Does this PR introduce a breaking change?**

 No

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
