### PR TITLE
feat: after successful registration login tab opened on login page

### DIFF
--- a/src/screens/LoginPage/LoginPage.test.tsx
+++ b/src/screens/LoginPage/LoginPage.test.tsx
@@ -301,6 +301,54 @@ describe('Testing Login Page Screen', () => {
     userEvent.click(screen.getByTestId('registrationBtn'));
   });
 
+  test('switches to login tab on successful registration', async () => {
+    const formData = {
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'johndoe@gmail.com',
+      password: 'johndoe',
+      confirmPassword: 'johndoe',
+    };
+
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <LoginPage />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+
+    userEvent.click(screen.getByTestId(/goToRegisterPortion/i));
+    userEvent.type(
+      screen.getByPlaceholderText(/First Name/i),
+      formData.firstName
+    );
+    userEvent.type(
+      screen.getByPlaceholderText(/Last name/i),
+      formData.lastName
+    );
+    userEvent.type(screen.getByTestId(/signInEmail/i), formData.email);
+    userEvent.type(screen.getByPlaceholderText('Password'), formData.password);
+    userEvent.type(
+      screen.getByPlaceholderText('Confirm Password'),
+      formData.confirmPassword
+    );
+
+    userEvent.click(screen.getByTestId('registrationBtn'));
+
+    await wait();
+
+    // Check if the login tab is now active by checking for elements that only appear in the login tab
+    expect(screen.getByTestId('loginBtn')).toBeInTheDocument();
+    expect(screen.getByTestId('goToRegisterPortion')).toBeInTheDocument();
+  });
+
   test('Testing toggle login register portion', async () => {
     render(
       <MockedProvider addTypename={false} link={link}>

--- a/src/screens/LoginPage/LoginPage.tsx
+++ b/src/screens/LoginPage/LoginPage.tsx
@@ -143,6 +143,8 @@ function loginPage(): JSX.Element {
               'Successfully Registered. Please wait until you will be approved.'
             );
 
+            setShowTab('LOGIN');
+
             setSignFormState({
               signfirstName: '',
               signlastName: '',


### PR DESCRIPTION
- after the user is successfully registered, login tab is opened


**What kind of change does this PR introduce?**

Feature

**Issue Number:**

Fixes #1343 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

https://www.loom.com/share/060389b1e8c04dca935d05bfbe8784d5?sid=1087406d-319b-4dc4-b9bc-c2383a5cbddf

**If relevant, did you update the documentation?**

Not relevant

**Summary**

- When a new user is registered there's a toast about successful registration but user has to manually visit the login tab and then login.
- Now after a successful registration login tab is opened

**Does this PR introduce a breaking change?**

No breaking change


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
