### PR TITLE
Fixes: Advertisement End date can be earlier than Start date

### DIFF
--- a/src/components/Advertisements/core/AdvertisementRegister/AdvertisementRegister.test.tsx
+++ b/src/components/Advertisements/core/AdvertisementRegister/AdvertisementRegister.test.tsx
@@ -277,4 +277,65 @@ describe('Testing Advertisement Register Component', () => {
       );
     });
   });
+
+  test('Throws error when the end date is less than the start date', async () => {
+    const { getByText, getByLabelText, queryByText } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <Provider store={store}>
+          <BrowserRouter>
+            <I18nextProvider i18n={i18n}>
+              {
+                <AdvertisementRegister
+                  endDate={new Date()}
+                  startDate={new Date()}
+                  type="BANNER"
+                  name="Advert1"
+                  orgId="1"
+                  link="google.com"
+                />
+              }
+            </I18nextProvider>
+          </BrowserRouter>
+        </Provider>
+      </MockedProvider>
+    );
+
+    fireEvent.click(getByText(translations.addNew));
+    expect(queryByText(translations.RClose)).toBeInTheDocument();
+    fireEvent.change(getByLabelText(translations.Rname), {
+      target: { value: 'Test Advertisement' },
+    });
+    expect(getByLabelText(translations.Rname)).toHaveValue(
+      'Test Advertisement'
+    );
+
+    fireEvent.change(getByLabelText(translations.Rlink), {
+      target: { value: 'http://example.com' },
+    });
+    expect(getByLabelText(translations.Rlink)).toHaveValue(
+      'http://example.com'
+    );
+
+    fireEvent.change(getByLabelText(translations.Rtype), {
+      target: { value: 'BANNER' },
+    });
+    expect(getByLabelText(translations.Rtype)).toHaveValue('BANNER');
+
+    fireEvent.change(getByLabelText(translations.RstartDate), {
+      target: { value: '2023-02-02' },
+    });
+    expect(getByLabelText(translations.RstartDate)).toHaveValue('2023-02-02');
+
+    fireEvent.change(getByLabelText(translations.RendDate), {
+      target: { value: '2023-01-01' },
+    });
+    expect(getByLabelText(translations.RendDate)).toHaveValue('2023-01-01');
+
+    fireEvent.click(getByText(translations.register));
+    await waitFor(() => {
+      expect(toast.error).toBeCalledWith(
+        'End date must be greater than or equal to start date'
+      );
+    });
+  });
 });

--- a/src/components/Advertisements/core/AdvertisementRegister/AdvertisementRegister.tsx
+++ b/src/components/Advertisements/core/AdvertisementRegister/AdvertisementRegister.tsx
@@ -94,6 +94,10 @@ function advertisementRegister({
   const handleRegister = async (): Promise<void> => {
     try {
       console.log('At handle register', formState);
+      if (formState.endDate < formState.startDate) {
+        toast.error('End date must be greater than or equal to start date');
+        return;
+      }
       const { data } = await create({
         variables: {
           orgId: currentOrg,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR solves the issue of Advertisements Date Issue.

**Issue Number:**

#1485 

**Did you add tests for your changes?**

Yes

**Summary**

Now, the end date of the advertisement cannot be less than the start date.

**Snapshots**

![image](https://github.com/PalisadoesFoundation/talawa-admin/assets/110725065/72fc9ff3-490c-4ace-96a0-b450c9ac36d8)

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
