### PR TITLE
fix: change error logs to show `error.message` only

### DIFF
--- a/src/components/ActionItems/ActionItemsContainer.tsx
+++ b/src/components/ActionItems/ActionItemsContainer.tsx
@@ -111,9 +111,11 @@ function actionItemsContainer({
       actionItemsRefetch();
       hideUpdateModal();
       toast.success(t('successfulUpdation'));
-    } catch (error: any) {
-      toast.error(error.message);
-      console.log(error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
 
@@ -129,9 +131,11 @@ function actionItemsContainer({
       actionItemsRefetch();
       toggleDeleteModal();
       toast.success(t('successfulDeletion'));
-    } catch (error: any) {
-      toast.error(error.message);
-      console.log(error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
 

--- a/src/components/ActionItems/ActionItemsModalBody.tsx
+++ b/src/components/ActionItems/ActionItemsModalBody.tsx
@@ -118,9 +118,11 @@ export const ActionItemsModalBody = ({
       actionItemsRefetch();
       hideCreateModal();
       toast.success(t('successfulCreation'));
-    } catch (error: any) {
-      toast.error(error.message);
-      console.log(error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
 

--- a/src/components/Advertisements/core/AdvertisementRegister/AdvertisementRegister.tsx
+++ b/src/components/Advertisements/core/AdvertisementRegister/AdvertisementRegister.tsx
@@ -117,9 +117,11 @@ function advertisementRegister({
         });
         handleClose();
       }
-    } catch (error) {
-      toast.error('An error occured, could not create new advertisement');
-      console.log('error occured', error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
   const handleUpdate = async (): Promise<void> => {
@@ -181,8 +183,11 @@ function advertisementRegister({
         refetch();
         handleClose();
       }
-    } catch (error: any) {
-      toast.error(error.message);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
   return (

--- a/src/components/Advertisements/core/AdvertisementRegister/AdvertisementRegister.tsx
+++ b/src/components/Advertisements/core/AdvertisementRegister/AdvertisementRegister.tsx
@@ -119,8 +119,8 @@ function advertisementRegister({
       }
     } catch (error: unknown) {
       if (error instanceof Error) {
-        toast.error(error.message);
-        console.log(error.message);
+        toast.error('An error occured, could not create new advertisement');
+        console.log('error occured', error.message);
       }
     }
   };
@@ -183,11 +183,8 @@ function advertisementRegister({
         refetch();
         handleClose();
       }
-    } catch (error: unknown) {
-      if (error instanceof Error) {
-        toast.error(error.message);
-        console.log(error.message);
-      }
+    } catch (error: any) {
+      toast.error(error.message);
     }
   };
   return (

--- a/src/components/OrgActionItemCategories/OrgActionItemCategories.tsx
+++ b/src/components/OrgActionItemCategories/OrgActionItemCategories.tsx
@@ -75,9 +75,11 @@ const OrgActionItemCategories = (): any => {
       setModalIsOpen(false);
 
       toast.success(t('successfulCreation'));
-    } catch (error: any) {
-      toast.error(error.message);
-      console.log(error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
 
@@ -101,9 +103,11 @@ const OrgActionItemCategories = (): any => {
         setModalIsOpen(false);
 
         toast.success(t('successfulUpdation'));
-      } catch (error: any) {
-        toast.error(error.message);
-        console.log(error);
+      } catch (error: unknown) {
+        if (error instanceof Error) {
+          toast.error(error.message);
+          console.log(error.message);
+        }
       }
     }
   };
@@ -125,9 +129,11 @@ const OrgActionItemCategories = (): any => {
       toast.success(
         disabledStatus ? t('categoryEnabled') : t('categoryDisabled'),
       );
-    } catch (error: any) {
-      toast.error(error.message);
-      console.log(error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
 

--- a/src/components/OrgPostCard/OrgPostCard.tsx
+++ b/src/components/OrgPostCard/OrgPostCard.tsx
@@ -68,10 +68,12 @@ export default function orgPostCard(
           window.location.reload();
         }, 2000);
       }
-    } catch (error: any) {
-      console.log(error);
-      /* istanbul ignore next */
-      errorHandler(t, error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        console.log(error.message);
+        /* istanbul ignore next */
+        errorHandler(t, error);
+      }
     }
   };
   const toggleShowEditModal = (): void => {

--- a/src/components/UserPortal/UserSidebar/UserSidebar.tsx
+++ b/src/components/UserPortal/UserSidebar/UserSidebar.tsx
@@ -40,7 +40,7 @@ function userSidebar(): JSX.Element {
     variables: { userId: userId },
   });
 
-  console.log(error);
+  console.log(error?.message);
 
   /* istanbul ignore next */
   React.useEffect(() => {

--- a/src/screens/OrganizationActionItems/OrganizationActionItems.tsx
+++ b/src/screens/OrganizationActionItems/OrganizationActionItems.tsx
@@ -125,7 +125,7 @@ function organizationActionItems(): JSX.Element {
       toast.success(t('successfulCreation'));
     } catch (error: any) {
       toast.error(error.message);
-      console.log(error);
+      console.log(error.message);
     }
   };
 

--- a/src/screens/OrganizationActionItems/OrganizationActionItems.tsx
+++ b/src/screens/OrganizationActionItems/OrganizationActionItems.tsx
@@ -123,9 +123,11 @@ function organizationActionItems(): JSX.Element {
       actionItemsRefetch();
       hideCreateModal();
       toast.success(t('successfulCreation'));
-    } catch (error: any) {
-      toast.error(error.message);
-      console.log(error.message);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
 

--- a/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
+++ b/src/screens/OrganizationDashboard/OrganizationDashboard.tsx
@@ -103,7 +103,7 @@ function organizationDashboard(): JSX.Element {
 
   useEffect(() => {
     if (errorOrg || errorPost || errorEvent) {
-      console.log('error', errorPost);
+      console.log('error', errorPost?.message);
       navigate('/orglist');
     }
   }, [errorOrg, errorPost, errorEvent]);

--- a/src/screens/OrganizationFundCampaign/OrganizationFundCampagins.tsx
+++ b/src/screens/OrganizationFundCampaign/OrganizationFundCampagins.tsx
@@ -125,8 +125,10 @@ const orgFundCampaign = (): JSX.Element => {
       refetchFundCampaign();
       hideCreateCampaignModal();
     } catch (error: unknown) {
-      toast.error((error as Error).message);
-      console.log(error);
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
 
@@ -172,8 +174,10 @@ const orgFundCampaign = (): JSX.Element => {
       hideUpdateCampaignModal();
       toast.success(t('updatedCampaign'));
     } catch (error: unknown) {
-      toast.error((error as Error).message);
-      console.log(error);
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
 
@@ -188,8 +192,10 @@ const orgFundCampaign = (): JSX.Element => {
       refetchFundCampaign();
       hideDeleteCampaignModal();
     } catch (error: unknown) {
-      toast.error((error as Error).message);
-      console.log(error);
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
   if (fundCampaignLoading) {

--- a/src/screens/OrganizationFunds/OrganizationFunds.tsx
+++ b/src/screens/OrganizationFunds/OrganizationFunds.tsx
@@ -130,8 +130,10 @@ const organizationFunds = (): JSX.Element => {
       refetchFunds();
       hideCreateModal();
     } catch (error: unknown) {
-      toast.error((error as Error).message);
-      console.log(error);
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
   const updateFundHandler = async (
@@ -167,8 +169,10 @@ const organizationFunds = (): JSX.Element => {
       hideUpdateModal();
       toast.success(t('fundUpdated'));
     } catch (error: unknown) {
-      toast.error((error as Error).message);
-      console.log(error);
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
   const archiveFundHandler = async (): Promise<void> => {
@@ -185,8 +189,10 @@ const organizationFunds = (): JSX.Element => {
         ? toast.success(t('fundUnarchived'))
         : toast.success(t('fundArchived'));
     } catch (error: unknown) {
-      toast.error((error as Error).message);
-      console.log(error);
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
   const deleteFundHandler = async (): Promise<void> => {
@@ -200,8 +206,10 @@ const organizationFunds = (): JSX.Element => {
       toggleDeleteModal();
       toast.success(t('fundDeleted'));
     } catch (error: unknown) {
-      toast.error((error as Error).message);
-      console.log(error);
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
   //it is used to rerender the component to use updated Fund in setState

--- a/src/screens/OrganizationPeople/AddMember.tsx
+++ b/src/screens/OrganizationPeople/AddMember.tsx
@@ -87,9 +87,11 @@ function AddMember(): JSX.Element {
       memberRefetch({
         orgId: currentUrl,
       });
-    } catch (error: any) {
-      toast.error(error.message);
-      console.log(error);
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+        console.log(error.message);
+      }
     }
   };
 


### PR DESCRIPTION
### What kind of change does this PR introduce?

Change error logs to show `error.message` only

### Issue Number:

Fixes #1788 

### Did you add tests for your changes?

Not required