### PR TITLE
fix: Fixed organizations not visible

### DIFF
--- a/src/screens/OrgList/OrgList.test.tsx
+++ b/src/screens/OrgList/OrgList.test.tsx
@@ -68,6 +68,29 @@ describe('Organisations Page testing as SuperAdmin', () => {
     },
     image: new File(['hello'], 'hello.png', { type: 'image/png' }),
   };
+  test('Should display organisations for superAdmin even if admin For field is empty', async () => {
+    window.location.assign('/');
+    setItem('id', '123');
+    setItem('SuperAdmin', true);
+    setItem('AdminFor', []);
+
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <OrgList />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    await wait();
+    expect(
+      screen.queryByText('Organizations Not Found'),
+    ).not.toBeInTheDocument();
+  });
 
   test('Testing search functionality by pressing enter', async () => {
     setItem('id', '123');

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -406,9 +406,10 @@ function orgList(): JSX.Element {
       </div>
       {/* Text Infos for list */}
       {!isLoading &&
-      ((orgsData?.organizationsConnection.length === 0 &&
-        searchByName.length == 0) ||
-        (userData && adminFor.length === 0)) ? (
+      (!orgsData?.organizationsConnection ||
+        orgsData.organizationsConnection.length === 0) &&
+      searchByName.length === 0 &&
+      (!userData || adminFor.length === 0 || superAdmin) ? (
         <div className={styles.notFound}>
           <h3 className="m-0">{t('noOrgErrorTitle')}</h3>
           <h6 className="text-secondary">{t('noOrgErrorDescription')}</h6>
@@ -419,10 +420,10 @@ function orgList(): JSX.Element {
         searchByName.length > 0 ? (
         /* istanbul ignore next */
         <div className={styles.notFound} data-testid="noResultFound">
-          <h4 className="m-0">
+            <h4 className="m-0">
             {t('noResultsFoundFor')} &quot;{searchByName}&quot;
           </h4>
-        </div>
+          </div>
       ) : (
         <>
           <InfiniteScroll

--- a/src/screens/OrgList/OrgList.tsx
+++ b/src/screens/OrgList/OrgList.tsx
@@ -420,10 +420,10 @@ function orgList(): JSX.Element {
         searchByName.length > 0 ? (
         /* istanbul ignore next */
         <div className={styles.notFound} data-testid="noResultFound">
-            <h4 className="m-0">
+          <h4 className="m-0">
             {t('noResultsFoundFor')} &quot;{searchByName}&quot;
           </h4>
-          </div>
+        </div>
       ) : (
         <>
           <InfiniteScroll


### PR DESCRIPTION

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->
bugfix

**Issue Number:**

Fixes #1768 

**Did you add tests for your changes?**
Yes.

**Snapshots/Videos:**

[Screencast from 2024-04-04 12-33-54.webm](https://github.com/PalisadoesFoundation/talawa-admin/assets/116624667/888ca95b-1989-4cf1-bf1a-f4cb9c6400ec)


**If relevant, did you update the documentation?**
Not Relevant.

**Summary**
This PR fixes the issue of organizations not being visible when one signs up as a `superadmin` other than the `defaultSuperadmin` or the `testSuperadmin`. Now, it works well with newly registered `LAST_RESORT_SUPERADMIN_EMAIL`.

**Does this PR introduce a breaking change?**
No.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->
