### PR TITLE
Fix user icon boundary on profile page #2267

### DIFF
--- a/src/components/UserProfileSettings/UserProfile.tsx
+++ b/src/components/UserProfileSettings/UserProfile.tsx
@@ -86,7 +86,7 @@ const UserProfile: React.FC<InterfaceUserProfile> = ({
                   : email}
               </span>
               <ReactTooltip id="email" />
-              <span className="d-flex">
+              <span className="d-flex mt-2">
                 <CalendarMonthOutlinedIcon />
                 <span className="d-flex align-end">
                   {tCommon('joined')} {joinedDate(createdAt)}

--- a/src/components/UserProfileSettings/UserProfileSettings.module.css
+++ b/src/components/UserProfileSettings/UserProfileSettings.module.css
@@ -50,7 +50,7 @@
 .profileDetails {
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: start;
   justify-content: space-evenly;
   margin-left: 10%;
 }

--- a/src/components/UserProfileSettings/UserProfileSettings.module.css
+++ b/src/components/UserProfileSettings/UserProfileSettings.module.css
@@ -38,9 +38,13 @@
 }
 
 .imgContianer img {
-  height: 120px;
-  width: 120px;
+  height: 100px;
+  width: 100px;
   border-radius: 50%;
+}
+.profileContainer {
+  align-items: center;
+  justify-content: center;
 }
 
 .profileDetails {
@@ -54,9 +58,6 @@
 @media screen and (max-width: 1280px) and (min-width: 992px) {
   .imgContianer {
     margin: 1rem auto;
-  }
-  .profileContainer {
-    flex-direction: column;
   }
 }
 


### PR DESCRIPTION
What kind of change does this PR introduce? Bugfix

Issue Number: Fixes #2267

Did you add tests for your changes? No (If unit tests are applicable, consider adding them)

This PR resolves the issue where the user icon initials exceeded their boundary, disrupting the UI of the user profile page. The issue was observed when users logged in and viewed their profile. The fix ensures that the user icon initials are correctly contained within their boundary, maintaining a clean and consistent UI.

Before 
![photo_2024-09-16_15-21-58](https://github.com/user-attachments/assets/2f5b01c8-dd49-44f2-8fc6-69fb4dc64401)
After
![photo_2024-09-16_15-20-27](https://github.com/user-attachments/assets/1da87c7d-ba62-42bc-976c-8e11225540eb)


If relevant, did you update the documentation? N/A

Does this PR introduce a breaking change? No

Other information: N/A

Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)? Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `.profileContainer` class for improved alignment of profile elements.
- **Style**
	- Adjusted image container dimensions for a more refined visual presentation of user profile images.
	- Enhanced layout by centering profile elements using flexbox properties.
	- Added top margin to the user's joined date for better spacing in the profile card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->