### PR TITLE
Bug Fix: Frontend now reflects advertisement deletion, aligning with backend.

### DIFF
--- a/src/components/Advertisements/core/AdvertisementEntry/AdvertisementEntry.tsx
+++ b/src/components/Advertisements/core/AdvertisementEntry/AdvertisementEntry.tsx
@@ -5,6 +5,7 @@ import { Button, Card, Col, Row, Spinner } from 'react-bootstrap';
 import { DELETE_ADVERTISEMENT_BY_ID } from 'GraphQl/Mutations/mutations';
 import { useMutation } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
+import { ADVERTISEMENTS_GET } from 'GraphQl/Queries/Queries';
 interface InterfaceAddOnEntryProps {
   id: string;
   name: string;
@@ -27,7 +28,9 @@ function advertisementEntry({
 }: InterfaceAddOnEntryProps): JSX.Element {
   const { t } = useTranslation('translation', { keyPrefix: 'advertisement' });
   const [buttonLoading, setButtonLoading] = useState(false);
-  const [deleteAdById] = useMutation(DELETE_ADVERTISEMENT_BY_ID);
+  const [deleteAdById] = useMutation(DELETE_ADVERTISEMENT_BY_ID, {
+    refetchQueries: [ADVERTISEMENTS_GET],
+  });
 
   const onDelete = async (): Promise<void> => {
     setButtonLoading(true);


### PR DESCRIPTION

**What kind of change does this PR introduce?**
- Before 
  - Upon deleting the advertisement, it is expected to be removed from the backend and no longer displayed on the frontend. However, despite deletion on the backend, the advertisement continues to appear on the frontend.
- After
  - Now Deletion will reflect to both frontend and backend

**Issue Number:**

Fixes #1109 

**Did you add tests for your changes?**

- No

**Snapshots/Videos:**

- Before 

[Delete_Bug.webm](https://github.com/PalisadoesFoundation/talawa-admin/assets/66772290/f8671b76-b3eb-4b4b-948f-79854babfee8)

- After


[Fixes_Delete_bug.webm](https://github.com/PalisadoesFoundation/talawa-admin/assets/66772290/239ceedd-5bd9-4e3f-8769-2b8614c61d74)




**If relevant, did you update the documentation?**


**Summary**
- Now when user will delete the advertisement it will refelect to frontend as well.

**Does this PR introduce a breaking change?**
- No

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

- Yes
