### PR TITLE
Fix event creation issue with white spaces.

### DIFF
--- a/src/screens/OrganizationEvents/OrganizationEvents.tsx
+++ b/src/screens/OrganizationEvents/OrganizationEvents.tsx
@@ -83,41 +83,53 @@ function organizationEvents(): JSX.Element {
     e: ChangeEvent<HTMLFormElement>
   ): Promise<void> => {
     e.preventDefault();
-    try {
-      const { data: createEventData } = await create({
-        variables: {
-          title: formState.title,
-          description: formState.eventdescrip,
-          isPublic: publicchecked,
-          recurring: recurringchecked,
-          isRegisterable: registrablechecked,
-          organizationId: currentUrl,
-          startDate: dayjs(startDate).format('YYYY-MM-DD'),
-          endDate: dayjs(endDate).format('YYYY-MM-DD'),
-          allDay: alldaychecked,
-          location: formState.location,
-          startTime: !alldaychecked ? formState.startTime + 'Z' : null,
-          endTime: !alldaychecked ? formState.endTime + 'Z' : null,
-        },
-      });
-
-      /* istanbul ignore next */
-      if (createEventData) {
-        toast.success(t('eventCreated'));
-        refetch();
-        hideInviteModal();
-        setFormState({
-          title: '',
-          eventdescrip: '',
-          date: '',
-          location: '',
-          startTime: '08:00:00',
-          endTime: '18:00:00',
+    if (
+      formState.title.trim().length > 0 &&
+      formState.eventdescrip.trim().length > 0 &&
+      formState.location.trim().length > 0
+    ) {
+      try {
+        const { data: createEventData } = await create({
+          variables: {
+            title: formState.title,
+            description: formState.eventdescrip,
+            isPublic: publicchecked,
+            recurring: recurringchecked,
+            isRegisterable: registrablechecked,
+            organizationId: currentUrl,
+            startDate: dayjs(startDate).format('YYYY-MM-DD'),
+            endDate: dayjs(endDate).format('YYYY-MM-DD'),
+            allDay: alldaychecked,
+            location: formState.location,
+            startTime: !alldaychecked ? formState.startTime + 'Z' : null,
+            endTime: !alldaychecked ? formState.endTime + 'Z' : null,
+          },
         });
+
+        /* istanbul ignore next */
+        if (createEventData) {
+          toast.success(t('eventCreated'));
+          refetch();
+          hideInviteModal();
+          setFormState({
+            title: '',
+            eventdescrip: '',
+            date: '',
+            location: '',
+            startTime: '08:00:00',
+            endTime: '18:00:00',
+          });
+        }
+      } catch (error: any) {
+        /* istanbul ignore next */
+        errorHandler(t, error);
       }
-    } catch (error: any) {
-      /* istanbul ignore next */
-      errorHandler(t, error);
+    } else if (formState.title.trim().length === 0) {
+      toast.warning('Please enter a valid title!');
+    } else if (formState.eventdescrip.trim().length === 0) {
+      toast.warning('Please enter a valid description!');
+    } else if (formState.location.trim().length === 0) {
+      toast.warning('Please enter a valid location!');
     }
   };
 

--- a/src/screens/OrganizationEvents/OrganizationEvents.tsx
+++ b/src/screens/OrganizationEvents/OrganizationEvents.tsx
@@ -124,12 +124,15 @@ function organizationEvents(): JSX.Element {
         /* istanbul ignore next */
         errorHandler(t, error);
       }
-    } else if (formState.title.trim().length === 0) {
-      toast.warning('Please enter a valid title!');
-    } else if (formState.eventdescrip.trim().length === 0) {
-      toast.warning('Please enter a valid description!');
-    } else if (formState.location.trim().length === 0) {
-      toast.warning('Please enter a valid location!');
+    }
+    if (formState.title.trim().length === 0) {
+      toast.warning('Title can not be blank!');
+    }
+    if (formState.eventdescrip.trim().length === 0) {
+      toast.warning('Description can not be blank!');
+    }
+    if (formState.location.trim().length === 0) {
+      toast.warning('Location can not be blank!');
     }
   };
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

A bug.

**Issue Number:**

Fixes #1021 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

https://github.com/PalisadoesFoundation/talawa-admin/assets/109683163/edc731eb-d87f-480b-85e4-3631cba75bf0

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

Previously events can be created with white spaces only. To fix this issue I have added a validation that if the title, description or the location has values with white spaces only than It will show a warning. I have attached a video for the same showing that.
Now user can't create an event with white spaces and no text.

**Does this PR introduce a breaking change?**

No

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
