### PR TITLE
Fix: Removed unnecessary drop down from the users page

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -192,7 +192,6 @@
     "users": "Users",
     "name": "Name",
     "email": "Email",
-    "roles_userType": "Role/User-Type",
     "joined_organizations": "Joined Organizations",
     "blocked_organizations": "Blocked Organizations",
     "orgJoinedBy": "Organizations Joined By",

--- a/public/locales/fr.json
+++ b/public/locales/fr.json
@@ -159,7 +159,6 @@
     "users": "Utilisateurs",
     "name": "Nom",
     "email": "E-mail",
-    "roles_userType": "Rôle/Type d'utilisateur",
     "joined_organizations": "Organisations rejointes",
     "blocked_organizations": "Organisations bloquées",
     "endOfResults": "Fin des résultats",

--- a/public/locales/hi.json
+++ b/public/locales/hi.json
@@ -159,7 +159,6 @@
     "users": "उपयोगकर्ता",
     "name": "नाम",
     "email": "ईमेल",
-    "roles_userType": "भूमिका/उपयोगकर्ता-प्रकार",
     "joined_organizations": "संगठनों में शामिल हुए",
     "blocked_organizations": "अवरोधित संगठन",
     "endOfResults": "परिणामों का अंत",

--- a/public/locales/sp.json
+++ b/public/locales/sp.json
@@ -159,7 +159,6 @@
     "users": "Usuarios",
     "name": "Nombre",
     "email": "Correo electrónico",
-    "roles_userType": "Rol/Tipo de usuario",
     "joined_organizations": "Organizaciones unidas",
     "blocked_organizations": "Organizaciones bloqueadas",
     "endOfResults": "Fin de los resultados",

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -231,7 +231,6 @@
     "users": "用户",
     "name": "姓名",
     "email": "電子郵件",
-    "roles_userType": "角色/用戶類型",
     "joined_organizations": "加入的組織",
     "blocked_organizations": "阻止的組織",
     "endOfResults": "結果結束",

--- a/src/components/UsersTableItem/UserTableItem.test.tsx
+++ b/src/components/UsersTableItem/UserTableItem.test.tsx
@@ -210,10 +210,6 @@ describe('Testing User Table Item', () => {
     expect(screen.getByText(/1/i)).toBeInTheDocument();
     expect(screen.getByText(/John Doe/i)).toBeInTheDocument();
     expect(screen.getByText(/john@example.com/i)).toBeInTheDocument();
-    expect(screen.getByTestId(`changeRole${123}`)).toBeInTheDocument();
-    expect(screen.getByTestId(`changeRole${123}`)).toHaveValue(
-      `SUPERADMIN?${123}`,
-    );
     expect(screen.getByTestId(`showJoinedOrgsBtn${123}`)).toBeInTheDocument();
     expect(
       screen.getByTestId(`showBlockedByOrgsBtn${123}`),
@@ -472,8 +468,6 @@ describe('Testing User Table Item', () => {
     expect(screen.getByText(/29-07-2023/i)).toBeInTheDocument();
     expect(screen.getByTestId('removeUserFromOrgBtnabc')).toBeInTheDocument();
     expect(screen.getByTestId('removeUserFromOrgBtndef')).toBeInTheDocument();
-    expect(screen.getByTestId(`changeRoleInOrgabc`)).toHaveValue('ADMIN?abc');
-    expect(screen.getByTestId(`changeRoleInOrgdef`)).toHaveValue('USER?def');
 
     // Search for Joined Organization 1
     const searchBtn = screen.getByTestId(`searchBtnJoinedOrgs`);
@@ -694,8 +688,6 @@ describe('Testing User Table Item', () => {
     expect(screen.getByText(/29-03-2023/i)).toBeInTheDocument();
     expect(screen.getByTestId('removeUserFromOrgBtnxyz')).toBeInTheDocument();
     expect(screen.getByTestId('removeUserFromOrgBtnmno')).toBeInTheDocument();
-    expect(screen.getByTestId(`changeRoleInOrgxyz`)).toHaveValue('ADMIN?xyz');
-    expect(screen.getByTestId(`changeRoleInOrgmno`)).toHaveValue('USER?mno');
     // Click on Creator Link
     fireEvent.click(screen.getByTestId(`creatorxyz`));
     expect(toast.success).toBeCalledWith('Profile Page Coming Soon !');

--- a/src/components/UsersTableItem/UsersTableItem.tsx
+++ b/src/components/UsersTableItem/UsersTableItem.tsx
@@ -24,7 +24,7 @@ type Props = {
 
 const UsersTableItem = (props: Props): JSX.Element => {
   const { t } = useTranslation('translation', { keyPrefix: 'users' });
-  const { user, index, loggedInUserId, resetAndRefetch } = props;
+  const { user, index, resetAndRefetch } = props;
 
   const [showJoinedOrganizations, setShowJoinedOrganizations] = useState(false);
   const [showBlockedOrganizations, setShowBlockedOrganizations] =
@@ -160,6 +160,9 @@ const UsersTableItem = (props: Props): JSX.Element => {
       setShowBlockedOrganizations(true);
     }
   }
+
+  const isSuperAdmin = user.appUserProfile.isSuperAdmin;
+
   return (
     <>
       {/* Table Item */}
@@ -167,26 +170,6 @@ const UsersTableItem = (props: Props): JSX.Element => {
         <th scope="row">{index + 1}</th>
         <td>{`${user.user.firstName} ${user.user.lastName}`}</td>
         <td>{user.user.email}</td>
-        <td>
-          <Form.Select
-            name={`role${user.user._id}`}
-            data-testid={`changeRole${user.user._id}`}
-            disabled={user.user._id === loggedInUserId}
-            defaultValue={
-              user.appUserProfile.isSuperAdmin
-                ? 'SUPERADMIN' + `?${user.user._id}`
-                : user.appUserProfile.adminApproved
-                  ? 'ADMIN' + `?${user.user._id}`
-                  : 'USER' + `?${user.user._id}`
-            }
-          >
-            <option value={`ADMIN?${user.user._id}`}>{t('admin')}</option>
-            <option value={`SUPERADMIN?${user.user._id}`}>
-              {t('superAdmin')}
-            </option>
-            <option value={`USER?${user.user._id}`}>{t('user')}</option>
-          </Form.Select>
-        </td>
         <td>
           <Button
             onClick={() => setShowJoinedOrganizations(true)}
@@ -318,14 +301,36 @@ const UsersTableItem = (props: Props): JSX.Element => {
                             {org.creator.firstName} {org.creator.lastName}
                           </Button>
                         </td>
-                        <td>{isAdmin ? 'ADMIN' : 'USER'}</td>
+                        <td>
+                          {isSuperAdmin
+                            ? 'SUPERADMIN'
+                            : isAdmin
+                              ? 'ADMIN'
+                              : 'USER'}
+                        </td>
                         <td>
                           <Form.Select
                             size="sm"
                             onChange={changeRoleInOrg}
                             data-testid={`changeRoleInOrg${org._id}`}
+                            disabled={isSuperAdmin}
+                            defaultValue={
+                              isSuperAdmin
+                                ? `SUPERADMIN`
+                                : isAdmin
+                                  ? `ADMIN?${org._id}`
+                                  : `USER?${org._id}`
+                            }
                           >
-                            {isAdmin ? (
+                            {isSuperAdmin ? (
+                              <>
+                                <option value={`SUPERADMIN`}>SUPERADMIN</option>
+                                <option value={`ADMIN?${org._id}`}>
+                                  ADMIN
+                                </option>
+                                <option value={`USER?${org._id}`}>USER</option>
+                              </>
+                            ) : isAdmin ? (
                               <>
                                 <option value={`ADMIN?${org._id}`}>
                                   ADMIN
@@ -500,8 +505,24 @@ const UsersTableItem = (props: Props): JSX.Element => {
                             size="sm"
                             onChange={changeRoleInOrg}
                             data-testid={`changeRoleInOrg${org._id}`}
+                            disabled={isSuperAdmin}
+                            defaultValue={
+                              isSuperAdmin
+                                ? `SUPERADMIN`
+                                : isAdmin
+                                  ? `ADMIN?${org._id}`
+                                  : `USER?${org._id}`
+                            }
                           >
-                            {isAdmin ? (
+                            {isSuperAdmin ? (
+                              <>
+                                <option value={`SUPERADMIN`}>SUPERADMIN</option>
+                                <option value={`ADMIN?${org._id}`}>
+                                  ADMIN
+                                </option>
+                                <option value={`USER?${org._id}`}>USER</option>
+                              </>
+                            ) : isAdmin ? (
                               <>
                                 <option value={`ADMIN?${org._id}`}>
                                   ADMIN

--- a/src/screens/Users/Users.tsx
+++ b/src/screens/Users/Users.tsx
@@ -244,7 +244,6 @@ const Users = (): JSX.Element => {
     '#',
     t('name'),
     t('email'),
-    t('roles_userType'),
     t('joined_organizations'),
     t('blocked_organizations'),
   ];


### PR DESCRIPTION

**What kind of change does this PR introduce?**

This PR is a bug fix.

**Issue Number:**

Fixes #1799 

**Did you add tests for your changes?**

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->
Yes

**Snapshots/Videos:**

[removed_drop_down.webm](https://github.com/PalisadoesFoundation/talawa-admin/assets/116624667/9b4fc421-f16b-498e-bf60-f9b83912545d)

Updated users page:

![users_screen](https://github.com/PalisadoesFoundation/talawa-admin/assets/116624667/cc71bf41-85e6-4a95-8b23-37b7d3bab689)


**If relevant, did you update the documentation?**

NA

**Summary**

- The drop down present on the `users page` was of no use as we are now following _per-organization policy_. I removed the drop down.
- The `Superadmin` can now edit the user roles from within the modals present on the `users page`.

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->
No


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
Yes