### PR TITLE
Bug Fixes: Fix in blocked user card navigation

### DIFF
--- a/src/screens/BlockUser/BlockUser.test.tsx
+++ b/src/screens/BlockUser/BlockUser.test.tsx
@@ -367,6 +367,10 @@ describe('Testing Block/Unblock user screen', () => {
       </MockedProvider>
     );
 
+    await act(async () => {
+      userEvent.click(screen.getByTestId('userFilter'));
+    });
+    userEvent.click(screen.getByTestId('showMembers'));
     await wait();
 
     expect(screen.getByTestId('unBlockUser123')).toBeInTheDocument();
@@ -395,6 +399,10 @@ describe('Testing Block/Unblock user screen', () => {
         </BrowserRouter>
       </MockedProvider>
     );
+    await act(async () => {
+      userEvent.click(screen.getByTestId('userFilter'));
+    });
+    userEvent.click(screen.getByTestId('showMembers'));
 
     await wait();
 
@@ -424,6 +432,10 @@ describe('Testing Block/Unblock user screen', () => {
         </BrowserRouter>
       </MockedProvider>
     );
+    await act(async () => {
+      userEvent.click(screen.getByTestId('userFilter'));
+    });
+    userEvent.click(screen.getByTestId('showMembers'));
 
     await wait();
 
@@ -461,6 +473,11 @@ describe('Testing Block/Unblock user screen', () => {
         </BrowserRouter>
       </MockedProvider>
     );
+
+    await act(async () => {
+      userEvent.click(screen.getByTestId('userFilter'));
+    });
+    userEvent.click(screen.getByTestId('showMembers'));
 
     await wait();
 
@@ -576,6 +593,10 @@ describe('Testing Block/Unblock user screen', () => {
         </BrowserRouter>
       </MockedProvider>
     );
+    await act(async () => {
+      userEvent.click(screen.getByTestId('userFilter'));
+    });
+    userEvent.click(screen.getByTestId('showMembers'));
 
     await wait();
 

--- a/src/screens/BlockUser/BlockUser.tsx
+++ b/src/screens/BlockUser/BlockUser.tsx
@@ -39,7 +39,7 @@ const Requests = (): JSX.Element => {
   const [membersData, setMembersData] = useState<InterfaceMember[]>([]);
   const [searchByFirstName, setSearchByFirstName] = useState<boolean>(true);
   const [searchByName, setSearchByName] = useState<string>('');
-  const [showBlockedMembers, setShowBlockedMembers] = useState<boolean>(false);
+  const [showBlockedMembers, setShowBlockedMembers] = useState<boolean>(true);
 
   const {
     data: memberData,


### PR DESCRIPTION

**What kind of change does this PR introduce?**
- This PR addresses a bug in the Talawa dashboard where clicking on the blocked user card from the dashboard navigates to the wrong section (all members screen instead of the blocked user screen) in the block/unblock section.

**Issue Number:**

Fixes #1120 

**Did you add tests for your changes?**

- Yes

**Snapshots/Videos:**
- Before  : It navigate directly to all members


[cinnamon-2023-12-23T011117+0530.webm](https://github.com/PalisadoesFoundation/talawa-admin/assets/66772290/59591c41-9a2a-4264-812a-f32419b62d40)


- After : It navigate to blocked members

[cinnamon-2023-12-23T011015+0530.webm](https://github.com/PalisadoesFoundation/talawa-admin/assets/66772290/2736c9a0-ba45-46c2-937f-a75ea4608e44)



**If relevant, did you update the documentation?**
- No

**Summary**
Now user will directly go to Blocked user table.

**Does this PR introduce a breaking change?**

- No

**Other information**

- : )

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

- Yes
