### PR TITLE
Add Unit Tests for OrgPostCard

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -60,7 +60,7 @@
     "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
     "@typescript-eslint/no-non-null-assertion": "error",
     "@typescript-eslint/no-var-requires": "error",
-    "@typescript-eslint/ban-types": "off",
+    "@typescript-eslint/ban-types": "error",
     "@typescript-eslint/no-duplicate-enum-values": "error",
     "@typescript-eslint/array-type": "error",
     "@typescript-eslint/consistent-type-assertions": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -60,7 +60,7 @@
     "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
     "@typescript-eslint/no-non-null-assertion": "error",
     "@typescript-eslint/no-var-requires": "error",
-    "@typescript-eslint/ban-types": "error",
+    "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/no-duplicate-enum-values": "error",
     "@typescript-eslint/array-type": "error",
     "@typescript-eslint/consistent-type-assertions": "error",

--- a/src/components/OrgPostCard/OrgPostCard.test.tsx
+++ b/src/components/OrgPostCard/OrgPostCard.test.tsx
@@ -113,6 +113,7 @@ describe('Testing Organization Post Card', () => {
 
   const props = {
     id: '12',
+    postID: '123',
     postTitle: 'Event Info',
     postInfo: 'Time change',
     postAuthor: 'John Doe',
@@ -134,11 +135,25 @@ describe('Testing Organization Post Card', () => {
   }));
   global.alert = jest.fn();
 
+  test('Opens post on image click', () => {
+    const { getByTestId, getByAltText } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <I18nextProvider i18n={i18nForTest}>
+          <OrgPostCard {...props} />
+        </I18nextProvider>
+      </MockedProvider>,
+    );
+    userEvent.click(screen.getByAltText('image'));
+
+    expect(getByTestId('card-text')).toBeInTheDocument();
+    expect(getByTestId('card-title')).toBeInTheDocument();
+    expect(getByAltText('image')).toBeInTheDocument();
+  });
   test('renders with default props', () => {
     const { getByAltText, getByTestId } = render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props} />
+          <OrgPostCard {...props} />
         </I18nextProvider>
       </MockedProvider>,
     );
@@ -146,12 +161,11 @@ describe('Testing Organization Post Card', () => {
     expect(getByTestId('card-title')).toBeInTheDocument();
     expect(getByAltText('image')).toBeInTheDocument();
   });
-
   test('toggles "Read more" button', () => {
     const { getByTestId } = render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props} />
+          <OrgPostCard {...props} />
         </I18nextProvider>
       </MockedProvider>,
     );
@@ -168,7 +182,7 @@ describe('Testing Organization Post Card', () => {
     render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props} />
+          <OrgPostCard {...props} />
         </I18nextProvider>
       </MockedProvider>,
     );
@@ -187,7 +201,7 @@ describe('Testing Organization Post Card', () => {
     render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props} />
+          <OrgPostCard {...props} />
         </I18nextProvider>
       </MockedProvider>,
     );
@@ -199,7 +213,7 @@ describe('Testing Organization Post Card', () => {
     const { getByTestId } = render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props} />
+          <OrgPostCard {...props} />
         </I18nextProvider>
       </MockedProvider>,
     );
@@ -264,11 +278,89 @@ describe('Testing Organization Post Card', () => {
       { timeout: 2500 },
     );
   });
