### PR TITLE
refactor: standardized left drawer expansion/collapse methodology

### DIFF
--- a/src/components/LeftDrawer/LeftDrawer.module.css
+++ b/src/components/LeftDrawer/LeftDrawer.module.css
@@ -28,10 +28,6 @@
   animation: goToLeftBigScreen 0.5s ease-in-out;
 }
 
-.leftDrawer .closeModalBtn {
-  display: none;
-}
-
 .leftDrawer .talawaLogo {
   width: 100%;
   height: 65px;
@@ -127,31 +123,21 @@
     right: 0;
   }
 
-  .leftDrawer .closeModalBtn {
-    display: block;
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    z-index: 10;
-  }
-
-  /* For smaller devices .activeDrawer in real behaves like inactive */
-  .activeDrawer {
+  .inactiveDrawer {
     opacity: 0;
     left: 0;
     z-index: -1;
     animation: closeDrawer 0.4s ease-in-out;
   }
 
-  /* For smaller devices .inactiveDrawer in real behaves like active */
-  .inactiveDrawer {
+  .activeDrawer {
     display: flex;
     z-index: 100;
     animation: openDrawer 0.6s ease-in-out;
   }
 
   .logout {
-    margin-bottom: 1.5rem !important;
+    margin-bottom: 2.5rem !important;
   }
 }
 

--- a/src/components/LeftDrawer/LeftDrawer.test.tsx
+++ b/src/components/LeftDrawer/LeftDrawer.test.tsx
@@ -123,21 +123,6 @@ describe('Testing Left Drawer component for SUPERADMIN', () => {
     ).toBeTruthy();
   });
 
