### PR TITLE
Add a dialog/toast when the API is unavailable, both at login and during the login session for both portals

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,6 +31,7 @@ import {
   REACT_APP_BACKEND_WEBSOCKET_URL,
 } from 'Constant/constant';
 import { refreshToken } from 'utils/getRefreshToken';
+import { toast } from 'react-toastify';
 
 const errorLink = onError(
   ({ graphQLErrors, networkError, operation, forward }) => {
@@ -55,6 +56,12 @@ const errorLink = onError(
       });
     } else if (networkError) {
       console.log(`[Network error]: ${networkError}`);
+      toast.error(
+        'API server unavailable. Check your connection or try again later',
+        {
+          toastId: 'apiServer',
+        }
+      );
     }
   }
 );


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix, feature request

**Issue Number:**

Fixes #1197 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**


https://github.com/PalisadoesFoundation/talawa-admin/assets/121512095/cac44b7d-8c1d-4e10-95d0-469f5df0e933



**If relevant, did you update the documentation?**

No

**Summary**

this change adds a toast/dialog whenever the API server connection is down during login or user session for both the portals

**Does this PR introduce a breaking change?**

No

**Other information**

N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