+  test('Testing post updating functionality fail case', async () => {
+    const props2 = {
+      id: '',
+      postID: '123',
+      postTitle: 'Event Info',
+      postInfo: 'Time change',
+      postAuthor: 'John Doe',
+      postPhoto: 'test.png',
+      postVideo: 'test.mp4',
+      pinned: true,
+    };
+    const { getByTestId } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <I18nextProvider i18n={i18nForTest}>
+          <OrgPostCard {...props2} />
+        </I18nextProvider>
+      </MockedProvider>,
+    );
+
+    await wait();
+    userEvent.click(screen.getByAltText('image'));
+    userEvent.click(screen.getByTestId('moreiconbtn'));
+
+    userEvent.click(screen.getByTestId('editPostModalBtn'));
+    fireEvent.change(getByTestId('updateTitle'), {
+      target: { value: 'updated title' },
+    });
+    fireEvent.change(getByTestId('updateText'), {
+      target: { value: 'This is a updated text' },
+    });
+    const postVideoUrlInput = screen.queryByTestId('postVideoUrl');
+    if (postVideoUrlInput) {
+      fireEvent.change(getByTestId('postVideoUrl'), {
+        target: { value: 'This is a updated video' },
+      });
+      userEvent.click(screen.getByPlaceholderText(/video/i));
+      const input = getByTestId('postVideoUrl');
+      const file = new File(['test-video'], 'test.mp4', { type: 'video/mp4' });
+      Object.defineProperty(input, 'files', {
+        value: [file],
+      });
+      fireEvent.change(input);
+      await waitFor(() => {
+        convertToBase64(file);
+      });
+
+      userEvent.click(screen.getByTestId('closePreview'));
+    }
+    const imageUrlInput = screen.queryByTestId('postImageUrl');
+    if (imageUrlInput) {
+      fireEvent.change(getByTestId('postImageUrl'), {
+        target: { value: 'This is a updated image' },
+      });
+      userEvent.click(screen.getByPlaceholderText(/image/i));
+      const input = getByTestId('postImageUrl');
+      const file = new File(['test-image'], 'test.jpg', { type: 'image/jpeg' });
+      Object.defineProperty(input, 'files', {
+        value: [file],
+      });
+      fireEvent.change(input);
+
+      // Simulate the asynchronous base64 conversion function
+      await waitFor(() => {
+        convertToBase64(file); // Replace with the expected base64-encoded image
+      });
+      document.getElementById = jest.fn(() => input);
+      const clearImageButton = getByTestId('closeimage');
+      fireEvent.click(clearImageButton);
+    }
+    userEvent.click(screen.getByTestId('updatePostBtn'));
+
+    await waitFor(
+      () => {
+        expect(window.location.reload).toHaveBeenCalled();
+      },
+      { timeout: 2500 },
+    );
+  });
   test('Testing pin post functionality', async () => {
     render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props} />
+          <OrgPostCard {...props} />
         </I18nextProvider>
       </MockedProvider>,
     );
