### PR TITLE
fix: sort button not displaying the selected option (#1297)

### DIFF
--- a/src/screens/OrgPost/OrgPost.tsx
+++ b/src/screens/OrgPost/OrgPost.tsx
@@ -253,12 +253,9 @@ function orgPost(): JSX.Element {
                     title="Sort Post"
                     data-testid="sort"
                   >
-                    <Dropdown.Toggle
-                      variant="outline-success"
-                      data-testid="sortpost"
-                    >
+                    <Dropdown.Toggle variant="success" data-testid="sortpost">
                       <SortIcon className={'me-1'} />
-                      {t('sortPost')}
+                      {sortingOption === 'latest' ? t('Latest') : t('Oldest')}
                     </Dropdown.Toggle>
                     <Dropdown.Menu>
                       <Dropdown.Item

--- a/src/screens/Users/Users.tsx
+++ b/src/screens/Users/Users.tsx
@@ -266,12 +266,9 @@ const Users = (): JSX.Element => {
                 title="Sort Users"
                 data-testid="sort"
               >
-                <Dropdown.Toggle
-                  variant="outline-success"
-                  data-testid="sortUsers"
-                >
+                <Dropdown.Toggle variant="success" data-testid="sortUsers">
                   <SortIcon className={'me-1'} />
-                  {t('sort')}
+                  {sortingOption === 'newest' ? t('Newest') : t('Oldest')}
                 </Dropdown.Toggle>
                 <Dropdown.Menu>
                   <Dropdown.Item


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- This PR addresses a bug in the Talawa dashboard where clicking on the sort button in the users and posts page doesn't show the selected sorting option in the button.

**Issue Number:**

Fixes #1297 

**Did you add tests for your changes?**

All Test cases passed

**Snapshots/Videos:**

https://github.com/PalisadoesFoundation/talawa-admin/assets/100997409/b02f29ed-f3e9-49d4-938d-b17caefccd5f


**Summary**

In the Users & Posts pages, when we use the sort functionality it doesn't show the currently selected sort option which creates confusion. So the proposed solution in the Pull Request (PR) aims to fix this by displaying the current sort option selected.

**Does this PR introduce a breaking change?**

No

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
