### PR TITLE
Fix orgList screen refreshing entire data on load more orgs

### DIFF
--- a/src/GraphQl/Mutations/mutations.ts
+++ b/src/GraphQl/Mutations/mutations.ts
@@ -84,13 +84,21 @@ export const ADDRESS_DETAILS_FRAGMENT = gql`
 
 export const UPDATE_USER_MUTATION = gql`
   mutation UpdateUserProfile(
+    $id: ID
     $firstName: String
     $lastName: String
     $email: EmailAddress
+    $applangcode: String
     $file: String
   ) {
     updateUserProfile(
-      data: { firstName: $firstName, lastName: $lastName, email: $email }
+      data: {
+        firstName: $firstName
+        lastName: $lastName
+        email: $email
+        id: $id
+        applangcode: $applangcode
+      }
       file: $file
     ) {
       _id

--- a/src/GraphQl/Mutations/mutations.ts
+++ b/src/GraphQl/Mutations/mutations.ts
@@ -84,21 +84,13 @@ export const ADDRESS_DETAILS_FRAGMENT = gql`
 
 export const UPDATE_USER_MUTATION = gql`
   mutation UpdateUserProfile(
-    $id: ID
     $firstName: String
     $lastName: String
     $email: EmailAddress
-    $applangcode: String
     $file: String
   ) {
     updateUserProfile(
-      data: {
-        firstName: $firstName
-        lastName: $lastName
-        email: $email
-        id: $id
-        applangcode: $applangcode
-      }
+      data: { firstName: $firstName, lastName: $lastName, email: $email }
       file: $file
     ) {
       _id

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -464,50 +464,49 @@ function orgList(): JSX.Element {
                 </div>
               }
             >
-              {isLoading ? (
-                <>
-                  {[...Array(perPageResult)].map((_, index) => (
-                    <div key={index} className={styles.itemCard}>
-                      <div className={styles.loadingWrapper}>
-                        <div className={styles.innerContainer}>
-                          <div
-                            className={`${styles.orgImgContainer} shimmer`}
-                          ></div>
-                          <div className={styles.content}>
-                            <h5 className="shimmer" title="Org name"></h5>
-                            <h6 className="shimmer" title="Location"></h6>
-                            <h6 className="shimmer" title="Admins"></h6>
-                            <h6 className="shimmer" title="Members"></h6>
-                          </div>
-                        </div>
-                        <div className={`shimmer ${styles.button}`} />
-                      </div>
-                    </div>
-                  ))}
-                </>
-              ) : userData && userData.user.userType == 'SUPERADMIN' ? (
-                orgsData?.organizationsConnection.map((item) => {
-                  return (
-                    <div key={item._id} className={styles.itemCard}>
-                      <OrgListCard data={item} />
-                    </div>
-                  );
-                })
-              ) : (
-                userData &&
-                userData.user.userType == 'ADMIN' &&
-                userData.user.adminFor.length > 0 &&
-                orgsData?.organizationsConnection.map((item) => {
-                  if (isAdminForCurrentOrg(item)) {
+              {userData && userData.user.userType == 'SUPERADMIN'
+                ? orgsData?.organizationsConnection.map((item) => {
                     return (
                       <div key={item._id} className={styles.itemCard}>
                         <OrgListCard data={item} />
                       </div>
                     );
-                  }
-                })
-              )}
+                  })
+                : userData &&
+                  userData.user.userType == 'ADMIN' &&
+                  userData.user.adminFor.length > 0 &&
+                  orgsData?.organizationsConnection.map((item) => {
+                    if (isAdminForCurrentOrg(item)) {
+                      return (
+                        <div key={item._id} className={styles.itemCard}>
+                          <OrgListCard data={item} />
+                        </div>
+                      );
+                    }
+                  })}
             </InfiniteScroll>
+            {isLoading && (
+              <>
+                {[...Array(perPageResult)].map((_, index) => (
+                  <div key={index} className={styles.itemCard}>
+                    <div className={styles.loadingWrapper}>
+                      <div className={styles.innerContainer}>
+                        <div
+                          className={`${styles.orgImgContainer} shimmer`}
+                        ></div>
+                        <div className={styles.content}>
+                          <h5 className="shimmer" title="Org name"></h5>
+                          <h6 className="shimmer" title="Location"></h6>
+                          <h6 className="shimmer" title="Admins"></h6>
+                          <h6 className="shimmer" title="Members"></h6>
+                        </div>
+                      </div>
+                      <div className={`shimmer ${styles.button}`} />
+                    </div>
+                  </div>
+                ))}
+              </>
+            )}
           </>
         )}
         {/* Create Organization Modal */}


### PR DESCRIPTION

**What kind of change does this PR introduce?**

This PR fixes the issue when loading more orgs in organization list data, the entire data refreshes. With this PR, instead of refreshing entire data, it only refreshes the newly fetched data through pagination.

**Issue Number:**

Fixes #1359 

**Did you add tests for your changes?**


**Snapshots/Videos:**

https://github.com/PalisadoesFoundation/talawa-admin/assets/52243229/f9127e5e-1135-4905-a5e8-196c15b0f56b



**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
