### PR TITLE
Advertisement Date Error While Editing is Solved.

### DIFF
--- a/src/components/Advertisements/core/AdvertisementRegister/AdvertisementRegister.test.tsx
+++ b/src/components/Advertisements/core/AdvertisementRegister/AdvertisementRegister.test.tsx
@@ -338,4 +338,65 @@ describe('Testing Advertisement Register Component', () => {
       );
     });
   });
+  test('Throws error when the end date is less than the start date while editing the advertisement', async () => {
+    const { getByText, getByLabelText, queryByText } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <Provider store={store}>
+          <BrowserRouter>
+            <I18nextProvider i18n={i18n}>
+              {
+                <AdvertisementRegister
+                  formStatus="edit"
+                  endDate={new Date()}
+                  startDate={new Date()}
+                  type="BANNER"
+                  name="Advert1"
+                  orgId="1"
+                  link="google.com"
+                />
+              }
+            </I18nextProvider>
+          </BrowserRouter>
+        </Provider>
+      </MockedProvider>
+    );
+
+    fireEvent.click(getByText(translations.edit));
+    expect(queryByText(translations.editAdvertisement)).toBeInTheDocument();
+    fireEvent.change(getByLabelText(translations.Rname), {
+      target: { value: 'Test Advertisement' },
+    });
+    expect(getByLabelText(translations.Rname)).toHaveValue(
+      'Test Advertisement'
+    );
+
+    fireEvent.change(getByLabelText(translations.Rlink), {
+      target: { value: 'http://example.com' },
+    });
+    expect(getByLabelText(translations.Rlink)).toHaveValue(
+      'http://example.com'
+    );
+
+    fireEvent.change(getByLabelText(translations.Rtype), {
+      target: { value: 'BANNER' },
+    });
+    expect(getByLabelText(translations.Rtype)).toHaveValue('BANNER');
+
+    fireEvent.change(getByLabelText(translations.RstartDate), {
+      target: { value: '2023-02-02' },
+    });
+    expect(getByLabelText(translations.RstartDate)).toHaveValue('2023-02-02');
+
+    fireEvent.change(getByLabelText(translations.RendDate), {
+      target: { value: '2023-01-01' },
+    });
+    expect(getByLabelText(translations.RendDate)).toHaveValue('2023-01-01');
+
+    fireEvent.click(getByText(translations.saveChanges));
+    await waitFor(() => {
+      expect(toast.error).toBeCalledWith(
+        'End date must be greater than or equal to start date'
+      );
+    });
+  });
 });

--- a/src/components/Advertisements/core/AdvertisementRegister/AdvertisementRegister.tsx
+++ b/src/components/Advertisements/core/AdvertisementRegister/AdvertisementRegister.tsx
@@ -141,6 +141,10 @@ function advertisementRegister({
       if (formState.type !== typeEdit) {
         updatedFields.type = formState.type;
       }
+      if (formState.endDate < formState.startDate) {
+        toast.error('End date must be greater than or equal to start date');
+        return;
+      }
       const startDateFormattedString = dayjs(formState.startDate).format(
         'YYYY-MM-DD'
       );


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Now, While Editing an Advertisement, we cannot make the end date of an advertisement before the Starting date.

**Issue Number:**

Fixes #1547 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![image](https://github.com/PalisadoesFoundation/talawa-admin/assets/110725065/0803b724-618a-4e17-a271-41adc42499a2)

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
