### PR TITLE
Fixed-Issue-#1259 Keeping the message in design when no posts is found.

### DIFF
--- a/src/components/NotFound/NotFound.module.css
+++ b/src/components/NotFound/NotFound.module.css
@@ -1,15 +1,13 @@
 .section {
-  position: relative;
-  margin: 20px auto;
-  width: 100%;
-  background-color: #fff;
-  padding: 4px;
-  border-radius: 0.5rem;
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
 }
 
 .error {
   font-size: 1.2rem;
-  color: #575656;
   font-weight: 500;
 }
 


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #1259 

**Did you add tests for your changes?**

Added some css to make the design uniform.

**Snapshots/Videos:**
![Screenshot from 2023-12-23 21-36-07](https://github.com/PalisadoesFoundation/talawa-admin/assets/99260988/3628f253-738c-4436-8a28-4e16c5f0ceac)






**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

**Other information**

I incorporated this design because it is also used in organization serch and elsewhere on the website when no elements related to the search are found, contributing to a uniform website design.

[Screencast from 2023-12-23 21-32-00.webm](https://github.com/PalisadoesFoundation/talawa-admin/assets/99260988/4e06bf6a-7ed1-4c07-b73a-388fa5442095)














**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
