### PR TITLE
fixed placeholder and default -1 value in number of rows

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -710,6 +710,7 @@
     "createdOrganizations": "Created Organizations",
     "selectOrganization": "Select an organization",
     "searchUsers": "Search users",
+    "searchOrganizations": "Search organizations",
     "nothingToShow": "Nothing to show here.",
     "organizations": "Organizations"
   },

--- a/src/components/PaginationList/PaginationList.tsx
+++ b/src/components/PaginationList/PaginationList.tsx
@@ -18,7 +18,13 @@ interface InterfacePropsInterface {
   ) => void;
 }
 
-const PaginationList = (props: InterfacePropsInterface): JSX.Element => {
+const PaginationList = ({
+  count,
+  rowsPerPage,
+  page,
+  onPageChange,
+  onRowsPerPageChange,
+}: InterfacePropsInterface): JSX.Element => {
   const { t } = useTranslation('translation', {
     keyPrefix: 'paginationList',
   });
@@ -34,24 +40,23 @@ const PaginationList = (props: InterfacePropsInterface): JSX.Element => {
           }}
           rowsPerPageOptions={[]}
           colSpan={5}
-          count={props.count}
-          rowsPerPage={props.rowsPerPage}
-          page={props.page}
+          count={count}
+          rowsPerPage={rowsPerPage}
+          page={page}
           SelectProps={{
             inputProps: {
               'aria-label': 'rows per page',
             },
             native: true,
           }}
-          onPageChange={props.onPageChange}
-          onRowsPerPageChange={props.onRowsPerPageChange}
+          onPageChange={onPageChange}
+          onRowsPerPageChange={onRowsPerPageChange}
           ActionsComponent={Pagination}
         />
       </Hidden>
       <Hidden smDown initialWidth={'lg'}>
         <TablePagination
           rowsPerPageOptions={[
-            -1,
             5,
             10,
             30,
@@ -59,17 +64,17 @@ const PaginationList = (props: InterfacePropsInterface): JSX.Element => {
           ]}
           data-testid={'table-pagination'}
           colSpan={4}
-          count={props.count}
-          rowsPerPage={props.rowsPerPage}
-          page={props.page}
+          count={count}
+          rowsPerPage={rowsPerPage}
+          page={page}
           SelectProps={{
             inputProps: {
               'aria-label': 'rows per page',
             },
             native: true,
           }}
-          onPageChange={props.onPageChange}
-          onRowsPerPageChange={props.onRowsPerPageChange}
+          onPageChange={onPageChange}
+          onRowsPerPageChange={onRowsPerPageChange}
           ActionsComponent={Pagination}
           labelRowsPerPage={t('rowsPerPage')}
         />

--- a/src/screens/UserPortal/Organizations/Organizations.tsx
+++ b/src/screens/UserPortal/Organizations/Organizations.tsx
@@ -273,7 +273,7 @@ export default function organizations(): JSX.Element {
           <div>
             <InputGroup className={styles.maxWidth}>
               <Form.Control
-                placeholder={t('searchUsers')}
+                placeholder={t('searchOrganizations')}
                 id="searchUserOrgs"
                 type="text"
                 className={`${styles.borderNone} ${styles.backgroundWhite}`}


### PR DESCRIPTION
**What Kind of change does this PR do?**

Fixed the Placeholder and the default -1 value in number of rows, taken care of the naming translation conventions as well.
Along with it there was props destruction error so also solved it to as was generating error in commit. Code it working fine
![SearchOrg](https://github.com/user-attachments/assets/32c0b3a0-f32c-4e09-b596-f5b180b82314)

![RowsPerPage](https://github.com/user-attachments/assets/02c51da7-e6f9-4bbb-8b76-830aabdfd690)

its working absolutely fine! hope I get my first open source contribution!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new translation for "Search organizations" to enhance localization.
	- Updated placeholder text in the organizations search input for clarity.
  
- **Refactor**
	- Improved readability by destructuring props in the `PaginationList` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->