### PR TITLE
Joined date fixed on User profile 

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -33,6 +33,7 @@ const MOCKS = [
           _id: '123',
           firstName: 'John',
           lastName: 'Doe',
+          createdAt: '2023-04-13T04:53:17.742+00:00',
           image: 'john.jpg',
           email: 'johndoe@gmail.com',
           birthDate: '1990-01-01',

--- a/src/GraphQl/Queries/Queries.ts
+++ b/src/GraphQl/Queries/Queries.ts
@@ -8,6 +8,7 @@ export const CHECK_AUTH = gql`
       _id
       firstName
       lastName
+      createdAt
       image
       email
       birthDate

--- a/src/components/UserProfileSettings/UserProfile.test.tsx
+++ b/src/components/UserProfileSettings/UserProfile.test.tsx
@@ -11,6 +11,7 @@ describe('UserProfile component', () => {
     const userDetails = {
       firstName: 'John',
       lastName: 'Doe',
+      createdAt: '2023-04-13T04:53:17.742+00:00',
       email: 'john.doe@example.com',
       image: 'profile-image-url',
     };
@@ -31,7 +32,7 @@ describe('UserProfile component', () => {
     expect(profileImage).toBeInTheDocument();
     expect(profileImage).toHaveAttribute('src', 'profile-image-url');
 
-    expect(getByText('Joined 1st May, 2021')).toBeInTheDocument();
+    expect(getByText('Joined 13 April 2023')).toBeInTheDocument();
 
     expect(getByText('Copy Profile Link')).toBeInTheDocument();
   });

--- a/src/components/UserProfileSettings/UserProfile.tsx
+++ b/src/components/UserProfileSettings/UserProfile.tsx
@@ -8,13 +8,25 @@ import styles from './UserProfileSettings.module.css';
 interface InterfaceUserProfile {
   firstName: string;
   lastName: string;
+  createdAt: string;
   email: string;
   image: string;
 }
+const prettyDate = (param: string): string => {
+  const date = new Date(param);
+  if (date?.toDateString() === 'Invalid Date') {
+    return 'Unavailable';
+  }
+  const day = date.getDate();
+  const month = date.toLocaleString('default', { month: 'long' });
+  const year = date.getFullYear();
+  return `${day} ${month} ${year}`;
+};
 
 const UserProfile: React.FC<InterfaceUserProfile> = ({
   firstName,
   lastName,
+  createdAt,
   email,
   image,
 }): JSX.Element => {
@@ -49,7 +61,7 @@ const UserProfile: React.FC<InterfaceUserProfile> = ({
               <span className="d-flex">
                 <CalendarMonthOutlinedIcon />
                 <span className="d-flex align-end">
-                  {tCommon('joined')} 1st May, 2021
+                  {tCommon('joined')} {prettyDate(createdAt)}
                 </span>
               </span>
             </div>

--- a/src/components/UserProfileSettings/UserProfile.tsx
+++ b/src/components/UserProfileSettings/UserProfile.tsx
@@ -12,7 +12,7 @@ interface InterfaceUserProfile {
   email: string;
   image: string;
 }
-const prettyDate = (param: string): string => {
+const joinedDate = (param: string): string => {
   const date = new Date(param);
   if (date?.toDateString() === 'Invalid Date') {
     return 'Unavailable';
@@ -61,7 +61,7 @@ const UserProfile: React.FC<InterfaceUserProfile> = ({
               <span className="d-flex">
                 <CalendarMonthOutlinedIcon />
                 <span className="d-flex align-end">
-                  {tCommon('joined')} {prettyDate(createdAt)}
+                  {tCommon('joined')} {joinedDate(createdAt)}
                 </span>
               </span>
             </div>

--- a/src/screens/UserPortal/Settings/Settings.test.tsx
+++ b/src/screens/UserPortal/Settings/Settings.test.tsx
@@ -19,6 +19,7 @@ const MOCKS = [
       variables: {
         firstName: 'Noble',
         lastName: 'Mittal',
+        createdAt: '2021-03-01',
         gender: 'MALE',
         phoneNumber: '+174567890',
         birthDate: '2024-03-01',
@@ -51,6 +52,7 @@ const Mocks1 = [
           email: 'johndoe@gmail.com',
           firstName: 'John',
           lastName: 'Doe',
+          createdAt: '2021-03-01T00:00:00.000Z',
           gender: 'MALE',
           maritalStatus: 'SINGLE',
           educationGrade: 'GRADUATE',
@@ -83,6 +85,7 @@ const Mocks2 = [
           email: 'johndoe@gmail.com',
           firstName: '',
           lastName: '',
+          createdAt: '',
           gender: '',
           maritalStatus: '',
           educationGrade: '',

--- a/src/screens/UserPortal/Settings/Settings.tsx
+++ b/src/screens/UserPortal/Settings/Settings.tsx
@@ -21,6 +21,7 @@ import DeleteUser from 'components/UserProfileSettings/DeleteUser';
 import OtherSettings from 'components/UserProfileSettings/OtherSettings';
 import UserSidebar from 'components/UserPortal/UserSidebar/UserSidebar';
 import ProfileDropdown from 'components/ProfileDropdown/ProfileDropdown';
+import { create } from 'domain';
 
 export default function settings(): JSX.Element {
   const { t } = useTranslation('translation', {
@@ -52,6 +53,7 @@ export default function settings(): JSX.Element {
   const [userDetails, setUserDetails] = React.useState({
     firstName: '',
     lastName: '',
+    createdAt: '',
     gender: '',
     email: '',
     phoneNumber: '',
@@ -110,6 +112,7 @@ export default function settings(): JSX.Element {
       const {
         firstName,
         lastName,
+        createdAt,
         gender,
         phone,
         birthDate,
@@ -123,6 +126,7 @@ export default function settings(): JSX.Element {
         ...userDetails,
         firstName: firstName || '',
         lastName: lastName || '',
+        createdAt: createdAt || '',
         gender: gender || '',
         phoneNumber: phone?.mobile || '',
         birthDate: birthDate || '',
@@ -142,6 +146,7 @@ export default function settings(): JSX.Element {
       const {
         firstName,
         lastName,
+        createdAt,
         gender,
         email,
         phone,
@@ -156,6 +161,7 @@ export default function settings(): JSX.Element {
       setUserDetails({
         firstName,
         lastName,
+        createdAt,
         gender,
         email,
         phoneNumber: phone?.mobile || '',
@@ -215,6 +221,7 @@ export default function settings(): JSX.Element {
               <UserProfile
                 firstName={userDetails.firstName}
                 lastName={userDetails.lastName}
+                createdAt={userDetails.createdAt}
                 email={userDetails.email}
                 image={userDetails.image}
               />
@@ -579,6 +586,7 @@ export default function settings(): JSX.Element {
               <UserProfile
                 firstName={userDetails.firstName}
                 lastName={userDetails.lastName}
+                createdAt={userDetails.createdAt}
                 email={userDetails.email}
                 image={userDetails.image}
               />


### PR DESCRIPTION


**What kind of change does this PR introduce?**

BugFix
Fixed the joining date of user on the user profile section.

**Issue Number:**

Fixes #2118 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<img width="439" alt="Screenshot 2024-07-25 at 1 20 56 PM" src="https://github.com/user-attachments/assets/a2e1852e-edd6-495a-b8e6-5a4ba71112f8">


**If relevant, did you update the documentation?**

NA

**Summary**

The joining date for the USER was static and was set to " 1st May, 2021 " which was incorrect . Fixed this by dynamically rendering the actual user profile createdAt date.

**Does this PR introduce a breaking change?**

No

**Other information**


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced user profile data by including the account creation date.
	- Introduced a new date formatting function for improved readability of the join date.
  
- **Bug Fixes**
	- Updated test cases to reflect the new `createdAt` property and adjust expected values.
  
- **Documentation**
	- Improved user interface to dynamically display the user's join date instead of a hardcoded value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->