@@ -289,6 +381,7 @@ describe('Testing Organization Post Card', () => {
   test('Testing pin post functionality fail case', async () => {
     const props2 = {
       id: '',
+      postID: '123',
       postTitle: 'Event Info',
       postInfo: 'Time change',
       postAuthor: 'John Doe',
@@ -299,7 +392,7 @@ describe('Testing Organization Post Card', () => {
     render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props2} />
+          <OrgPostCard {...props2} />
         </I18nextProvider>
       </MockedProvider>,
     );
@@ -315,7 +408,7 @@ describe('Testing Organization Post Card', () => {
       <MockedProvider addTypename={false} link={link}>
         <BrowserRouter>
           <I18nextProvider i18n={i18nForTest}>
-            <OrgPostCard postID="123" {...props} />
+            <OrgPostCard {...props} />
           </I18nextProvider>
         </BrowserRouter>
       </MockedProvider>,
@@ -339,6 +432,7 @@ describe('Testing Organization Post Card', () => {
   test('Testing post delete functionality fail case', async () => {
     const props2 = {
       id: '',
+      postID: '123',
       postTitle: 'Event Info',
       postInfo: 'Time change',
       postAuthor: 'John Doe',
@@ -350,7 +444,7 @@ describe('Testing Organization Post Card', () => {
       <MockedProvider addTypename={false} link={link}>
         <BrowserRouter>
           <I18nextProvider i18n={i18nForTest}>
-            <OrgPostCard postID="123" {...props2} />
+            <OrgPostCard {...props2} />
           </I18nextProvider>
         </BrowserRouter>
       </MockedProvider>,
@@ -368,7 +462,7 @@ describe('Testing Organization Post Card', () => {
     render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props} />
+          <OrgPostCard {...props} />
         </I18nextProvider>
       </MockedProvider>,
     );
@@ -377,12 +471,15 @@ describe('Testing Organization Post Card', () => {
 
     userEvent.click(screen.getByAltText('image'));
     userEvent.click(screen.getByTestId('closeiconbtn'));
+
+    //Primary Modal is closed
+    expect(screen.queryByTestId('moreiconbtn')).not.toBeInTheDocument();
   });
   test('Testing close functionality of secondary modal', async () => {
     render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props} />
+          <OrgPostCard {...props} />
         </I18nextProvider>
       </MockedProvider>,
     );
@@ -392,12 +489,30 @@ describe('Testing Organization Post Card', () => {
     userEvent.click(screen.getByAltText('image'));
     userEvent.click(screen.getByTestId('moreiconbtn'));
     userEvent.click(screen.getByTestId('closebtn'));
+
+    //Secondary Modal is closed
+    expect(screen.queryByTestId('deletePostModalBtn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('editPostModalBtn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pinpostBtn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('closebtn')).not.toBeInTheDocument();
   });
   test('renders without "Read more" button when postInfo length is less than or equal to 43', () => {
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <I18nextProvider i18n={i18nForTest}>
+          <OrgPostCard {...props} />
+        </I18nextProvider>
+      </MockedProvider>,
+    );
+    expect(screen.queryByTestId('toggleBtn')).not.toBeInTheDocument();
+  });
+  test('renders with "Read more" button when postInfo length is more than 43', () => {
     const props2 = {
       id: '12',
+      postID: '123',
       postTitle: 'Event Info',
-      postInfo: 'Lorem ipsum dolor sit amet',
+      postInfo:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vitae vestibulum.', // Length is greater than 43
       postAuthor: 'John Doe',
       postPhoto: 'photoLink',
       postVideo: 'videoLink',
@@ -406,16 +521,19 @@ describe('Testing Organization Post Card', () => {
     render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props2} />
+          <OrgPostCard {...props2} />
         </I18nextProvider>
       </MockedProvider>,
     );
+    userEvent.click(screen.getByAltText('image'));
+
+    expect(screen.getByTestId('toggleBtn')).toBeInTheDocument();
   });
   test('updates state variables correctly when handleEditModal is called', () => {
     const link2 = new StaticMockLink(MOCKS, true);
     render(
       <MockedProvider link={link2} addTypename={false}>
-        <OrgPostCard postID="123" {...props} />
+        <OrgPostCard {...props} />
       </MockedProvider>,
     );
     userEvent.click(screen.getByAltText('image'));
@@ -426,23 +544,48 @@ describe('Testing Organization Post Card', () => {
 
     userEvent.click(screen.getByTestId('editPostModalBtn'));
 
-    // expect(screen.queryByTestId('editPostModalBtn')).toBeInTheDocument();
-    // expect(screen.queryByTestId('deletePostModalBtn')).not.toBeInTheDocument();
-    // expect(screen.queryByTestId('closeiconbtn')).not.toBeInTheDocument();
+    //Primary Modal is closed
+    expect(screen.queryByTestId('closeiconbtn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('moreiconbtn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('toggleBtn')).not.toBeInTheDocument();
 
-    // expect(screen.getByTestId('editPostModal')).toHaveClass('show');
-    // expect(screen.getByTestId('deletePostModal')).not.toHaveClass('show');
+    //Secondary Modal is closed
+    expect(screen.queryByTestId('deletePostModalBtn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('editPostModalBtn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pinpostBtn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('closebtn')).not.toBeInTheDocument();
+  });
+  test('updates state variables correctly when handleDeleteModal is called', () => {
+    const link2 = new StaticMockLink(MOCKS, true);
+    render(
+      <MockedProvider link={link2} addTypename={false}>
+        <OrgPostCard {...props} />
+      </MockedProvider>,
+    );
+    userEvent.click(screen.getByAltText('image'));
 
-    // expect(screen.getByTestId('modalVisible')).toBe('false');
-    // expect(screen.getByTestId('menuVisible')).toBe('false');
-    // expect(screen.getByTestId('showEditModal')).toBe('true');
-    // expect(screen.getByTestId('showDeleteModal')).toBe('false');
+    userEvent.click(screen.getByTestId('moreiconbtn'));
+
+    expect(screen.queryByTestId('deletePostModalBtn')).toBeInTheDocument();
+
+    userEvent.click(screen.getByTestId('deletePostModalBtn'));
+
+    //Primary Modal is closed
+    expect(screen.queryByTestId('closeiconbtn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('moreiconbtn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('toggleBtn')).not.toBeInTheDocument();
+
+    //Secondary Modal is closed
+    expect(screen.queryByTestId('deletePostModalBtn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('editPostModalBtn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('pinpostBtn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('closebtn')).not.toBeInTheDocument();
   });
   test('clears postvideo state and resets file input value', async () => {
     const { getByTestId } = render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props} />
+          <OrgPostCard {...props} />
         </I18nextProvider>
       </MockedProvider>,
     );
@@ -476,7 +619,7 @@ describe('Testing Organization Post Card', () => {
     const { getByTestId } = render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props} />
+          <OrgPostCard {...props} />
         </I18nextProvider>
       </MockedProvider>,
     );
@@ -509,13 +652,63 @@ describe('Testing Organization Post Card', () => {
       fireEvent.click(clearImageButton);
     }
   });
+  test('clears postitle state and resets file input value', async () => {
+    const { getByTestId } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <I18nextProvider i18n={i18nForTest}>
+          <OrgPostCard {...props} />
+        </I18nextProvider>
+      </MockedProvider>,
+    );
+
+    await wait();
+
+    userEvent.click(screen.getByAltText('image'));
+    userEvent.click(screen.getByTestId('moreiconbtn'));
+    userEvent.click(screen.getByTestId('editPostModalBtn'));
+
+    fireEvent.change(getByTestId('updateTitle'), {
+      target: { value: '' },
+    });
+
+    userEvent.click(screen.getByTestId('updatePostBtn')); // Should not update post
+
+    expect(screen.getByTestId('updateTitle')).toHaveValue('');
+    expect(screen.getByTestId('closeOrganizationModal')).toBeInTheDocument();
+    expect(screen.getByTestId('updatePostBtn')).toBeInTheDocument();
+  });
+  test('clears postinfo state and resets file input value', async () => {
+    const { getByTestId } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <I18nextProvider i18n={i18nForTest}>
+          <OrgPostCard {...props} />
+        </I18nextProvider>
+      </MockedProvider>,
+    );
+
+    await wait();
+
+    userEvent.click(screen.getByAltText('image'));
+    userEvent.click(screen.getByTestId('moreiconbtn'));
+    userEvent.click(screen.getByTestId('editPostModalBtn'));
+
+    fireEvent.change(getByTestId('updateText'), {
+      target: { value: '' },
+    });
+
+    userEvent.click(screen.getByTestId('updatePostBtn')); // Should not update post
+
+    expect(screen.getByTestId('updateText')).toHaveValue('');
+    expect(screen.getByTestId('closeOrganizationModal')).toBeInTheDocument();
+    expect(screen.getByTestId('updatePostBtn')).toBeInTheDocument();
+  });
   test('Testing create organization modal', async () => {
     setItem('id', '123');
 
     render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props} />
+          <OrgPostCard {...props} />
         </I18nextProvider>
       </MockedProvider>,
     );
@@ -535,7 +728,7 @@ describe('Testing Organization Post Card', () => {
     const { getByTestId } = render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props} />
+          <OrgPostCard {...props} />
         </I18nextProvider>
       </MockedProvider>,
     );
@@ -554,7 +747,7 @@ describe('Testing Organization Post Card', () => {
     const { getByTestId } = render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props} />
+          <OrgPostCard {...props} />
         </I18nextProvider>
       </MockedProvider>,
     );
@@ -573,6 +766,7 @@ describe('Testing Organization Post Card', () => {
   test('for rendering when no image and no video is available', async () => {
     const props2 = {
       id: '',
+      postID: '123',
       postTitle: 'Event Info',
       postInfo: 'Time change',
       postAuthor: 'John Doe',
@@ -584,7 +778,7 @@ describe('Testing Organization Post Card', () => {
     const { getByAltText } = render(
       <MockedProvider addTypename={false} link={link}>
         <I18nextProvider i18n={i18nForTest}>
-          <OrgPostCard postID="123" {...props2} />
+          <OrgPostCard {...props2} />
         </I18nextProvider>
       </MockedProvider>,
     );


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR introduces unit tests for the OrgPostCard component .

**Issue Number:**
Fixes #1868 

**Did you add tests for your changes?**
Not relevant here

**Snapshots/Videos:**
![Screenshot 2024-09-13 223702](https://github.com/user-attachments/assets/2c26af03-2032-43a8-b9bb-46d12f1136e8)

**If relevant, did you update the documentation?**
Not relevant here

**Summary**
1.Added comprehensive unit tests for OrgPostCard.tsx to achieve 100% code coverage.
2.Ensured that all referenced components, widgets, and modals were tested.

**Does this PR introduce a breaking change?**
No

Other information

Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?
Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced testing suite for the `OrgPostCard` component with new test cases for image click functionality and post update scenarios.
	- Improved coverage for edge cases, ensuring correct behavior when required fields are left empty and verifying component state resets after interactions.
	- Added checks for rendering behavior based on `postInfo` string length, ensuring dynamic display of the "Read more" button.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->