### PR TITLE
Fixed admin card navigation in dashboard

### DIFF
--- a/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
@@ -137,7 +137,7 @@ function organizationDashboard(): JSX.Element {
                   role="button"
                   className="mb-4"
                   onClick={(): void => {
-                    history.push(peopleLink);
+                    history.push(peopleLink, { role: 1 });
                   }}
                 >
                   <DashBoardCard

--- a/src/screens/OrganizationPeople/OrganizationPeople.tsx
+++ b/src/screens/OrganizationPeople/OrganizationPeople.tsx
@@ -1,6 +1,7 @@
 import { useLazyQuery } from '@apollo/client';
 import dayjs from 'dayjs';
 import React, { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Container, Form } from 'react-bootstrap';
 import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
@@ -28,9 +29,12 @@ function organizationPeople(): JSX.Element {
 
   document.title = t('title');
 
+  const location = useLocation();
+  const role = location?.state as any;
+
   const currentUrl = window.location.href.split('=')[1];
 
-  const [state, setState] = useState(0);
+  const [state, setState] = useState(role?.role || 0);
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(5);
 

--- a/src/screens/OrganizationPeople/OrganizationPeople.tsx
+++ b/src/screens/OrganizationPeople/OrganizationPeople.tsx
@@ -22,6 +22,10 @@ import styles from './OrganizationPeople.module.css';
 
 import { toast } from 'react-toastify';
 
+interface InterfaceLocationState {
+  role: number;
+}
+
 function organizationPeople(): JSX.Element {
   const { t } = useTranslation('translation', {
     keyPrefix: 'organizationPeople',
@@ -29,8 +33,8 @@ function organizationPeople(): JSX.Element {
 
   document.title = t('title');
 
-  const location = useLocation();
-  const role = location?.state as any;
+  const location = useLocation<InterfaceLocationState>();
+  const role = location?.state;
 
   const currentUrl = window.location.href.split('=')[1];
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**

Fixes #1126 

**Snapshots/Videos:**

[www_screencapture_com_2023-12-9_04_32.webm](https://github.com/PalisadoesFoundation/talawa-admin/assets/97614113/4b40a760-1c65-4159-8eb3-90e4bed3aa79)

**Summary**

Earlier on clicking on the admin card the user was navigated to members section in Talawa Members. Fixed the navigation to direct it to admin section in Talawa Members.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
