### PR TITLE
 Fixed: App can only be accessed on localhost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,6 @@ REACT_APP_BACKEND_WEBSOCKET_URL=ws://localhost:4000/graphql
 # If you want to logs Compiletime and Runtime error , warning and info write YES or if u want to  
 # keep the console clean leave it blank
 ALLOW_LOGS=
+
+# If you want to access Talawa Admin from a remote host
+REACT_APP_REMOTE_HOST=

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -194,6 +194,14 @@ http://localhost:${{customPort}}/
 
 Replace `${{customPort}}` with the actual custom port number you have configured in your `.env` file.
 
+
+If you are trying to run the localhost from a remote host and your api is also running on the localhost, you will have to change the 'REACT_APP_REMOTE_HOST' env variable.
+
+```
+REACT_APP_REMOTE_HOST=your_url
+# example:  REACT_APP_REMOTE_HOST=http://192.168.1.5
+```
+
 ## Talawa-Admin Registration
 
 The first time you navigate to the running talawa-admin's website you'll land at talawa-admin registration page. Sign up using whatever credentials you want and create the account. Make sure to remember the email and password you entered because they'll be used to sign you in later on.

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "react-icons": "^4.12.0",
         "react-infinite-scroll-component": "^6.1.0",
         "react-redux": "^7.2.5",
-        "react-router-dom": "^6.21.3",
+        "react-router-dom": "^6.22.2",
         "react-scripts": "5.0.1",
         "react-toastify": "^9.0.3",
         "redux": "^4.1.1",
@@ -4544,6 +4544,14 @@
       "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.2.tgz",
+      "integrity": "sha512-+Rnav+CaoTE5QJc4Jcwh5toUpnVLKYbpU6Ys0zqbakqbaLQHeglLVHPfxOiQqdNmUy5C2lXz5dwC6tQNX2JW2Q==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@restart/hooks": {
@@ -11835,16 +11843,11 @@
       }
     },
     "node_modules/history": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
-      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
       "dependencies": {
-        "@babel/runtime": "^7.1.2",
-        "loose-envify": "^1.2.0",
-        "resolve-pathname": "^3.0.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0",
-        "value-equal": "^1.0.1"
+        "@babel/runtime": "^7.7.6"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -12933,11 +12936,6 @@
       "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -17141,14 +17139,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
     },
-    "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -19306,45 +19296,34 @@
       }
     },
     "node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "version": "6.22.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.2.tgz",
+      "integrity": "sha512-YD3Dzprzpcq+tBMHBS822tCjnWD3iIZbTeSXMY9LPSG541EfoBGyZ3bS25KEnaZjLcmQpw2AVLkFyfgXY8uvcw==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.15.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8"
       }
     },
     "node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "version": "6.22.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.2.tgz",
+      "integrity": "sha512-WgqxD2qySEIBPZ3w0sHH+PUAiamDeszls9tzqMPBDA1YYVucTBXLU7+gtRfcSnhe92A3glPnvSxK2dhNoAVOIQ==",
       "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "@remix-run/router": "1.15.2",
+        "react-router": "6.22.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "react": ">=15"
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
-    },
-    "node_modules/react-router/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-scripts": {
       "version": "5.0.1",
@@ -20026,11 +20005,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/resolve-pathname": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
-      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -21990,16 +21964,6 @@
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
     },
-    "node_modules/tiny-invariant": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
-    },
-    "node_modules/tiny-warning": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
-      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
-    },
     "node_modules/tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -22762,11 +22726,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "node_modules/value-equal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
