### PR TITLE
Bug Fixes : On Creating advertisement page get reloaded

### DIFF
--- a/src/components/Advertisements/core/AdvertisementRegister/AdvertisementRegister.tsx
+++ b/src/components/Advertisements/core/AdvertisementRegister/AdvertisementRegister.tsx
@@ -6,6 +6,7 @@ import { useMutation } from '@apollo/client';
 import { ADD_ADVERTISEMENT_MUTATION } from 'GraphQl/Mutations/mutations';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'react-toastify';
+import { ADVERTISEMENTS_GET } from 'GraphQl/Queries/Queries';
 import dayjs from 'dayjs';
 
 interface InterfaceAddOnRegisterProps {
@@ -31,7 +32,9 @@ function advertisementRegister({
 
   const handleClose = (): void => setShow(false);
   const handleShow = (): void => setShow(true);
-  const [create] = useMutation(ADD_ADVERTISEMENT_MUTATION);
+  const [create] = useMutation(ADD_ADVERTISEMENT_MUTATION, {
+    refetchQueries: [ADVERTISEMENTS_GET],
+  });
 
   //getting orgId from URL
   const currentOrg = window.location.href.split('/id=')[1] + '';
@@ -59,9 +62,15 @@ function advertisementRegister({
 
       if (data) {
         toast.success('Advertisement created successfully');
-        setTimeout(() => {
-          window.location.reload();
-        }, 2000);
+        setFormState({
+          name: '',
+          link: '',
+          type: 'BANNER',
+          startDate: new Date(),
+          endDate: new Date(),
+          orgId: currentOrg,
+        });
+        handleClose();
       }
     } catch (error) {
       console.log('error occured', error);


### PR DESCRIPTION

**What kind of change does this PR introduce?**
- Resolves the bug where the page was refreshing unexpectedly upon creating a new advertisement in the Advertisement Section.

**Issue Number:**

Fixes #1115 

**Did you add tests for your changes?**

- No

**Snapshots/Videos:**
- Before 

[cinnamon-2023-12-02T215527+0530.webm](https://github.com/PalisadoesFoundation/talawa-admin/assets/66772290/1e4b369f-5636-41ea-8951-4286d36d6cb8)


- After



[cinnamon-2023-12-02T223826+0530.webm](https://github.com/PalisadoesFoundation/talawa-admin/assets/66772290/81ba3e40-4971-4caa-8f03-4ffd431441af)



**If relevant, did you update the documentation?**
- No 

**Summary**
- The current issue in the Advertisement Section involves an unexpected page refresh after creating a new advertisement. This behavior is attributed to the use of window.location.reload(). The proposed solution in the Pull Request (PR) aims to address this bug by removing the window.location.reload() statement, preventing the page from refreshing automatically. 

**Does this PR introduce a breaking change?**

- No

**Other information**

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
