### PR TITLE
Code Coverage for DeleteOrg.tsx

### DIFF
--- a/src/components/DeleteOrg/DeleteOrg.test.tsx
+++ b/src/components/DeleteOrg/DeleteOrg.test.tsx
@@ -63,6 +63,61 @@ describe('Delete Organization Component', () => {
     expect(window.location).toBeAt('/orgsetting/id=123');
   });
 
+  test('should render delete button if canDelete is true', () => {
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <DeleteOrg />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+    const deleteButton = screen.getByTestId(/openDeleteModalBtn/i);
+    expect(deleteButton).toBeInTheDocument();
+  });
+
+  test('should open delete modal when delete button is clicked', () => {
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <DeleteOrg />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+    const deleteButton = screen.getByTestId(/openDeleteModalBtn/i);
+    fireEvent.click(deleteButton);
+    const deleteModal = screen.getByTestId(/orgDeleteModal/i);
+    expect(deleteModal).toBeInTheDocument();
+  });
+
+  test('should close delete modal when close button is clicked', async () => {
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <DeleteOrg />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+    const deleteButton = screen.getByTestId(/openDeleteModalBtn/i);
+    fireEvent.click(deleteButton);
+    const closeButton = screen.getByTestId(/closeDelOrgModalBtn/i);
+    fireEvent.click(closeButton);
+    await act(async () => {
+      expect(screen.queryByTestId(/orgDeleteModal/i)).not.toBeInTheDocument();
+    });
+  });
+
   test('Delete organization functionality should work properly', async () => {
     window.location.assign('/orgsetting/id=123');
     localStorage.setItem('UserType', 'SUPERADMIN');


### PR DESCRIPTION


Fixes #1066

**Did you add tests for your changes?**
Yes 


**Summary**

## Test for Rendering Delete Button

This test checks if the delete button is rendered correctly when the `canDelete` prop is `true`. It renders the `DeleteOrg` component and then checks if the delete button (identified by the `data-testid` attribute `openDeleteModalBtn`) is present in the document.

## Test for Opening Delete Modal

This test checks if the delete modal appears when the delete button is clicked. It renders the `DeleteOrg` component, simulates a click event on the delete button, and then checks if the delete modal (identified by the `data-testid` attribute `orgDeleteModal`) is present in the document.

## Test for Closing Delete Modal

This test checks if the delete modal closes when the close button is clicked. It renders the `DeleteOrg` component, simulates a click event on the delete button to open the modal, simulates another click event on the close button (identified by the `data-testid` attribute `closeDelOrgModalBtn`), and then checks if the delete modal is not present in the document.

**Does this PR introduce a breaking change?**
No

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes