### PR TITLE
Test for code Coverage For DeleteOrg.tsx

### DIFF
--- a/src/components/DeleteOrg/DeleteOrg.test.tsx
+++ b/src/components/DeleteOrg/DeleteOrg.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import 'jest-location-mock';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
@@ -81,44 +81,6 @@ describe('Delete Organization Component', () => {
     screen.getByTestId(/deleteOrganizationBtn/i).click();
     expect(window.location).not.toBeNull();
   });
-  test('should handle deletion of non-sample organization', async () => {
-    window.location.assign('/orgsetting/id=123');
-    localStorage.setItem('UserType', 'SUPERADMIN');
-    render(
-      <MockedProvider addTypename={false} link={link}>
-        <BrowserRouter>
-          <Provider store={store}>
-            <I18nextProvider i18n={i18nForTest}>
-              <DeleteOrg />
-            </I18nextProvider>
-          </Provider>
-        </BrowserRouter>
-      </MockedProvider>
-    );
-    fireEvent.click(screen.getByTestId('openDeleteModalBtn'));
-    fireEvent.click(screen.getByTestId('deleteOrganizationBtn'));
-    await expect(screen.queryByTestId('orgDeleteModal')).toBeInTheDocument();
-    expect(window.location).not.toBeNull();
-  });
-  test('should handle deletion of sample organization', async () => {
-    window.location.assign('/orgsetting/id=123');
-    localStorage.setItem('UserType', 'SUPERADMIN');
-    render(
-      <MockedProvider addTypename={false} link={link}>
-        <BrowserRouter>
-          <Provider store={store}>
-            <I18nextProvider i18n={i18nForTest}>
-              <DeleteOrg />
-            </I18nextProvider>
-          </Provider>
-        </BrowserRouter>
-      </MockedProvider>
-    );
-    fireEvent.click(screen.getByTestId('openDeleteModalBtn'));
-    fireEvent.click(screen.getByTestId('deleteOrganizationBtn'));
-    await expect(screen.queryByTestId('orgDeleteModal')).toBeInTheDocument();
-    expect(window.location).not.toBeNull();
-  });
   test('should handle deletion failure gracefully', async () => {
     window.location.assign('/orgsetting/id=456'); // Using an ID that triggers a failure
     localStorage.setItem('UserType', 'SUPERADMIN');
@@ -137,5 +99,63 @@ describe('Delete Organization Component', () => {
     fireEvent.click(screen.getByTestId('openDeleteModalBtn'));
     fireEvent.click(screen.getByTestId('deleteOrganizationBtn'));
     expect(screen.queryByText(/Deletion failed!/i)).toBeNull();
+  });
+  test('should close the Delete Organization Modal when "Cancel" button is clicked', async () => {
+    window.location.assign('/orgsetting/id=123');
+    localStorage.setItem('UserType', 'SUPERADMIN');
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <DeleteOrg />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+    fireEvent.click(screen.getByTestId('openDeleteModalBtn'));
+    expect(screen.getByTestId('orgDeleteModal')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('closeDelOrgModalBtn'));
+    await waitFor(() => {
+      expect(screen.queryByTestId('orgDeleteModal')).toBeNull();
+    });
+    expect(window.location).toBeAt('/orgsetting/id=123');
+  });
+  test('should open the Delete Organization Modal when "Delete" button is clicked', async () => {
+    window.location.assign('/orgsetting/id=123');
+    localStorage.setItem('UserType', 'SUPERADMIN');
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <DeleteOrg />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+    fireEvent.click(screen.getByTestId('openDeleteModalBtn'));
+    expect(screen.getByTestId('orgDeleteModal')).toBeInTheDocument();
+    expect(window.location).toBeAt('/orgsetting/id=123');
+  });
+  test('render Delete Organization Modal when "Delete" button is clicked', async () => {
+    window.location.assign('/orgsetting/id=123');
+    localStorage.setItem('UserType', 'SUPERADMIN');
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <DeleteOrg />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+    fireEvent.click(screen.getByTestId('openDeleteModalBtn'));
+    expect(screen.getByTestId('orgDeleteModal')).toBeInTheDocument();
+    expect(window.location).toBeAt('/orgsetting/id=123');
   });
 });

--- a/src/components/DeleteOrg/DeleteOrg.test.tsx
+++ b/src/components/DeleteOrg/DeleteOrg.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import 'jest-location-mock';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
@@ -80,5 +80,62 @@ describe('Delete Organization Component', () => {
     screen.getByTestId(/openDeleteModalBtn/i).click();
     screen.getByTestId(/deleteOrganizationBtn/i).click();
     expect(window.location).not.toBeNull();
+  });
+  test('should handle deletion of non-sample organization', async () => {
+    window.location.assign('/orgsetting/id=123');
+    localStorage.setItem('UserType', 'SUPERADMIN');
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <DeleteOrg />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+    fireEvent.click(screen.getByTestId('openDeleteModalBtn'));
+    fireEvent.click(screen.getByTestId('deleteOrganizationBtn'));
+    await expect(screen.queryByTestId('orgDeleteModal')).toBeInTheDocument();
+    expect(window.location).not.toBeNull();
+  });
+  test('should handle deletion of sample organization', async () => {
+    window.location.assign('/orgsetting/id=123');
+    localStorage.setItem('UserType', 'SUPERADMIN');
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <DeleteOrg />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+    fireEvent.click(screen.getByTestId('openDeleteModalBtn'));
+    fireEvent.click(screen.getByTestId('deleteOrganizationBtn'));
+    await expect(screen.queryByTestId('orgDeleteModal')).toBeInTheDocument();
+    expect(window.location).not.toBeNull();
+  });
+  test('should handle deletion failure gracefully', async () => {
+    window.location.assign('/orgsetting/id=456'); // Using an ID that triggers a failure
+    localStorage.setItem('UserType', 'SUPERADMIN');
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <DeleteOrg />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    fireEvent.click(screen.getByTestId('openDeleteModalBtn'));
+    fireEvent.click(screen.getByTestId('deleteOrganizationBtn'));
+    expect(screen.queryByText(/Deletion failed!/i)).toBeNull();
   });
 });


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #1066 

**Did you add tests for your changes?**
Yes
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**

![Screenshot from 2023-12-21 11-31-35](https://github.com/PalisadoesFoundation/talawa-admin/assets/49303222/d31b73d5-b8e2-415c-b7a6-ed2773c48670)


**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->
### Handle Deletion Failure Gracefully:
-Objective: This test ensures that the DeleteOrg component handles deletion failure gracefully when attempting to delete an organization.


### Close Delete Organization Modal:
- Objective: This test verifies that the DeleteOrg component closes the Delete Organization Modal when the "Cancel" button is clicked.
### Open Delete Organization Modal:
- Objective: This test confirms that the DeleteOrg component opens the Delete Organization Modal when the "Delete" button is clicked.
### Render Delete Button:
- Objective: This test ensures that the  DeleteOrg component correctly renders the Delete button based on specified conditions.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes
