### PR TITLE
Avoid 400 badrequest error in login page

### DIFF
--- a/src/screens/LoginPage/LoginPage.test.tsx
+++ b/src/screens/LoginPage/LoginPage.test.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-commented-out-tests */
 import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
 import { act, render, screen } from '@testing-library/react';
@@ -16,7 +17,6 @@ import {
 } from 'GraphQl/Mutations/mutations';
 import { store } from 'state/store';
 import i18nForTest from 'utils/i18nForTest';
-import { BACKEND_URL } from 'Constant/constant';
 
 const MOCKS = [
   {
@@ -102,52 +102,52 @@ jest.mock('Constant/constant.ts', () => ({
   RECAPTCHA_SITE_KEY: 'xxx',
 }));
 
-describe('Talawa-API server fetch check', () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+// describe('Talawa-API server fetch check', () => {
+//   beforeEach(() => {
+//     jest.clearAllMocks();
+//   });
 
-  test('Checks if Talawa-API resource is loaded successfully', async () => {
-    global.fetch = jest.fn(() => Promise.resolve({} as unknown as Response));
+//   test('Checks if Talawa-API resource is loaded successfully', async () => {
+//     global.fetch = jest.fn(() => Promise.resolve({} as unknown as Response));
 
-    await act(async () => {
-      render(
-        <MockedProvider addTypename={false} link={link}>
-          <BrowserRouter>
-            <Provider store={store}>
-              <I18nextProvider i18n={i18nForTest}>
-                <LoginPage />
-              </I18nextProvider>
-            </Provider>
-          </BrowserRouter>
-        </MockedProvider>
-      );
-    });
+//     await act(async () => {
+//       render(
+//         <MockedProvider addTypename={false} link={link}>
+//           <BrowserRouter>
+//             <Provider store={store}>
+//               <I18nextProvider i18n={i18nForTest}>
+//                 <LoginPage />
+//               </I18nextProvider>
+//             </Provider>
+//           </BrowserRouter>
+//         </MockedProvider>
+//       );
+//     });
 
-    expect(fetch).toHaveBeenCalledWith(BACKEND_URL);
-  });
+//     expect(fetch).toHaveBeenCalledWith(BACKEND_URL);
+//   });
 
-  test('displays warning message when resource loading fails', async () => {
-    const mockError = new Error('Network error');
-    global.fetch = jest.fn(() => Promise.reject(mockError));
+//   test('displays warning message when resource loading fails', async () => {
+//     const mockError = new Error('Network error');
+//     global.fetch = jest.fn(() => Promise.reject(mockError));
 
-    await act(async () => {
-      render(
-        <MockedProvider addTypename={false} link={link}>
-          <BrowserRouter>
-            <Provider store={store}>
-              <I18nextProvider i18n={i18nForTest}>
-                <LoginPage />
-              </I18nextProvider>
-            </Provider>
-          </BrowserRouter>
-        </MockedProvider>
-      );
-    });
+//     await act(async () => {
+//       render(
+//         <MockedProvider addTypename={false} link={link}>
+//           <BrowserRouter>
+//             <Provider store={store}>
+//               <I18nextProvider i18n={i18nForTest}>
+//                 <LoginPage />
+//               </I18nextProvider>
+//             </Provider>
+//           </BrowserRouter>
+//         </MockedProvider>
+//       );
+//     });
 
-    expect(fetch).toHaveBeenCalledWith(BACKEND_URL);
-  });
-});
+//     expect(fetch).toHaveBeenCalledWith(BACKEND_URL);
+//   });
+// });
 
 describe('Testing Login Page Screen', () => {
   test('Component Should be rendered properly', async () => {

--- a/src/screens/LoginPage/LoginPage.tsx
+++ b/src/screens/LoginPage/LoginPage.tsx
@@ -21,11 +21,7 @@ import {
   YoutubeLogo,
 } from 'assets/svgs/social-icons';
 
-import {
-  REACT_APP_USE_RECAPTCHA,
-  RECAPTCHA_SITE_KEY,
-  BACKEND_URL,
-} from 'Constant/constant';
+import { REACT_APP_USE_RECAPTCHA, RECAPTCHA_SITE_KEY } from 'Constant/constant';
 import {
   LOGIN_MUTATION,
   RECAPTCHA_MUTATION,
@@ -133,18 +129,18 @@ function loginPage(): JSX.Element {
   const [recaptcha, { loading: recaptchaLoading }] =
     useMutation(RECAPTCHA_MUTATION);
 
-  useEffect(() => {
-    async function loadResource(): Promise<void> {
-      try {
-        await fetch(BACKEND_URL as string);
-      } catch (error: any) {
-        /* istanbul ignore next */
-        errorHandler(t, error);
-      }
-    }
+  // useEffect(() => {
+  //   async function loadResource(): Promise<void> {
+  //     try {
+  //       await fetch(BACKEND_URL as string);
+  //     } catch (error: any) {
+  //       /* istanbul ignore next */
+  //       errorHandler(t, error);
+  //     }
+  //   }
 
-    loadResource();
-  }, []);
+  //   loadResource();
+  // }, []);
 
   const verifyRecaptcha = async (
     recaptchaToken: any


### PR DESCRIPTION
**What kind of change does this PR introduce?**

It fixes 400 bad request network error which is to ping the server to check server health in login page.  

**Issue Number:**

Fixes #1244 

**Did you add tests for your changes?**

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**

<img width="1435" alt="400" src="https://github.com/PalisadoesFoundation/talawa-admin/assets/52243229/2c384eb9-f5f5-4b93-b696-60035ad55880">


**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

- Removed fetch method which is a simple request in loginPage component. It appears that CSRF feature is enabled from API server side. 
- Instead of modifying the request by introducing another `useQuery`, I removed it because there is already another network request `checkAuth` which also returns same alert if the server is not running and that is duplicating the alerts.
<img width="1435" alt="AlertDuplicates" src="https://github.com/PalisadoesFoundation/talawa-admin/assets/52243229/2f49ef3e-2582-4305-a535-2aa83c9f31e5">


**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
