### PR TITLE
Fixed the bug in pinned post functionality

### DIFF
--- a/src/GraphQl/Queries/Queries.ts
+++ b/src/GraphQl/Queries/Queries.ts
@@ -617,6 +617,7 @@ export const ORGANIZATION_POST_CONNECTION_LIST = gql`
           firstName
           lastName
         }
+        pinned
       }
     }
   }


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Bug fix

**Issue Number:**

Fixes #1121

**Snapshots/Videos:**

[www_screencapture_com_2023-12-5_17_12.webm](https://github.com/PalisadoesFoundation/talawa-admin/assets/97614113/18a10c60-6c89-4844-b186-0fa07e3521cd)


**Summary**

The query to fetch all the posts for an organization was missing pinned attribute.
Added the "pinned" in the query.

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
