### PR TITLE
Advertisement button in the left sidebar of talawa-admin dashboard not getting highlighted when active #1364

### DIFF
--- a/src/components/Advertisements/Advertisements.tsx
+++ b/src/components/Advertisements/Advertisements.tsx
@@ -95,7 +95,7 @@ export default function advertisements(): JSX.Element {
     <>
       <OrganizationScreen
         data-testid="AdEntryStore"
-        screenName="Advertisement Store"
+        screenName="Advertisement"
         title={t('title')}
       >
         <Row>


### PR DESCRIPTION

**What kind of change does this PR introduce?**
bug fix
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #<!--Add related issue number here.-->1364

**Did you add tests for your changes?**
No
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
![Screenshot (91)](https://github.com/PalisadoesFoundation/talawa-admin/assets/129819783/d52eb6fb-3641-4412-9a8c-0fb00097293c)

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**
This PR fixes issue #1364 where Advertisement button was not getting highlighted. This was caused as wrong Screenname was passed from Advertisement.tsx making the screenname and name as unequal.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->
The code follows the coding standards and guidelines outlined in the contributing guide.
[x] This change has been made against the develop branch.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
YES