-  test('Testing Drawer open close functionality', () => {
-    localStorage.setItem('UserType', 'SUPERADMIN');
-    render(
-      <MockedProvider addTypename={false} link={link}>
-        <BrowserRouter>
-          <I18nextProvider i18n={i18nForTest}>
-            <LeftDrawer {...propsOrg} />
-          </I18nextProvider>
-        </BrowserRouter>
-      </MockedProvider>
-    );
-    const closeModalBtn = screen.getByTestId(/closeModalBtn/i);
-    userEvent.click(closeModalBtn);
-  });
-
   test('Testing Drawer when hideDrawer is null', () => {
     localStorage.setItem('UserType', 'SUPERADMIN');
     render(

--- a/src/components/LeftDrawer/LeftDrawer.tsx
+++ b/src/components/LeftDrawer/LeftDrawer.tsx
@@ -20,7 +20,6 @@ export interface InterfaceLeftDrawerProps {
 const leftDrawer = ({
   screenName,
   hideDrawer,
-  setHideDrawer,
 }: InterfaceLeftDrawerProps): JSX.Element => {
   const { t } = useTranslation('translation', { keyPrefix: 'leftDrawer' });
 
@@ -51,16 +50,6 @@ const leftDrawer = ({
         }`}
         data-testid="leftDrawerContainer"
       >
-        <Button
-          variant="danger"
-          className={styles.closeModalBtn}
-          onClick={(): void => {
-            setHideDrawer(false);
-          }}
-          data-testid="closeModalBtn"
-        >
-          <i className="fa fa-times"></i>
-        </Button>
         <TalawaLogo className={styles.talawaLogo} />
         <p className={styles.talawaText}>{t('talawaAdminPortal')}</p>
         <h5 className={styles.titleHeader}>{t('menu')}</h5>

--- a/src/components/LeftDrawerEvent/LeftDrawerEvent.module.css
+++ b/src/components/LeftDrawerEvent/LeftDrawerEvent.module.css
@@ -45,10 +45,6 @@
   animation: goToLeftBigScreen 0.5s ease-in-out;
 }
 
-.leftDrawer .closeModalBtn {
-  display: none;
-}
-
 .leftDrawer .brandingContainer {
   display: flex;
   justify-content: flex-start;
@@ -172,31 +168,21 @@
     right: 0;
   }
 
-  .leftDrawer .closeModalBtn {
-    display: block;
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    z-index: 10;
-  }
-
-  /* For smaller devices .activeDrawer in real behaves like inactive */
-  .activeDrawer {
+  .inactiveDrawer {
     opacity: 0;
     left: 0;
     z-index: -1;
     animation: closeDrawer 0.4s ease-in-out;
   }
 
-  /* For smaller devices .inactiveDrawer in real behaves like active */
-  .inactiveDrawer {
+  .activeDrawer {
     display: flex;
     z-index: 100;
     animation: openDrawer 0.6s ease-in-out;
   }
 
   .logout {
-    margin-bottom: 1.5rem !important;
+    margin-bottom: 2.5rem !important;
   }
 }
 

--- a/src/components/LeftDrawerEvent/LeftDrawerEvent.test.tsx
+++ b/src/components/LeftDrawerEvent/LeftDrawerEvent.test.tsx
@@ -172,21 +172,6 @@ describe('Testing Left Drawer component for the Event Dashboard', () => {
     );
   });
 
-  test('Testing Drawer open close functionality', () => {
-    localStorage.setItem('UserType', 'SUPERADMIN');
-    render(
-      <MockedProvider mocks={mocks}>
-        <BrowserRouter>
-          <I18nextProvider i18n={i18nForTest}>
-            <LeftDrawerEvent {...props} />
-          </I18nextProvider>
-        </BrowserRouter>
-      </MockedProvider>
-    );
-    const closeModalBtn = screen.getByTestId(/closeModalBtn/i);
-    userEvent.click(closeModalBtn);
-  });
-
   test('Testing logout functionality', async () => {
     localStorage.setItem('UserType', 'SUPERADMIN');
     render(

--- a/src/components/LeftDrawerEvent/LeftDrawerEvent.tsx
+++ b/src/components/LeftDrawerEvent/LeftDrawerEvent.tsx
@@ -29,7 +29,6 @@ export interface InterfaceLeftDrawerProps {
 const leftDrawerEvent = ({
   event,
   hideDrawer,
-  setHideDrawer,
   setShowAddEventProjectModal,
 }: InterfaceLeftDrawerProps): JSX.Element => {
   const [revokeRefreshToken] = useMutation(REVOKE_REFRESH_TOKEN);
@@ -58,18 +57,6 @@ const leftDrawerEvent = ({
         }`}
         data-testid="leftDrawerContainer"
       >
-        {/* Close Drawer Button for small devices */}
-        <Button
-          variant="danger"
-          className={styles.closeModalBtn}
-          onClick={(): void => {
-            setHideDrawer(false);
-          }}
-          data-testid="closeModalBtn"
-        >
-          <i className="fa fa-times"></i>
-        </Button>
-
         {/* Branding Section */}
         <div className={styles.brandingContainer}>
           <TalawaLogo className={styles.talawaLogo} />

--- a/src/components/LeftDrawerEvent/LeftDrawerEventWrapper.module.css
+++ b/src/components/LeftDrawerEvent/LeftDrawerEventWrapper.module.css
@@ -34,6 +34,9 @@
 }
 .opendrawer {
   position: fixed;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   top: 0;
   left: 0;
   width: 40px;
@@ -44,10 +47,6 @@
   border-radius: 0px;
   margin-right: 20px;
   color: black;
-}
-
-.mobileopenBtn {
-  display: none;
 }
 
 @media (max-width: 1120px) {
@@ -62,7 +61,11 @@
 /* For tablets */
 @media (max-width: 820px) {
   .pageContainer {
-    padding-left: 1.5rem;
+    padding-left: 2.5rem;
+  }
+
+  .opendrawer {
+    width: 25px;
   }
 
   .contract,
@@ -71,19 +74,8 @@
   }
 
   .collapseSidebarButton {
-    display: none;
-  }
-}
-
-@media (max-width: 820px) {
-  .pageContainer {
-    padding: 1rem;
-  }
-  .mobileopenBtn {
-    display: block;
-  }
-  .opendrawer,
-  .collapseSidebarButton {
-    display: none;
+    width: 100%;
+    left: 0;
+    right: 0;
   }
 }

--- a/src/components/LeftDrawerEvent/LeftDrawerEventWrapper.test.tsx
+++ b/src/components/LeftDrawerEvent/LeftDrawerEventWrapper.test.tsx
@@ -88,17 +88,34 @@ describe('Testing Left Drawer Wrapper component for the Event Dashboard', () => 
 
     const pageContainer = getByTestId('mainpageright');
     expect(pageContainer.className).toMatch(/pageContainer/i);
-    fireEvent.click(getByTestId('closeLeftDrawerBtn') as HTMLElement);
-    expect(pageContainer.className).toMatch(/expand/i);
-    fireEvent.click(getByTestId('closeLeftDrawerBtn') as HTMLElement);
-    expect(pageContainer.className).toMatch(/contract/i);
-
     await waitFor(() =>
       expect(queryByText('Event Management')).toBeInTheDocument()
     );
+    // Resize window to trigger handleResize
+    window.innerWidth = 800; // Set a width less than or equal to 820
+    fireEvent(window, new Event('resize'));
+
+    await waitFor(() => {
+      fireEvent.click(getByTestId('openMenu') as HTMLElement);
+    });
+
     // sets hideDrawer to true
-    fireEvent.click(getByTestId('menuBtn') as HTMLElement);
+    await waitFor(() => {
+      fireEvent.click(getByTestId('menuBtn') as HTMLElement);
+    });
+
+    // Resize window back to a larger width
+    window.innerWidth = 1000; // Set a larger width
+    fireEvent(window, new Event('resize'));
+
     // sets hideDrawer to false
-    fireEvent.click(getByTestId('openMenu') as HTMLElement);
+    await waitFor(() => {
+      fireEvent.click(getByTestId('openMenu') as HTMLElement);
+    });
+
+    // sets hideDrawer to true
+    await waitFor(() => {
+      fireEvent.click(getByTestId('menuBtn') as HTMLElement);
+    });
   });
 });

--- a/src/components/LeftDrawerEvent/LeftDrawerEventWrapper.tsx
+++ b/src/components/LeftDrawerEvent/LeftDrawerEventWrapper.tsx
@@ -1,6 +1,5 @@
-import MenuIcon from '@mui/icons-material/Menu';
 import LeftDrawerEvent from './LeftDrawerEvent';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Button from 'react-bootstrap/Button';
 import styles from './LeftDrawerEventWrapper.module.css';
 
@@ -21,16 +20,27 @@ export const LeftDrawerEventWrapper = (
   props: InterfacePropType
 ): JSX.Element => {
   const [hideDrawer, setHideDrawer] = useState<boolean | null>(null);
-  const toggleDrawerVisibility = (): void => {
-    setHideDrawer(!hideDrawer);
+  const handleResize = (): void => {
+    if (window.innerWidth <= 820) {
+      setHideDrawer(!hideDrawer);
+    }
   };
+  useEffect(() => {
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   return (
     <>
       {hideDrawer ? (
         <Button
           className={styles.opendrawer}
-          onClick={toggleDrawerVisibility}
+          onClick={(): void => {
+            setHideDrawer(!hideDrawer);
+          }}
           data-testid="openMenu"
         >
           <i className="fa fa-angle-double-right" aria-hidden="true"></i>
@@ -69,15 +79,6 @@ export const LeftDrawerEventWrapper = (
           <div style={{ flex: 1 }}>
             <h2>Event Management</h2>
           </div>
-          <Button
-            className={styles.mobileopenBtn}
-            onClick={(): void => {
-              setHideDrawer(!hideDrawer);
-            }}
-            data-testid="closeLeftDrawerBtn"
-          >
-            <MenuIcon fontSize="medium" />
-          </Button>
         </div>
         {props.children}
       </div>

--- a/src/components/LeftDrawerOrg/LeftDrawerOrg.module.css
+++ b/src/components/LeftDrawerOrg/LeftDrawerOrg.module.css
@@ -45,10 +45,6 @@
   animation: goToLeftBigScreen 0.5s ease-in-out;
 }
 
-.leftDrawer .closeModalBtn {
-  display: none;
-}
-
 .leftDrawer .brandingContainer {
   display: flex;
   justify-content: flex-start;
@@ -171,31 +167,21 @@
     right: 0;
   }
 
-  .leftDrawer .closeModalBtn {
-    display: block;
-    position: absolute;
-    top: 1rem;
-    right: 1rem;
-    z-index: 10;
-  }
-
-  /* For smaller devices .activeDrawer in real behaves like inactive */
-  .activeDrawer {
+  .inactiveDrawer {
     opacity: 0;
     left: 0;
     z-index: -1;
-    animation: closeDrawer 0.4s ease-in-out;
+    animation: closeDrawer 0.2s ease-in-out;
   }
 
-  /* For smaller devices .inactiveDrawer in real behaves like active */
-  .inactiveDrawer {
+  .activeDrawer {
     display: flex;
     z-index: 100;
-    animation: openDrawer 0.6s ease-in-out;
+    animation: openDrawer 0.4s ease-in-out;
   }
 
   .logout {
-    margin-bottom: 1.5rem;
+    margin-bottom: 2.5rem;
   }
 }
 

--- a/src/components/LeftDrawerOrg/LeftDrawerOrg.test.tsx
+++ b/src/components/LeftDrawerOrg/LeftDrawerOrg.test.tsx
@@ -358,23 +358,6 @@ describe('Testing Left Drawer component for SUPERADMIN', () => {
     );
   });
 
-  test('Testing Drawer open close functionality', () => {
-    localStorage.setItem('UserType', 'SUPERADMIN');
-    render(
-      <MockedProvider addTypename={false} link={link}>
-        <BrowserRouter>
-          <Provider store={store}>
-            <I18nextProvider i18n={i18nForTest}>
-              <LeftDrawerOrg {...props} />
-            </I18nextProvider>
-          </Provider>
-        </BrowserRouter>
-      </MockedProvider>
-    );
-    const closeModalBtn = screen.getByTestId(/closeModalBtn/i);
-    userEvent.click(closeModalBtn);
-  });
-
   test('Testing logout functionality', async () => {
     localStorage.setItem('UserType', 'SUPERADMIN');
     render(

--- a/src/components/LeftDrawerOrg/LeftDrawerOrg.tsx
+++ b/src/components/LeftDrawerOrg/LeftDrawerOrg.tsx
@@ -28,7 +28,6 @@ const leftDrawerOrg = ({
   targets,
   orgId,
   hideDrawer,
-  setHideDrawer,
 }: InterfaceLeftDrawerProps): JSX.Element => {
   const { t } = useTranslation('translation', { keyPrefix: 'leftDrawerOrg' });
   const [organization, setOrganization] =
@@ -83,18 +82,6 @@ const leftDrawerOrg = ({
         }`}
         data-testid="leftDrawerContainer"
       >
-        {/* Close Drawer Btn for small devices */}
-        <Button
-          variant="danger"
-          className={styles.closeModalBtn}
-          onClick={(): void => {
-            setHideDrawer(false);
-          }}
-          data-testid="closeModalBtn"
-        >
-          <i className="fa fa-times"></i>
-        </Button>
-
         {/* Branding Section */}
         <div className={styles.brandingContainer}>
           <TalawaLogo className={styles.talawaLogo} />

--- a/src/components/OrganizationScreen/OrganizationScreen.module.css
+++ b/src/components/OrganizationScreen/OrganizationScreen.module.css
@@ -34,6 +34,9 @@
 }
 .opendrawer {
   position: fixed;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   top: 0;
   left: 0;
   width: 40px;
@@ -46,9 +49,6 @@
   color: black;
 }
 
-.mobileopenBtn {
-  display: none;
-}
 @media (max-width: 1120px) {
   .contract {
     padding-left: calc(250px + 2rem + 1.5rem);
@@ -61,7 +61,11 @@
 /* For tablets */
 @media (max-width: 820px) {
   .pageContainer {
-    padding-left: 1.5rem;
+    padding-left: 2.5rem;
+  }
+
+  .opendrawer {
+    width: 25px;
   }
 
   .contract,
@@ -70,19 +74,8 @@
   }
 
   .collapseSidebarButton {
-    display: none;
-  }
-}
-
-@media (max-width: 820px) {
-  .pageContainer {
-    padding: 1rem;
-  }
-  .mobileopenBtn {
-    display: block;
-  }
-  .opendrawer,
-  .collapseSidebarButton {
-    display: none;
+    width: 100%;
+    left: 0;
+    right: 0;
   }
 }

--- a/src/components/OrganizationScreen/OrganizationScreen.test.tsx
+++ b/src/components/OrganizationScreen/OrganizationScreen.test.tsx
@@ -1,42 +1,62 @@
 import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
+import 'jest-location-mock';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { store } from 'state/store';
 import i18nForTest from 'utils/i18nForTest';
 import type { InterfaceOrganizationScreenProps } from './OrganizationScreen';
 import OrganizationScreen from './OrganizationScreen';
+import { ORGANIZATIONS_LIST } from 'GraphQl/Queries/Queries';
+import { StaticMockLink } from 'utils/StaticMockLink';
 
 const props: InterfaceOrganizationScreenProps = {
   title: 'Dashboard',
   screenName: 'Dashboard',
   children: <div>Testing ...</div>,
 };
-
-type SetScreenSize = () => void;
+const MOCKS = [
+  {
+    request: {
+      query: ORGANIZATIONS_LIST,
+      variables: { id: '123' },
+    },
+    result: {
+      data: {
+        organizations: [
+          {
+            _id: '123',
+            image: null,
+            creator: {
+              firstName: 'John',
+              lastName: 'Doe',
+              email: 'JohnDoe@example.com',
+            },
+            name: 'Test Organization',
+            description: 'Testing this organization',
+            location: 'Lucknow, India',
+            isPublic: true,
+            visibleInSearch: true,
+            members: [],
+            admins: [],
+            membershipRequests: [],
+            blockedUsers: [],
+          },
+        ],
+      },
+    },
+  },
+];
+const link = new StaticMockLink(MOCKS, true);
 
 describe('Testing LeftDrawer in OrganizationScreen', () => {
-  const setTabletScreenSize: SetScreenSize = () => {
-    Object.defineProperty(window, 'innerWidth', {
-      writable: true,
-      configurable: true,
-      value: 768, // Example: setting tablet width
-    });
-    Object.defineProperty(window, 'innerHeight', {
-      writable: true,
-      configurable: true,
-      value: 1024, // Example: setting tablet height
-    });
-    window.dispatchEvent(new Event('resize'));
-  };
   test('Testing LeftDrawer in page functionality', async () => {
     localStorage.setItem('UserType', 'SUPERADMIN');
 
     render(
-      <MockedProvider addTypename={false}>
+      <MockedProvider addTypename={false} link={link}>
         <BrowserRouter>
           <Provider store={store}>
             <I18nextProvider i18n={i18nForTest}>
@@ -46,34 +66,31 @@ describe('Testing LeftDrawer in OrganizationScreen', () => {
         </BrowserRouter>
       </MockedProvider>
     );
-    // sets hideDrawer to true
-    userEvent.click(screen.getByTestId('menuBtn'));
-    // sets hideDrawer to false
-    userEvent.click(screen.getByTestId('openMenu'));
-  });
+    // Resize window to trigger handleResize
+    window.innerWidth = 800; // Set a width less than or equal to 820
+    fireEvent(window, new Event('resize'));
 
-  test('Testing expanding and closing on a tablet-sized screen', async () => {
-    localStorage.setItem('UserType', 'SUPERADMIN');
-
-    // Render the component with tablet-sized screen
-    render(
-      <MockedProvider addTypename={false}>
-        <BrowserRouter>
-          <Provider store={store}>
-            <I18nextProvider i18n={i18nForTest}>
-              <OrganizationScreen {...props} />
-            </I18nextProvider>
-          </Provider>
-        </BrowserRouter>
-      </MockedProvider>
-    );
-
-    // Set the screen size to simulate a tablet
-    setTabletScreenSize();
+    await waitFor(() => {
+      fireEvent.click(screen.getByTestId('openMenu') as HTMLElement);
+    });
 
     // sets hideDrawer to true
-    userEvent.click(screen.getByTestId('menuBtnmobile'));
+    await waitFor(() => {
+      fireEvent.click(screen.getByTestId('menuBtn') as HTMLElement);
+    });
+
+    // Resize window back to a larger width
+    window.innerWidth = 1000; // Set a larger width
+    fireEvent(window, new Event('resize'));
+
     // sets hideDrawer to false
-    userEvent.click(screen.getByTestId('closeModalBtn'));
+    await waitFor(() => {
+      fireEvent.click(screen.getByTestId('openMenu') as HTMLElement);
+    });
+
+    // sets hideDrawer to true
+    await waitFor(() => {
+      fireEvent.click(screen.getByTestId('menuBtn') as HTMLElement);
+    });
   });
 });

--- a/src/components/OrganizationScreen/OrganizationScreen.tsx
+++ b/src/components/OrganizationScreen/OrganizationScreen.tsx
@@ -1,6 +1,5 @@
-import MenuIcon from '@mui/icons-material/Menu';
 import LeftDrawerOrg from 'components/LeftDrawerOrg/LeftDrawerOrg';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Button from 'react-bootstrap/Button';
 import styles from './OrganizationScreen.module.css';
 import { useSelector } from 'react-redux';
@@ -25,15 +24,27 @@ const organizationScreen = ({
   } = useSelector((state: RootState) => state.appRoutes);
   const { targets, configUrl } = appRoutes;
 
-  const toggleDrawerVisibility = (): void => {
-    setHideDrawer(!hideDrawer);
+  const handleResize = (): void => {
+    if (window.innerWidth <= 820) {
+      setHideDrawer(!hideDrawer);
+    }
   };
+  useEffect(() => {
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
   return (
     <>
       {hideDrawer ? (
         <Button
           className={styles.opendrawer}
-          onClick={toggleDrawerVisibility}
+          onClick={(): void => {
+            setHideDrawer(!hideDrawer);
+          }}
           data-testid="openMenu"
         >
           <i className="fa fa-angle-double-right" aria-hidden="true"></i>
@@ -72,15 +83,6 @@ const organizationScreen = ({
           <div style={{ flex: 1 }}>
             <h2>{title}</h2>
           </div>
-          <Button
-            className={styles.mobileopenBtn}
-            onClick={(): void => {
-              setHideDrawer(!hideDrawer);
-            }}
-            data-testid="menuBtnmobile"
-          >
-            <MenuIcon fontSize="medium" />
-          </Button>
         </div>
         {children}
       </div>

--- a/src/components/SuperAdminScreen/SuperAdminScreen.module.css
+++ b/src/components/SuperAdminScreen/SuperAdminScreen.module.css
@@ -34,6 +34,9 @@
 }
 .opendrawer {
   position: fixed;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   top: 0;
   left: 0;
   width: 40px;
@@ -44,10 +47,6 @@
   border-radius: 0px;
   margin-right: 20px;
   color: black;
-}
-
-.mobileopenBtn {
-  display: none;
 }
 
 @media (max-width: 1120px) {
@@ -62,7 +61,11 @@
 /* For tablets */
 @media (max-width: 820px) {
   .pageContainer {
-    padding-left: 1.5rem;
+    padding-left: 2.5rem;
+  }
+
+  .opendrawer {
+    width: 25px;
   }
 
   .contract,
@@ -71,21 +74,9 @@
   }
 
   .collapseSidebarButton {
-    display: none;
-  }
-}
-
-@media (max-width: 820px) {
-  .pageContainer {
-    padding: 1rem;
-  }
-
-  .mobileopenBtn {
-    display: block;
-  }
-  .opendrawer,
-  .collapseSidebarButton {
-    display: none;
+    width: 100%;
+    left: 0;
+    right: 0;
   }
 }
 

--- a/src/components/SuperAdminScreen/SuperAdminScreen.test.tsx
+++ b/src/components/SuperAdminScreen/SuperAdminScreen.test.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
-import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
-import 'jest-localstorage-mock';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import 'jest-location-mock';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
@@ -18,22 +16,7 @@ const props: InterfaceSuperAdminScreenProps = {
   children: <div>Testing ...</div>,
 };
 
-type SetScreenSize = () => void;
-
 describe('Testing LeftDrawer in SuperAdminScreen', () => {
-  const setTabletScreenSize: SetScreenSize = () => {
-    Object.defineProperty(window, 'innerWidth', {
-      writable: true,
-      configurable: true,
-      value: 768, // Example: setting tablet width
-    });
-    Object.defineProperty(window, 'innerHeight', {
-      writable: true,
-      configurable: true,
-      value: 1024, // Example: setting tablet height
-    });
-    window.dispatchEvent(new Event('resize'));
-  };
   test('Testing LeftDrawer in page functionality', async () => {
     localStorage.setItem('UserType', 'SUPERADMIN');
 
@@ -49,33 +32,31 @@ describe('Testing LeftDrawer in SuperAdminScreen', () => {
       </MockedProvider>
     );
 
-    // Expand LeftDrawer
-    userEvent.click(screen.getByTestId('menuBtn'));
-    // Contract LeftDrawer
-    userEvent.click(screen.getByTestId('openMenu'));
-  });
-  test('Testing expanding and closing on a tablet-sized screen', async () => {
-    localStorage.setItem('UserType', 'SUPERADMIN');
+    // Resize window to trigger handleResize
+    window.innerWidth = 800; // Set a width less than or equal to 820
+    fireEvent(window, new Event('resize'));
 
-    // Render the component with tablet-sized screen
-    render(
-      <MockedProvider addTypename={false}>
-        <BrowserRouter>
-          <Provider store={store}>
-            <I18nextProvider i18n={i18nForTest}>
-              <SuperAdminScreen {...props} />
-            </I18nextProvider>
-          </Provider>
-        </BrowserRouter>
-      </MockedProvider>
-    );
-
-    // Set the screen size to simulate a tablet
-    setTabletScreenSize();
+    await waitFor(() => {
+      fireEvent.click(screen.getByTestId('openMenu') as HTMLElement);
+    });
 
     // sets hideDrawer to true
-    userEvent.click(screen.getByTestId('menuBtnmobile'));
+    await waitFor(() => {
+      fireEvent.click(screen.getByTestId('menuBtn') as HTMLElement);
+    });
+
+    // Resize window back to a larger width
+    window.innerWidth = 1000; // Set a larger width
+    fireEvent(window, new Event('resize'));
+
     // sets hideDrawer to false
-    userEvent.click(screen.getByTestId('closeModalBtn'));
+    await waitFor(() => {
+      fireEvent.click(screen.getByTestId('openMenu') as HTMLElement);
+    });
+
+    // sets hideDrawer to true
+    await waitFor(() => {
+      fireEvent.click(screen.getByTestId('menuBtn') as HTMLElement);
+    });
   });
 });

--- a/src/components/SuperAdminScreen/SuperAdminScreen.tsx
+++ b/src/components/SuperAdminScreen/SuperAdminScreen.tsx
@@ -1,6 +1,5 @@
-import MenuIcon from '@mui/icons-material/Menu';
 import LeftDrawer from 'components/LeftDrawer/LeftDrawer';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import Button from 'react-bootstrap/Button';
 import styles from './SuperAdminScreen.module.css';
 
@@ -16,16 +15,27 @@ const superAdminScreen = ({
 }: InterfaceSuperAdminScreenProps): JSX.Element => {
   const [hideDrawer, setHideDrawer] = useState<boolean | null>(null);
 
-  const toggleDrawerVisibility = (): void => {
-    setHideDrawer(!hideDrawer);
+  const handleResize = (): void => {
+    if (window.innerWidth <= 820) {
+      setHideDrawer(!hideDrawer);
+    }
   };
+  useEffect(() => {
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
 
   return (
     <>
       {hideDrawer ? (
         <Button
           className={styles.opendrawer}
-          onClick={toggleDrawerVisibility}
+          onClick={(): void => {
+            setHideDrawer(!hideDrawer);
+          }}
           data-testid="openMenu"
         >
           <i className="fa fa-angle-double-right" aria-hidden="true"></i>
@@ -60,15 +70,6 @@ const superAdminScreen = ({
           <div style={{ flex: 1 }}>
             <h2>{title}</h2>
           </div>
-          <Button
-            className={styles.mobileopenBtn}
-            onClick={(): void => {
-              setHideDrawer(!hideDrawer);
-            }}
-            data-testid="menuBtnmobile"
-          >
-            <MenuIcon fontSize="medium" />
-          </Button>
         </div>
         {children}
       </div>

--- a/src/screens/OrgList/OrgList.test.tsx
+++ b/src/screens/OrgList/OrgList.test.tsx
@@ -153,7 +153,6 @@ describe('Organisations Page testing as SuperAdmin', () => {
     const createOrgBtn = screen.getByTestId(/createOrganizationBtn/i);
     expect(createOrgBtn).toBeInTheDocument();
     userEvent.click(createOrgBtn);
-    userEvent.click(screen.getByTestId(/closeModalBtn/i));
   });
 
   test('Create organization model should work properly', async () => {
@@ -214,7 +213,6 @@ describe('Organisations Page testing as SuperAdmin', () => {
         screen.queryByText(/Congratulation the Organization is created/i)
       ).toBeInTheDocument()
     );
-    userEvent.click(screen.getByTestId(/closeOrganizationModal/i));
   });
 
   test('Plugin Notification model should work properly', async () => {


### PR DESCRIPTION


**What kind of change does this PR introduce?**
This PR introduces the standardization of left drawer expansion and collapse through refactoring.

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
Fixes #1413 

**Did you add tests for your changes?**
Yes

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**

https://github.com/PalisadoesFoundation/talawa-admin/assets/112749383/8f5d58cf-905d-441b-9bc2-bf4113289118

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
No

<!--Add link to Talawa-Docs.-->

**Summary**
- Previously, screens with a width of <= 820px utilized the hamburger icon for left drawer handling.
- With this change, all screens, regardless of width, will now have a consistent left drawer handling method, which was previously exclusive to screens with a width > 820px.
- The superadmin screen, organization screen, and event dashboard screen are all affected by this change.
- All changes have been verified and covered by tests.
- This modification aims to establish consistency throughout the entire application.

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes

<!--Yes or No-->
