### PR TITLE
Update test for LeftDrawerEventWrapper.tsx to 100% coverage

### DIFF
--- a/src/components/LeftDrawerEvent/LeftDrawerEventWrapper.test.tsx
+++ b/src/components/LeftDrawerEvent/LeftDrawerEventWrapper.test.tsx
@@ -76,7 +76,7 @@ afterEach(() => {
 
 describe('Testing Left Drawer Wrapper component for the Event Dashboard', () => {
   test('Component should be rendered properly and the close menu button should function', async () => {
-    const { queryByText, queryByTestId } = render(
+    const { queryByText, getByTestId } = render(
       <MockedProvider mocks={mocks}>
         <BrowserRouter>
           <I18nextProvider i18n={i18nForTest}>
@@ -86,9 +86,15 @@ describe('Testing Left Drawer Wrapper component for the Event Dashboard', () => 
       </MockedProvider>
     );
 
+    const pageContainer = getByTestId('mainpageright');
+    expect(pageContainer.className).toMatch(/pageContainer/i);
+    fireEvent.click(getByTestId('closeLeftDrawerBtn') as HTMLElement);
+    expect(pageContainer.className).toMatch(/expand/i);
+    fireEvent.click(getByTestId('closeLeftDrawerBtn') as HTMLElement);
+    expect(pageContainer.className).toMatch(/contract/i);
+
     await waitFor(() =>
       expect(queryByText('Event Management')).toBeInTheDocument()
     );
-    fireEvent.click(queryByTestId('closeLeftDrawerBtn') as HTMLElement);
   });
 });


### PR DESCRIPTION
Update test for LeftDrawerEventWrapper.tsx to 100% coverage.
Fixes #1033

**Summary**
Added tests which covers line 40, where pageContainer was not previously tested for 'expand' or 'contract' class. 

**Does this PR introduce a breaking change?**
No

**Other information**
Chose to use Regex because pageContainer classes somehow had extra suffix added in like "_pageContainer_1k3kw_1" which .toHaveClass method cannot assert properly. 


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes 