### PR TITLE
Feature : Standardize the Pull Request GitHub Action to match Talawa API

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -60,10 +60,8 @@ jobs:
       - name: Checkout the Repository
         uses: actions/checkout@v3
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16.14.1'
+      - name: Install Dependencies
+        run: npm install --legacy-peer-deps
       
       - name: Get changed TypeScript files
         id: changed-files

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -20,10 +20,8 @@ env:
   CODECOV_UNIQUE_NAME: CODECOV_UNIQUE_NAME-${{ github.run_id }}-${{ github.run_number }}
 
 jobs:
-
-  Continuous-Integration:
-
-    name: Performs linting, formatting, type-checking, and testing on the application
+  Code-Quality-Checks:
+    name: Performs linting, formatting, type-checking
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the Repository
@@ -49,14 +47,32 @@ jobs:
         if: steps.changed-files.outputs.only_changed != 'true'
         run: npm run typecheck
 
+      - name: Run linting check
+        if: steps.changed-files.outputs.only_changed != 'true'
+        run: npm run lint:check  
+
+
+  Test-Application:
+    name: Test Application
+    runs-on: ubuntu-latest
+    needs: [Code-Quality-Checks]
+    steps:
+      - name: Checkout the Repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.14.1'
+      
+      - name: Get changed TypeScript files
+        id: changed-files
+        uses: tj-actions/changed-files@v40
+          
       - name: Run tests
         if: steps.changed-files.outputs.only_changed != 'true'
         run: npm run test -- --watchAll=false --coverage       
       
-      - name: Run linting check
-        if: steps.changed-files.outputs.only_changed != 'true'
-        run: npm run lint:check
-
       - name: TypeScript compilation for changed files
         run: |
           for file in ${{ steps.changed-files.outputs.all_files }}; do


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- This pull request standardizes TypeScript GitHub Action workflows by introducing two dedicated jobs: Code-Quality-Checks and Test-Application. The Code-Quality-Checks job handles  performing linting, formatting checks and type-error check while the Test-Application job, reliant on the former, focuses on testing the application. This change enhances workflow organization, promoting clear separation of code quality and testing concerns for improved maintainability.

**Issue Number:**

Fixes #1277 

**Did you add tests for your changes?**

- No

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

- This PR standardizes TypeScript workflows with two jobs: Code-Quality-Checks for linting, formatting, and package installation, and Test-Application for testing. The separation enhances workflow clarity and maintainability.

**Does this PR introduce a breaking change?**

- No

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

- Yes