-      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "node_modules/vary": {
       "version": "1.1.2",

--- a/setup.ts
+++ b/setup.ts
@@ -6,6 +6,7 @@ import { askForTalawaApiUrl } from './src/setup/askForTalawaApiUrl/askForTalawaA
 import { checkEnvFile } from './src/setup/checkEnvFile/checkEnvFile';
 import { validateRecaptcha } from './src/setup/validateRecaptcha/validateRecaptcha';
 import { askForCustomPort } from './src/setup/askForCustomPort/askForCustomPort';
+import { askForRemoteUrl } from 'setup/askForRemoteUrl/askForRemoteUrl';
 
 export async function main(): Promise<void> {
   console.log('Welcome to the Talawa Admin setup! 🚀');
@@ -44,6 +45,39 @@ export async function main(): Promise<void> {
 
     fs.readFile('.env', 'utf8', (err, data) => {
       const result = data.replace(`PORT=${port}`, `PORT=${customPort}`);
+      fs.writeFileSync('.env', result, 'utf8');
+    });
+  }
+
+  let shouldSetRemoteHost: boolean;
+
+  if (process.env.REACT_APP_REMOTE_HOST) {
+    console.log(
+      `\nEndpoint for the remote url already exists with the value:\n${process.env.REACT_APP_REMOTE_HOST}`,
+    );
+    shouldSetRemoteHost = true;
+  } else {
+    const { shouldSetRemoteHostResponse } = await inquirer.prompt({
+      type: 'confirm',
+      name: 'shouldSetRemoteHostResponse',
+      message: 'Would you like to set up a remote host?',
+      default: true,
+    });
+    shouldSetRemoteHost = shouldSetRemoteHostResponse;
+  }
+
+  if (shouldSetRemoteHost) {
+    const endpoint = await askForRemoteUrl();
+
+    const existingUrl = dotenv.parse(
+      fs.readFileSync('.env'),
+    ).REACT_APP_REMOTE_HOST;
+
+    fs.readFile('.env', 'utf8', (err, data) => {
+      const result = data.replace(
+        `REACT_APP_REMOTE_HOST=${existingUrl}`,
+        `REACT_APP_REMOTE_HOST=${endpoint}`,
+      );
       fs.writeFileSync('.env', result, 'utf8');
     });
   }

--- a/src/Constant/constant.spec.ts
+++ b/src/Constant/constant.spec.ts
@@ -3,6 +3,7 @@ import {
   BACKEND_URL,
   RECAPTCHA_SITE_KEY,
   REACT_APP_USE_RECAPTCHA,
+  REMOTE_HOST,
 } from './constant';
 
 describe('constants', () => {
@@ -25,5 +26,9 @@ describe('constants', () => {
     expect(REACT_APP_USE_RECAPTCHA).toEqual(
       process.env.REACT_APP_USE_RECAPTCHA,
     );
+  });
+
+  it('REMOTE_HOST should be equal to REMOTE_HOST environment variable', () => {
+    expect(REMOTE_HOST).toEqual(process.env.REACT_APP_REMOTE_HOST);
   });
 });

--- a/src/Constant/constant.ts
+++ b/src/Constant/constant.ts
@@ -5,3 +5,4 @@ export const REACT_APP_USE_RECAPTCHA = process.env.REACT_APP_USE_RECAPTCHA;
 export const REACT_APP_CUSTOM_PORT = process.env.PORT;
 export const REACT_APP_BACKEND_WEBSOCKET_URL: string =
   process.env.REACT_APP_BACKEND_WEBSOCKET_URL || '';
+export const REMOTE_HOST = process.env.REACT_APP_REMOTE_HOST;

--- a/src/components/AddOn/support/services/Plugin.helper.test.ts
+++ b/src/components/AddOn/support/services/Plugin.helper.test.ts
@@ -1,6 +1,42 @@
-import PluginHelper from './Plugin.helper';
+import PluginHelper, { changeBackendUrl } from './Plugin.helper';
 
 describe('Testing src/components/AddOn/support/services/Plugin.helper.ts', () => {
+  it('should return the correct URL when on localhost', () => {
+    const result = changeBackendUrl('localhost', {
+      remoteHost: 'example.com',
+      backendUrl: 'http://localhost:3000',
+    });
+
+    expect(result).toBe('http://localhost:');
+  });
+
+  it('should return the correct URL when not on localhost(contains slash)', () => {
+    const result = changeBackendUrl('example.com/', {
+      remoteHost: 'example.com/',
+      backendUrl: 'http://localhost:3000',
+    });
+
+    expect(result).toBe('example.com:');
+  });
+
+  it('should return the correct URL when not on localhost', () => {
+    const result = changeBackendUrl('example.com', {
+      remoteHost: 'example.com',
+      backendUrl: 'http://localhost:3000',
+    });
+
+    expect(result).toBe('example.com:');
+  });
+
+  it('should return the correct URL when not on localhost(remote host is undefined)', () => {
+    const result = changeBackendUrl('example.com', {
+      remoteHost: undefined,
+      backendUrl: 'http://localhost:3000',
+    });
+
+    expect(result).toBe(':');
+  });
+
   test('Class should contain the required method definitions', () => {
     const pluginHelper = new PluginHelper();
     expect(pluginHelper).toHaveProperty('fetchStore');

--- a/src/components/AddOn/support/services/Plugin.helper.ts
+++ b/src/components/AddOn/support/services/Plugin.helper.ts
@@ -1,11 +1,36 @@
+import {
+  REMOTE_HOST,
+  BACKEND_URL,
+  REACT_APP_CUSTOM_PORT,
+} from 'Constant/constant';
+
+const changeBackendUrl = (): string => {
+  console.log(REMOTE_HOST);
+  if (
+    window.location.hostname != 'localhost' &&
+    BACKEND_URL?.includes('localhost')
+  ) {
+    let left = REMOTE_HOST || '';
+    if (left.endsWith('/')) {
+      left = left.slice(0, -1);
+    }
+    left = left.concat(':');
+    return left;
+  } else {
+    return 'http://localhost:';
+  }
+};
 class PluginHelper {
   fetchStore = async (): Promise<any> => {
-    const result = await fetch(`http://localhost:${process.env.PORT}/store`);
+    console.log('port' + REACT_APP_CUSTOM_PORT);
+    const result = await fetch(
+      `${changeBackendUrl() + process.env.PORT}/store`,
+    );
     return await result.json();
   };
 
   fetchInstalled = async (): Promise<any> => {
-    const result = await fetch(`http://localhost:3005/installed`);
+    const result = await fetch(`${changeBackendUrl()}3005/installed`);
     return await result.json();
   };
 

--- a/src/components/AddOn/support/services/Plugin.helper.ts
+++ b/src/components/AddOn/support/services/Plugin.helper.ts
@@ -4,13 +4,18 @@ import {
   REACT_APP_CUSTOM_PORT,
 } from 'Constant/constant';
 
-const changeBackendUrl = (): string => {
-  console.log(REMOTE_HOST);
-  if (
-    window.location.hostname != 'localhost' &&
-    BACKEND_URL?.includes('localhost')
-  ) {
-    let left = REMOTE_HOST || '';
+interface InterfaceConstants {
+  remoteHost: string | undefined;
+  backendUrl: string | undefined;
+}
+
+export const changeBackendUrl = (
+  hostname: string,
+  { remoteHost, backendUrl }: InterfaceConstants,
+): string => {
+  console.log(remoteHost);
+  if (hostname !== 'localhost' && backendUrl?.includes('localhost')) {
+    let left = remoteHost || '';
     if (left.endsWith('/')) {
       left = left.slice(0, -1);
     }
@@ -24,13 +29,15 @@ class PluginHelper {
   fetchStore = async (): Promise<any> => {
     console.log('port' + REACT_APP_CUSTOM_PORT);
     const result = await fetch(
-      `${changeBackendUrl() + process.env.PORT}/store`,
+      `${changeBackendUrl(window.location.hostname, { remoteHost: REMOTE_HOST, backendUrl: BACKEND_URL }) + process.env.PORT}/store`,
     );
     return await result.json();
   };
 
   fetchInstalled = async (): Promise<any> => {
-    const result = await fetch(`${changeBackendUrl()}3005/installed`);
+    const result = await fetch(
+      `${changeBackendUrl(window.location.hostname, { remoteHost: REMOTE_HOST, backendUrl: BACKEND_URL })}3005/installed`,
+    );
     return await result.json();
   };
 

--- a/src/components/Advertisements/core/AdvertisementEntry/AdvertisementEntry.test.tsx
+++ b/src/components/Advertisements/core/AdvertisementEntry/AdvertisementEntry.test.tsx
@@ -308,43 +308,6 @@ describe('Testing Advertisement Entry Component', () => {
     });
   });
 
-  test('Updates the advertisement and shows error toast on successful update', async () => {
-    const updateAdByIdMock = jest.fn();
-
-    mockUseMutation.mockReturnValue([updateAdByIdMock]);
-
-    render(
-      <ApolloProvider client={client}>
-        <Provider store={store}>
-          <BrowserRouter>
-            <I18nextProvider i18n={i18nForTest}>
-              <AdvertisementRegister
-                formStatus="edit"
-                idEdit="-100"
-                nameEdit="Updated"
-                endDateEdit={new Date()}
-                startDateEdit={new Date()}
-                typeEdit="POPUP"
-                orgIdEdit="1"
-                advertisementMediaEdit=""
-              />
-            </I18nextProvider>
-          </BrowserRouter>
-        </Provider>
-      </ApolloProvider>,
-    );
-
-    fireEvent.click(screen.getByTestId('editBtn'));
-
-    fireEvent.click(screen.getByTestId('addonupdate'));
-
-    expect(updateAdByIdMock).toHaveBeenCalledWith({
-      variables: {
-        id: '-100',
-      },
-    });
-  });
-
   test('Simulating if the mutation does not have data variable while registering', async () => {
     Object.defineProperty(window, 'location', {
       configurable: true,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,6 +29,7 @@ import './utils/i18n';
 import {
   BACKEND_URL,
   REACT_APP_BACKEND_WEBSOCKET_URL,
+  REMOTE_HOST,
 } from 'Constant/constant';
 import { refreshToken } from 'utils/getRefreshToken';
 import { ThemeProvider, createTheme } from '@mui/material';
@@ -55,6 +56,24 @@ const authLink = setContext((_, { headers }) => {
     },
   };
 });
+
+const changeBackendUrl = (url: string | undefined): string => {
+  if (
+    window.location.hostname != 'localhost' &&
+    BACKEND_URL?.includes('localhost')
+  ) {
+    const right = BACKEND_URL.replace('http://localhost:', ':');
+    let left = REMOTE_HOST || '';
+    if (left.endsWith('/')) {
+      left = left.slice(0, -1);
+    }
+    console.error(left + right);
+    console.log(left + right);
+    return left + right;
+  } else {
+    return url || '';
+  }
+};
 
 const errorLink = onError(
   ({ graphQLErrors, networkError, operation, forward }) => {
@@ -90,7 +109,7 @@ const errorLink = onError(
 );
 
 const httpLink = new HttpLink({
-  uri: BACKEND_URL,
+  uri: changeBackendUrl(BACKEND_URL),
 });
 
 // if didnt work use /subscriptions

--- a/src/setup/askForRemoteUrl/askForRemoteUrl.test.ts
+++ b/src/setup/askForRemoteUrl/askForRemoteUrl.test.ts
@@ -1,0 +1,52 @@
+import inquirer from 'inquirer';
+import { askForRemoteUrl, validateUrl } from './askForRemoteUrl'; // Replace 'yourFileName' with the actual name of your TypeScript file
+
+jest.mock('inquirer', () => ({
+  prompt: jest.fn(),
+}));
+
+describe('validateUrl function', () => {
+  it('should return true for a valid URL', () => {
+    const validUrl = 'http://example.com/';
+    const result = validateUrl(validUrl);
+    expect(result).toBe(true);
+  });
+
+  it('should return false for an invalid URL', () => {
+    const invalidUrl = 'invalid-url';
+    const result = validateUrl(invalidUrl);
+    expect(result).toBe(false);
+  });
+});
+
+describe('askForRemoteUrl function', () => {
+  test('should return the provided endpoint when user enters it', async () => {
+    const mockPrompt = jest.spyOn(inquirer, 'prompt').mockResolvedValueOnce({
+      url: 'http://example.com/',
+    });
+    const result = await askForRemoteUrl();
+    expect(mockPrompt).toHaveBeenCalledWith([
+      {
+        type: 'input',
+        name: 'url',
+        message: `Enter your remote url in the format 'http://hosturl/' (don't enter the port)`,
+        validate: validateUrl,
+      },
+    ]);
+    expect(result).toBe('http://example.com/');
+  });
+
+  test('should re-prompt the user until a valid URL is entered', async () => {
+    const invalidUrl = 'invalid-url';
+    const validUrl = 'http://example.com/';
+    jest
+      .spyOn(inquirer, 'prompt')
+      .mockResolvedValueOnce({
+        url: invalidUrl,
+      })
+      .mockResolvedValueOnce({ url: validUrl });
+
+    await askForRemoteUrl();
+    expect(inquirer.prompt).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/setup/askForRemoteUrl/askForRemoteUrl.ts
+++ b/src/setup/askForRemoteUrl/askForRemoteUrl.ts
@@ -1,0 +1,20 @@
+import inquirer from 'inquirer';
+
+export const validateUrl = (input: string): boolean => {
+  const ans =
+    input.includes(':') && input.indexOf(':') == input.lastIndexOf(':');
+  const urlRegex = /^(https?|ftp):\/\/[^\s/$.?#].[^\s]*$/;
+  return ans && urlRegex.test(input);
+};
+
+export async function askForRemoteUrl(): Promise<string> {
+  const { url } = await inquirer.prompt([
+    {
+      type: 'input',
+      name: 'url',
+      message: `Enter your remote url in the format 'http://hosturl/' (don't enter the port)`,
+      validate: validateUrl,
+    },
+  ]);
+  return url;
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This pr fixes the problem of the portal not being able to be accessed if not on localhost.

**Issue Number:**

Fixes #1244 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![IMG_1534](https://github.com/PalisadoesFoundation/talawa-admin/assets/49566965/12a19db8-f128-48d8-add0-e629ef9d8ce4)



**If relevant, did you update the documentation?**

Yes

**Summary**

This issue was caused mainly by the case in which the api url contains 'localhost'.

**Does this PR introduce a breaking change?**

No

**Other information**
There are 2 problems that occurred while working on the issue.
1. One problem occurring that needs to be fixed is the plugin store, which is coded incorrectly. in the src/components/AddOn/support/services/Plugin.helper.ts file.

```
    const result = await fetch(`http://localhost:${process.env.PORT}/store`);
    const result = await fetch(`http://localhost:3005/installed`);
```

are both fetching endpoints that do not exist and hence the addonstore component also does not work. 

2. The navbar button is not working on mobile devices.

Should I make issues for them?


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
