### PR TITLE
Fixed postion of 'All Organizations' button and changed its name

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -47,7 +47,7 @@
   "leftDrawer": {
     "talawaAdminPortal": "Talawa Admin Portal",
     "menu": "Menu",
-    "organizations": "Organizations",
+    "my organizations": "My Organizations",
     "requests": "Requests",
     "users": "Users",
     "logout": "Logout"
@@ -84,7 +84,7 @@
     "designation": "Designation",
     "email": "Email",
     "searchByName": "Search By Name",
-    "organizations": "Organizations",
+    "my organizations": "My Organizations",
     "createOrganization": "Create Organization",
     "createSampleOrganization": "Create Sample Organization",
     "description": "Description",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -42,7 +42,7 @@
   "leftDrawer": {
     "talawaAdminPortal": "Portail d'administration Talawa",
     "menu": "Menu",
-    "organizations": "Organisations",
+    "my organizations": "Mes Organisations",
     "requests": "Demandes",
     "users": "Utilisateurs",
     "logout": "Déconnexion"
@@ -78,7 +78,7 @@
     "designation": "La désignation",
     "email": "E-mail",
     "searchByName": "Rechercher par nom",
-    "organizations": "Organisations",
+    "my organizations": "Mes Organisations",
     "createOrganization": "Créer une organisation",
     "createSampleOrganization": "Créer une organisation d'exemple",
     "description": "La description",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -42,7 +42,7 @@
   "leftDrawer": {
     "talawaAdminPortal": "तलावा व्यवस्थापक पोर्टल",
     "menu": "मेन्यू",
-    "organizations": "संगठन",
+    "my organizations": "मेरे संगठन",
     "requests": "अनुरोध",
     "users": "उपयोगकर्ता",
     "logout": "लॉग आउट"
@@ -78,7 +78,7 @@
     "designation": "पद",
     "email": "ईमेल",
     "searchByName": "नाम से खोजें",
-    "organizations": "संगठन",
+    "my organizations": "मेरे संगठन",
     "createOrganization": "संगठन बनाएं",
     "createSampleOrganization": " सैंपल संगठन बनाएं",
     "description": "विवरण",

--- a/public/locales/sp.json
+++ b/public/locales/sp.json
@@ -42,7 +42,7 @@
   "leftDrawer": {
     "talawaAdminPortal": "Portal de administración de Talawa",
     "menu": "Menú",
-    "organizations": "Organizaciones",
+    "my organizations": "Mis Organizaciones",
     "requests": "Solicitudes",
     "users": "Usuarios",
     "logout": "Cerrar sesión"
@@ -78,7 +78,7 @@
     "designation": "Designacion",
     "email": "Correo electrónico",
     "searchByName": "Buscar por nombre",
-    "organizations": "Organizaciones",
+    "my organizations": "Mis Organizaciones.",
     "createOrganization": "Crear organización",
     "createSampleOrganization": "Crear organización de muestra",
     "description": "Descripción",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -42,7 +42,7 @@
   "leftDrawer": {
     "talawaAdminPortal": "塔拉瓦管理门户",
     "menu": "菜单",
-    "organizations": "组织",
+    "my organizations": "我的组织",
     "requests": "请求",
     "users": "用户",
     "logout": "退出登录"
@@ -78,7 +78,7 @@
     "designation": "指定",
     "email": "電子郵件",
     "searchByName": "按名稱搜索",
-    "organizations": "组织",
+    "my organizations": "我的组织",
     "createOrganization": "創建組織",
     "createSampleOrganization": "创建示范组织",
     "description": "描述",

--- a/src/components/IconComponent/IconComponent.test.tsx
+++ b/src/components/IconComponent/IconComponent.test.tsx
@@ -32,8 +32,8 @@ const screenTestIdMap: Record<string, Record<string, string>> = {
     testId: 'Icon-Component-SettingsIcon',
   },
   AllOrganizations: {
-    name: 'All Organizations',
-    testId: 'Icon-Component-AllOrganizationsIcon',
+    name: 'My Organizations',
+    testId: 'Icon-Component-MyOrganizationsIcon',
   },
   EventProject: {
     name: 'Add Event Project',

--- a/src/components/IconComponent/IconComponent.tsx
+++ b/src/components/IconComponent/IconComponent.tsx
@@ -22,6 +22,13 @@ export interface InterfaceIconComponent {
 
 const iconComponent = (props: InterfaceIconComponent): JSX.Element => {
   switch (props.name) {
+    case 'My Organizations':
+      return (
+        <OrganizationsIcon
+          stroke={props.fill}
+          data-testid="Icon-Component-MyOrganizationsIcon"
+        />
+      );
     case 'Dashboard':
       return (
         <DashboardIcon {...props} data-testid="Icon-Component-DashboardIcon" />
@@ -51,13 +58,6 @@ const iconComponent = (props: InterfaceIconComponent): JSX.Element => {
         <SettingsIcon
           stroke={props.fill}
           data-testid="Icon-Component-SettingsIcon"
-        />
-      );
-    case 'All Organizations':
-      return (
-        <OrganizationsIcon
-          stroke={props.fill}
-          data-testid="Icon-Component-AllOrganizationsIcon"
         />
       );
     case 'Add Event Project':

--- a/src/components/LeftDrawer/LeftDrawer.test.tsx
+++ b/src/components/LeftDrawer/LeftDrawer.test.tsx
@@ -19,7 +19,7 @@ const props = {
 
 const propsOrg: InterfaceLeftDrawerProps = {
   ...props,
-  screenName: 'Organizations',
+  screenName: 'My Organizations',
 };
 const propsReq: InterfaceLeftDrawerProps = {
   ...props,
@@ -66,7 +66,7 @@ afterEach(() => {
 });
 
 describe('Testing Left Drawer component for SUPERADMIN', () => {
-  test('Component should be rendered properly', () => {
+  test('Component should be rendered properly', async () => {
     localStorage.setItem('UserImage', '');
     localStorage.setItem('UserType', 'SUPERADMIN');
     render(
@@ -79,7 +79,7 @@ describe('Testing Left Drawer component for SUPERADMIN', () => {
       </MockedProvider>
     );
 
-    expect(screen.getByText('Organizations')).toBeInTheDocument();
+    expect(screen.getByText('My Organizations')).toBeInTheDocument();
     expect(screen.getByText('Requests')).toBeInTheDocument();
     expect(screen.getByText('Users')).toBeInTheDocument();
     expect(screen.getByText('Talawa Admin Portal')).toBeInTheDocument();
@@ -231,7 +231,7 @@ describe('Testing Left Drawer component for ADMIN', () => {
       </MockedProvider>
     );
 
-    expect(screen.getByText('Organizations')).toBeInTheDocument();
+    expect(screen.getByText('My Organizations')).toBeInTheDocument();
     expect(screen.getByText('Talawa Admin Portal')).toBeInTheDocument();
 
     expect(screen.getByText(/John Doe/i)).toBeInTheDocument();

--- a/src/components/LeftDrawer/LeftDrawer.test.tsx
+++ b/src/components/LeftDrawer/LeftDrawer.test.tsx
@@ -66,7 +66,7 @@ afterEach(() => {
 });
 
 describe('Testing Left Drawer component for SUPERADMIN', () => {
-  test('Component should be rendered properly', async () => {
+  test('Component should be rendered properly', () => {
     localStorage.setItem('UserImage', '');
     localStorage.setItem('UserType', 'SUPERADMIN');
     render(

--- a/src/components/LeftDrawer/LeftDrawer.tsx
+++ b/src/components/LeftDrawer/LeftDrawer.tsx
@@ -67,9 +67,11 @@ const leftDrawer = ({
         <h5 className={styles.titleHeader}>{t('menu')}</h5>
         <div className={styles.optionList}>
           <Button
-            variant={screenName === 'Organizations' ? 'success' : 'light'}
+            variant={screenName === 'My Organizations' ? 'success' : 'light'}
             className={`${
-              screenName === 'Organizations' ? 'text-white' : 'text-secondary'
+              screenName === 'My Organizations'
+                ? 'text-white'
+                : 'text-secondary'
             }`}
             data-testid="orgsBtn"
             onClick={(): void => {
@@ -85,7 +87,7 @@ const leftDrawer = ({
                 }`}
               />
             </div>
-            {t('organizations')}
+            {t('my organizations')}
           </Button>
           {userType === 'SUPERADMIN' && (
             <Button

--- a/src/components/LeftDrawer/LeftDrawer.tsx
+++ b/src/components/LeftDrawer/LeftDrawer.tsx
@@ -81,7 +81,7 @@ const leftDrawer = ({
             <div className={styles.iconWrapper}>
               <OrganizationsIcon
                 stroke={`${
-                  screenName === 'Organizations'
+                  screenName === 'My Organizations'
                     ? 'var(--bs-white)'
                     : 'var(--bs-secondary)'
                 }`}

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -270,7 +270,10 @@ function orgList(): JSX.Element {
 
   return (
     <>
-      <SuperAdminScreen title={t('organizations')} screenName="Organizations">
+      <SuperAdminScreen
+        title={t('my organizations')}
+        screenName="My Organizations"
+      >
         {/* Buttons Container */}
         <div className={styles.btnsContainer}>
           <div className={styles.input}>

--- a/src/state/reducers/routesReducer.test.ts
+++ b/src/state/reducers/routesReducer.test.ts
@@ -10,6 +10,7 @@ describe('Testing Routes reducer', () => {
       })
     ).toEqual({
       targets: [
+        { name: 'My Organizations', url: '/orglist/id=undefined' },
         { name: 'Dashboard', url: '/orgdash/id=undefined' },
         { name: 'People', url: '/orgpeople/id=undefined' },
         { name: 'Events', url: '/orgevents/id=undefined' },
@@ -30,10 +31,10 @@ describe('Testing Routes reducer', () => {
           ],
         },
         { name: 'Settings', url: '/orgsetting/id=undefined' },
-        { name: 'All Organizations', url: '/orglist/id=undefined' },
       ],
       configUrl: 'undefined',
       components: [
+        { name: 'My Organizations', comp_id: 'orglist', component: 'OrgList' },
         {
           name: 'Dashboard',
           comp_id: 'orgdash',
@@ -70,7 +71,6 @@ describe('Testing Routes reducer', () => {
           ],
         },
         { name: 'Settings', comp_id: 'orgsetting', component: 'OrgSettings' },
-        { name: 'All Organizations', comp_id: 'orglist', component: 'OrgList' },
         { name: '', comp_id: 'member', component: 'MemberDetail' },
       ],
     });
@@ -84,6 +84,7 @@ describe('Testing Routes reducer', () => {
       })
     ).toEqual({
       targets: [
+        { name: 'My Organizations', url: '/orglist/id=undefined' },
         { name: 'Dashboard', url: '/orgdash/id=undefined' },
         { name: 'People', url: '/orgpeople/id=undefined' },
         { name: 'Events', url: '/orgevents/id=undefined' },
@@ -101,11 +102,11 @@ describe('Testing Routes reducer', () => {
           ],
         },
         { name: 'Settings', url: '/orgsetting/id=undefined' },
-        { name: 'All Organizations', url: '/orglist/id=undefined' },
         { test: 'testupdate' },
       ],
       configUrl: 'undefined',
       components: [
+        { name: 'My Organizations', comp_id: 'orglist', component: 'OrgList' },
         {
           name: 'Dashboard',
           comp_id: 'orgdash',
@@ -142,7 +143,6 @@ describe('Testing Routes reducer', () => {
           ],
         },
         { name: 'Settings', comp_id: 'orgsetting', component: 'OrgSettings' },
-        { name: 'All Organizations', comp_id: 'orglist', component: 'OrgList' },
         { name: '', comp_id: 'member', component: 'MemberDetail' },
       ],
     });
@@ -156,6 +156,7 @@ describe('Testing Routes reducer', () => {
       })
     ).toEqual({
       targets: [
+        { name: 'My Organizations', url: '/orglist/id=undefined' },
         { name: 'Dashboard', url: '/orgdash/id=undefined' },
         { name: 'People', url: '/orgpeople/id=undefined' },
         { name: 'Events', url: '/orgevents/id=undefined' },
@@ -166,7 +167,6 @@ describe('Testing Routes reducer', () => {
         },
         { name: 'Advertisement', url: '/orgads/id=undefined' },
         { name: 'Settings', url: '/orgsetting/id=undefined' },
-        { name: 'All Organizations', url: '/orglist/id=undefined' },
         {
           comp_id: null,
           component: null,
@@ -183,6 +183,7 @@ describe('Testing Routes reducer', () => {
       ],
       configUrl: 'undefined',
       components: [
+        { name: 'My Organizations', comp_id: 'orglist', component: 'OrgList' },
         {
           name: 'Dashboard',
           comp_id: 'orgdash',
@@ -220,7 +221,6 @@ describe('Testing Routes reducer', () => {
           ],
         },
         { name: 'Settings', comp_id: 'orgsetting', component: 'OrgSettings' },
-        { name: 'All Organizations', comp_id: 'orglist', component: 'OrgList' },
         { name: '', comp_id: 'member', component: 'MemberDetail' },
       ],
     });

--- a/src/state/reducers/routesReducer.ts
+++ b/src/state/reducers/routesReducer.ts
@@ -63,6 +63,7 @@ export type TargetsType = {
 
 // Note: Routes with names appear on NavBar
 const components: ComponentType[] = [
+  { name: 'My Organizations', comp_id: 'orglist', component: 'OrgList' },
   { name: 'Dashboard', comp_id: 'orgdash', component: 'OrganizationDashboard' },
   { name: 'People', comp_id: 'orgpeople', component: 'OrganizationPeople' },
   { name: 'Events', comp_id: 'orgevents', component: 'OrganizationEvents' },
@@ -84,7 +85,6 @@ const components: ComponentType[] = [
   },
 
   { name: 'Settings', comp_id: 'orgsetting', component: 'OrgSettings' },
-  { name: 'All Organizations', comp_id: 'orglist', component: 'OrgList' },
   { name: '', comp_id: 'member', component: 'MemberDetail' },
 ];
 


### PR DESCRIPTION
What kind of change does this PR introduce?

This PR renames the "All Organizations" button to "My Organizations" and fixes its postion as specified in the issue.

Issue Number: #1123 

Fixes https://github.com/PalisadoesFoundation/talawa-admin/issues/1123

Did you add tests for your changes?

No

Snapshots/Videos:

https://github.com/PalisadoesFoundation/talawa-admin/assets/132701661/d7d35876-8f97-4bc9-84d6-7757f0fa7979

If relevant, did you update the documentation?

No

Summary

This pull request addresses the specified issue by renaming the "All Organizations" button to "My Organizations" and adjusting its position to enhance the UI/UX.

Does this PR introduce a breaking change?

No

Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?

Yes