### PR TITLE
fix: Update post removes photos or videos

### DIFF
--- a/src/components/OrgPostCard/OrgPostCard.tsx
+++ b/src/components/OrgPostCard/OrgPostCard.tsx
@@ -42,7 +42,8 @@ export default function OrgPostCard(
     postvideo: '',
     pinned: false,
   });
-
+  const [postPhotoUpdated, setPostPhotoUpdated] = useState(false);
+  const [postVideoUpdated, setPostVideoUpdated] = useState(false);
   const [togglePost, setPostToggle] = useState('Read more');
   const [showEditModal, setShowEditModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -80,6 +81,8 @@ export default function OrgPostCard(
       postvideo: props.postVideo,
       pinned: props.pinned,
     });
+    setPostPhotoUpdated(false);
+    setPostVideoUpdated(false);
     setShowEditModal((prev) => !prev);
   };
   const toggleShowDeleteModal = (): void => setShowDeleteModal((prev) => !prev);
@@ -105,6 +108,7 @@ export default function OrgPostCard(
       ...postformState,
       postphoto: '',
     });
+    setPostPhotoUpdated(true);
     const fileInput = document.getElementById(
       'postImageUrl'
     ) as HTMLInputElement;
@@ -118,6 +122,7 @@ export default function OrgPostCard(
       ...postformState,
       postvideo: '',
     });
+    setPostVideoUpdated(true);
     const fileInput = document.getElementById(
       'postVideoUrl'
     ) as HTMLInputElement;
@@ -201,24 +206,15 @@ export default function OrgPostCard(
     e.preventDefault();
 
     try {
-      const imageInput = document.getElementById(
-        'postImageUrl'
-      ) as HTMLInputElement;
-      const videoInput = document.getElementById(
-        'postVideoUrl'
-      ) as HTMLInputElement;
-
       const { data } = await updatePostMutation({
         variables: {
           id: props.id,
           title: postformState.posttitle,
           text: postformState.postinfo,
-          ...((postformState.postphoto !== null ||
-            (imageInput && imageInput.value === '')) && {
+          ...(postPhotoUpdated && {
             imageUrl: postformState.postphoto,
           }),
-          ...((postformState.postvideo !== null ||
-            (videoInput && videoInput.value === '')) && {
+          ...(postVideoUpdated && {
             videoUrl: postformState.postvideo,
           }),
         },
@@ -533,7 +529,7 @@ export default function OrgPostCard(
                       ...prevPostFormState,
                       postphoto: '',
                     }));
-
+                    setPostPhotoUpdated(true);
                     const file = e.target.files?.[0];
                     if (file) {
                       setPostFormState({
@@ -582,6 +578,7 @@ export default function OrgPostCard(
                       ...prevPostFormState,
                       postvideo: '',
                     }));
+                    setPostVideoUpdated(true);
                     const target = e.target as HTMLInputElement;
                     const file = target.files && target.files[0];
                     if (file) {

--- a/src/components/OrgPostCard/OrgPostCard.tsx
+++ b/src/components/OrgPostCard/OrgPostCard.tsx
@@ -201,24 +201,26 @@ export default function OrgPostCard(
     e.preventDefault();
 
     try {
-      let imageUrl = null;
-      let videoUrl = null;
-
-      if (e.target?.postphoto && e.target?.postphoto.files.length > 0) {
-        imageUrl = postformState.postphoto;
-      }
-
-      if (e.target?.postvideo && e.target?.postvideo.files.length > 0) {
-        videoUrl = postformState.postvideo;
-      }
+      const imageInput = document.getElementById(
+        'postImageUrl'
+      ) as HTMLInputElement;
+      const videoInput = document.getElementById(
+        'postVideoUrl'
+      ) as HTMLInputElement;
 
       const { data } = await updatePostMutation({
         variables: {
           id: props.id,
           title: postformState.posttitle,
           text: postformState.postinfo,
-          ...(imageUrl !== null && { imageUrl }),
-          ...(videoUrl !== null && { videoUrl }),
+          ...((postformState.postphoto !== null ||
+            (imageInput && imageInput.value === '')) && {
+            imageUrl: postformState.postphoto,
+          }),
+          ...((postformState.postvideo !== null ||
+            (videoInput && videoInput.value === '')) && {
+            videoUrl: postformState.postvideo,
+          }),
         },
       });
 

--- a/src/components/OrgPostCard/OrgPostCard.tsx
+++ b/src/components/OrgPostCard/OrgPostCard.tsx
@@ -217,8 +217,8 @@ export default function OrgPostCard(
           id: props.id,
           title: postformState.posttitle,
           text: postformState.postinfo,
-          imageUrl,
-          videoUrl,
+          ...(imageUrl !== null && { imageUrl }),
+          ...(videoUrl !== null && { videoUrl }),
         },
       });
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

### Before:
Image or Video used to automatically removed if user wants to update other fields in Post.
### After:
Fixed removing of image or videos if user doesn't want to update or remove image or videos.

**Issue Number:**

Fixes #1110 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

https://github.com/PalisadoesFoundation/talawa-admin/assets/109150688/71c5a1ba-19ec-499b-b04d-ba7fb5f63272


**Summary**
Post used to update with null fields of images or videos, if user doesn't reupload it. Now query will not send null fields of images or videos.

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
