### PR TITLE
Add English Translation for `makeActive` String

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -264,6 +264,7 @@
     "editActionItem": "Edit Action Item",
     "isCompleted": "Completed",
     "latest": "Latest",
+    "makeActive": "Active",
     "noActionItems": "No Action Items",
     "options": "Options",
     "preCompletionNotes": "Pre Completion Notes",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -267,6 +267,7 @@
     "editActionItem": "Modifier l'élément d'action",
     "isCompleted": "Complété",
     "latest": "Dernier",
+    "makeActive": "Actif",
     "noActionItems": "Aucune action",
     "options": "Possibilités",
     "preCompletionNotes": "Notes préalables à l'achèvement",

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -267,6 +267,7 @@
     "editActionItem": "क्रिया आइटम संपादित करें",
     "isCompleted": "पुरा होना।",
     "latest": "नवीनतम",
+    "makeActive": "सक्रिय",
     "noActionItems": "कोई एक्शन आइटम नहीं",
     "options": "विकल्प",
     "preCompletionNotes": "समापन पूर्व नोट्स",

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -267,6 +267,7 @@
     "editActionItem": "编辑操作项",
     "isCompleted": "完全的",
     "latest": "最新的",
+    "makeActive": "积极的",
     "noActionItems": "无行动项目",
     "options": "选项",
     "preCompletionNotes": "预完成注释",

--- a/src/components/ActionItems/ActionItemsContainer.test.tsx
+++ b/src/components/ActionItems/ActionItemsContainer.test.tsx
@@ -182,6 +182,48 @@ describe('Testing Action Item Categories Component', () => {
     );
   });
 
+  test('completed action item status change modal loads correctly', async () => {
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <Provider store={store}>
+          <BrowserRouter>
+            <LocalizationProvider dateAdapter={AdapterDayjs}>
+              <I18nextProvider i18n={i18nForTest}>
+                <ActionItemsContainer {...props} />
+              </I18nextProvider>
+            </LocalizationProvider>
+          </BrowserRouter>
+        </Provider>
+      </MockedProvider>,
+    );
+
+    await wait();
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByTestId('actionItemStatusChangeCheckbox')[1],
+      ).toBeInTheDocument();
+    });
+    userEvent.click(screen.getAllByTestId('actionItemStatusChangeCheckbox')[1]);
+
+    await waitFor(() => {
+      return expect(
+        screen.findByTestId('actionItemStatusChangeModalCloseBtn'),
+      ).resolves.toBeInTheDocument();
+    });
+    expect(screen.getByText(translations.actionItemStatus)).toBeInTheDocument();
+
+    expect(
+      screen.getByTestId('actionItemsStatusChangeNotes'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(translations.actionItemCompleted),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: translations.makeActive }),
+    ).toBeInTheDocument();
+  });
+
   test('opens and closes the preview modal correctly', async () => {
     render(
       <MockedProvider addTypename={false} link={link}>

--- a/src/components/ActionItems/ActionItemsContainer.test.tsx
+++ b/src/components/ActionItems/ActionItemsContainer.test.tsx
@@ -473,6 +473,9 @@ describe('Testing Action Item Categories Component', () => {
         screen.getByTestId('actionItemStatusChangeSubmitBtn'),
       ).toBeInTheDocument();
     });
+    expect(
+      screen.getByTestId('actionItemStatusChangeSubmitBtn'),
+    ).toHaveTextContent(translations.markCompletion);
     userEvent.click(screen.getByTestId('actionItemStatusChangeSubmitBtn'));
 
     await waitFor(() => {
@@ -506,6 +509,9 @@ describe('Testing Action Item Categories Component', () => {
         screen.getByTestId('actionItemStatusChangeSubmitBtn'),
       ).toBeInTheDocument();
     });
+    expect(
+      screen.getByTestId('actionItemStatusChangeSubmitBtn'),
+    ).toHaveTextContent(translations.makeActive);
     userEvent.click(screen.getByTestId('actionItemStatusChangeSubmitBtn'));
 
     await waitFor(() => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
bugfix

**Issue Number:**

Fixes #2048 

**Did you add tests for your changes?**
Yes

**Snapshots/Videos:**
![image](https://github.com/PalisadoesFoundation/talawa-admin/assets/100834122/9d1a0d97-f601-4eec-9259-e077839521c7)
![image](https://github.com/PalisadoesFoundation/talawa-admin/assets/100834122/896a4c9f-52ed-42c6-a83a-012a60734a1b)
![image](https://github.com/PalisadoesFoundation/talawa-admin/assets/100834122/9ca6ac5f-5987-4c20-92d4-e8be4ae0da6a)
![image](https://github.com/PalisadoesFoundation/talawa-admin/assets/100834122/fede9244-db1a-4749-b34c-e3f1c3204d95)
![image](https://github.com/PalisadoesFoundation/talawa-admin/assets/100834122/69baeeae-7d93-41b9-9c2f-9afbf0a10c61)

**Summary**
1) Added `makeActive`  string in all translations file
2) Updated test to check label of status update button on modal in Action Items page

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added translations for the term "Active" in English, French, Hindi, and Chinese locales.

- **Tests**
  - Enhanced test coverage to verify text content before and after user interactions in the `ActionItemsContainer` component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->