### PR TITLE
Created a all events button on event dashboard

### DIFF
--- a/src/components/LeftDrawerEvent/LeftDrawerEvent.test.tsx
+++ b/src/components/LeftDrawerEvent/LeftDrawerEvent.test.tsx
@@ -18,7 +18,7 @@ const props: InterfaceLeftDrawerProps = {
     title: 'Test Event',
     description: 'Test Description',
     organization: {
-      _id: 'Test Organization',
+      _id: 'TestOrganization',
     },
   },
   hideDrawer: false,
@@ -217,5 +217,22 @@ describe('Testing Left Drawer component for the Event Dashboard', () => {
     const truncatedEventDescription = eventDescription.substring(0, 30) + '...';
     expect(truncatedEventTitle).toContain('...');
     expect(truncatedEventDescription).toContain('...');
+  });
+  test('Testing all events button', async () => {
+    localStorage.setItem('UserType', 'SUPERADMIN');
+    render(
+      <MockedProvider mocks={mocks}>
+        <BrowserRouter>
+          <I18nextProvider i18n={i18nForTest}>
+            <LeftDrawerEvent {...props} />
+          </I18nextProvider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    userEvent.click(screen.getByTestId('allEventsBtn'));
+    expect(global.window.location.pathname).toBe(
+      `/orgevents/id=${props.event.organization._id}`
+    );
   });
 });

--- a/src/components/LeftDrawerEvent/LeftDrawerEvent.tsx
+++ b/src/components/LeftDrawerEvent/LeftDrawerEvent.tsx
@@ -130,6 +130,20 @@ const leftDrawerEvent = ({
             eventId={event._id}
             key={`${event?._id || 'loading'}Stats`}
           />
+          <Button
+            variant="light"
+            data-testid="allEventsBtn"
+            className="text-secondary"
+            aria-label="allEvents"
+            onClick={(): void => {
+              history.push(`/orgevents/id=${event.organization._id}`);
+            }}
+          >
+            <div className={styles.iconWrapper}>
+              <IconComponent name="Events" fill="var(--bs-secondary)" />
+            </div>
+            All Events
+          </Button>
         </div>
 
         {/* Profile Section & Logout Btn */}


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `alpha-x.x.x`: For stability testing: Only bug fixes accepted.
- `master`: Where the stable production ready code lies. Only security related bugs.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

BugFix<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #1050 <!--Add related issue number here.-->

**Did you add tests for your changes?**
Yes

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
![Screenshot from 2023-11-12 01-18-44](https://github.com/PalisadoesFoundation/talawa-admin/assets/93936630/256be1ce-9577-45df-9dad-e72a17877a37)


<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**
Event dashboard page don't have any option to return back to events page of the organization. So, in this PR I have created a **All Events** button which redirect the user to the events page of the organization.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
