### PR TITLE
feat: Add people to tag functaionality (GSoC)

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -332,7 +332,10 @@
     "successfullyUnassigned": "Tag unassigned from user",
     "addPeople": "Add People",
     "add": "Add",
-    "subTags": "Sub Tags"
+    "subTags": "Sub Tags",
+    "assignedToAll": "Tag Assigned to All",
+    "successfullyAssignedToPeople": "Tag assigned successfully",
+    "assignPeople": "Assign"
   },
   "userListCard": {
     "addAdmin": "Add Admin",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -335,7 +335,11 @@
     "subTags": "Sub Tags",
     "assignedToAll": "Tag Assigned to All",
     "successfullyAssignedToPeople": "Tag assigned successfully",
-    "assignPeople": "Assign"
+    "assignPeople": "Assign",
+    "errorOccurredWhileLoadingMembers": "Error occured while loading members",
+    "userName": "User Name",
+    "actions": "Actions",
+    "noOneSelected": "No One Selected"
   },
   "userListCard": {
     "addAdmin": "Add Admin",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -335,7 +335,11 @@
     "subTags": "Sous-étiquettes",
     "assignedToAll": "Étiquette attribuée à tous",
     "successfullyAssignedToPeople": "Étiquette attribuée avec succès",
-    "assignPeople": "Attribuer"
+    "assignPeople": "Attribuer",
+    "errorOccurredWhileLoadingMembers": "Erreur survenue lors du chargement des membres",
+    "userName": "Nom d'utilisateur",
+    "actions": "Actions",
+    "noOneSelected": "Personne sélectionnée"
   },
   "userListCard": {
     "addAdmin": "Ajouter un administrateur",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -332,7 +332,10 @@
     "successfullyUnassigned": "Étiquette retirée de l'utilisateur",
     "addPeople": "Ajouter des personnes",
     "add": "Ajouter",
-    "subTags": "Sous-étiquettes"
+    "subTags": "Sous-étiquettes",
+    "assignedToAll": "Étiquette attribuée à tous",
+    "successfullyAssignedToPeople": "Étiquette attribuée avec succès",
+    "assignPeople": "Attribuer"
   },
   "userListCard": {
     "addAdmin": "Ajouter un administrateur",

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -332,7 +332,10 @@
     "successfullyUnassigned": "उपयोगकर्ता से टैग हटा दिया गया",
     "addPeople": "लोगों को जोड़ें",
     "add": "जोड़ें",
-    "subTags": "उप-टैग्स"
+    "subTags": "उप-टैग्स",
+    "assignedToAll": "सभी को टैग असाइन किया गया",
+    "successfullyAssignedToPeople": "टैग सफलतापूर्वक असाइन किया गया",
+    "assignPeople": "असाइन करें"
   },
   "userListCard": {
     "addAdmin": "व्यवस्थापक जोड़ें",

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -335,7 +335,11 @@
     "subTags": "उप-टैग्स",
     "assignedToAll": "सभी को टैग असाइन किया गया",
     "successfullyAssignedToPeople": "टैग सफलतापूर्वक असाइन किया गया",
-    "assignPeople": "असाइन करें"
+    "assignPeople": "असाइन करें",
+    "errorOccurredWhileLoadingMembers": "सदस्यों को लोड करते समय त्रुटि हुई",
+    "userName": "उपयोगकर्ता नाम",
+    "actions": "क्रियाएँ",
+    "noOneSelected": "कोई चयनित नहीं"
   },
   "userListCard": {
     "addAdmin": "व्यवस्थापक जोड़ें",

--- a/public/locales/sp/translation.json
+++ b/public/locales/sp/translation.json
@@ -335,7 +335,11 @@
     "subTags": "Subetiquetas",
     "assignedToAll": "Etiqueta asignada a todos",
     "successfullyAssignedToPeople": "Etiqueta asignada con éxito",
-    "assignPeople": "Asignar"
+    "assignPeople": "Asignar",
+    "errorOccurredWhileLoadingMembers": "Error al cargar los miembros",
+    "userName": "Nombre de usuario",
+    "actions": "Acciones",
+    "noOneSelected": "Nadie seleccionado"
   },
   "userListCard": {
     "joined": "Unido",

--- a/public/locales/sp/translation.json
+++ b/public/locales/sp/translation.json
@@ -332,7 +332,10 @@
     "successfullyUnassigned": "Etiqueta desasignada del usuario",
     "addPeople": "Agregar Personas",
     "add": "Agregar",
-    "subTags": "Subetiquetas"
+    "subTags": "Subetiquetas",
+    "assignedToAll": "Etiqueta asignada a todos",
+    "successfullyAssignedToPeople": "Etiqueta asignada con éxito",
+    "assignPeople": "Asignar"
   },
   "userListCard": {
     "joined": "Unido",

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -335,7 +335,11 @@
     "subTags": "子标签",
     "assignedToAll": "标签分配给所有人",
     "successfullyAssignedToPeople": "标签分配成功",
-    "assignPeople": "分配"
+    "assignPeople": "分配",
+    "errorOccurredWhileLoadingMembers": "加载成员时出错",
+    "userName": "用户名",
+    "actions": "操作",
+    "noOneSelected": "未选择任何人"
   },
   "userListCard": {
     "addAdmin": "添加管理员",

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -332,7 +332,10 @@
     "successfullyUnassigned": "标签已从用户中取消分配",
     "addPeople": "添加人员",
     "add": "添加",
-    "subTags": "子标签"
+    "subTags": "子标签",
+    "assignedToAll": "标签分配给所有人",
+    "successfullyAssignedToPeople": "标签分配成功",
+    "assignPeople": "分配"
   },
   "userListCard": {
     "addAdmin": "添加管理员",

--- a/src/GraphQl/Mutations/TagMutations.ts
+++ b/src/GraphQl/Mutations/TagMutations.ts
@@ -72,3 +72,18 @@ export const REMOVE_USER_TAG = gql`
     }
   }
 `;
+
+/**
+ * GraphQL mutation to add people to tag.
+ *
+ * @param tagId - Id of the tag to be assigned.
+ * @param userIds - Ids of the users to assign to.
+ */
+
+export const ADD_PEOPLE_TO_TAG = gql`
+  mutation AddPeopleToUserTag($tagId: ID!, $userIds: [ID!]!) {
+    addPeopleToUserTag(input: { tagId: $tagId, userIds: $userIds }) {
+      _id
+    }
+  }
+`;

--- a/src/GraphQl/Queries/userTagQueries.ts
+++ b/src/GraphQl/Queries/userTagQueries.ts
@@ -92,7 +92,7 @@ export const USER_TAG_SUB_TAGS = gql`
  */
 
 export const USER_TAGS_MEMBERS_TO_ASSIGN_TO = gql`
-  query UserTagDetails(
+  query GetMembersToAssignTo(
     $id: ID!
     $after: String
     $before: String

--- a/src/GraphQl/Queries/userTagQueries.ts
+++ b/src/GraphQl/Queries/userTagQueries.ts
@@ -85,6 +85,48 @@ export const USER_TAG_SUB_TAGS = gql`
 `;
 
 /**
+ * GraphQL query to retrieve organization members that aren't assigned a certain tag.
+ *
+ * @param id - The ID of the tag.
+ * @returns The list of organization members.
+ */
+
+export const USER_TAGS_MEMBERS_TO_ASSIGN_TO = gql`
+  query UserTagDetails(
+    $id: ID!
+    $after: String
+    $before: String
+    $first: PositiveInt
+    $last: PositiveInt
+  ) {
+    getUserTag(id: $id) {
+      name
+      usersToAssignTo(
+        after: $after
+        before: $before
+        first: $first
+        last: $last
+      ) {
+        edges {
+          node {
+            _id
+            firstName
+            lastName
+          }
+        }
+        pageInfo {
+          startCursor
+          endCursor
+          hasNextPage
+          hasPreviousPage
+        }
+        totalCount
+      }
+    }
+  }
+`;
+
+/**
  * GraphQL query to retrieve the ancestor tags of a certain tag.
  *
  * @param id - The ID of the current tag.

--- a/src/components/AddPeopleToTag/AddPeopleToTag.module.css
+++ b/src/components/AddPeopleToTag/AddPeopleToTag.module.css
@@ -1,0 +1,77 @@
+.errorContainer {
+  min-height: 100vh;
+}
+
+.errorMessage {
+  margin-top: 25%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
+
+.errorIcon {
+  transform: scale(1.5);
+  color: var(--bs-danger);
+  margin-bottom: 1rem;
+}
+
+.tableHeader {
+  background-color: var(--bs-primary);
+  color: var(--bs-white);
+  font-size: 1rem;
+}
+
+.rowBackground {
+  background-color: var(--bs-white);
+  max-height: 120px;
+}
+
+.scrollContainer {
+  max-height: 100px; /* Adjust as needed */
+  overflow-y: auto;
+  margin-bottom: 1rem;
+}
+
+.memberBadge {
+  display: flex;
+  align-items: center;
+  padding: 5px 10px;
+  border-radius: 12px;
+  background-color: #f8f9fa; /* Light background */
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+  max-width: calc(100% - 30px); /* Ensure it fits within the container */
+}
+
+.removeFilterIcon {
+  cursor: pointer;
+}
+
+.scrollContainer {
+  max-height: 350px; /* Set your desired max height */
+  overflow-y: auto; /* Enable vertical scrolling */
+}
+
+/* SimpleLoader.css */
+.simple-loader {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+}
+
+.spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid rgba(0, 0, 0, 0.1);
+  border-top-color: #3498db;
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/AddPeopleToTag/AddPeopleToTag.test.tsx
+++ b/src/components/AddPeopleToTag/AddPeopleToTag.test.tsx
@@ -153,12 +153,17 @@ describe('Organisation Tags Page', () => {
     // Find the infinite scroll div by test ID or another selector
     const scrollableDiv = screen.getByTestId('scrollableDiv');
 
+    const initialMemberDataLength = screen.getAllByTestId('memberName').length;
+
     // Set scroll position to the bottom
     fireEvent.scroll(scrollableDiv, {
       target: { scrollY: scrollableDiv.scrollHeight },
     });
 
     await waitFor(() => {
+      const finalMemberDataLength = screen.getAllByTestId('memberName').length;
+      expect(finalMemberDataLength).toBeGreaterThan(initialMemberDataLength);
+
       expect(getByText(translations.addPeople)).toBeInTheDocument();
     });
   });

--- a/src/components/AddPeopleToTag/AddPeopleToTag.test.tsx
+++ b/src/components/AddPeopleToTag/AddPeopleToTag.test.tsx
@@ -1,4 +1,4 @@
-import React, { act } from 'react';
+import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
 import type { RenderResult } from '@testing-library/react';
 import {
@@ -26,11 +26,10 @@ import { MOCKS, MOCKS_ERROR } from './AddPeopleToTagsMocks';
 const link = new StaticMockLink(MOCKS, true);
 const link2 = new StaticMockLink(MOCKS_ERROR, true);
 
-async function wait(ms = 500): Promise<void> {
-  await act(() => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
+async function wait(): Promise<void> {
+  await waitFor(() => {
+    // The waitFor utility automatically uses optimal timing
+    return Promise.resolve();
   });
 }
 

--- a/src/components/AddPeopleToTag/AddPeopleToTag.test.tsx
+++ b/src/components/AddPeopleToTag/AddPeopleToTag.test.tsx
@@ -1,0 +1,194 @@
+import React, { act } from 'react';
+import { MockedProvider } from '@apollo/react-testing';
+import type { RenderResult } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+} from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import 'jest-location-mock';
+import { I18nextProvider } from 'react-i18next';
+
+import { store } from 'state/store';
+import userEvent from '@testing-library/user-event';
+import { StaticMockLink } from 'utils/StaticMockLink';
+import { toast } from 'react-toastify';
+import type { ApolloLink } from '@apollo/client';
+import type { InterfaceAddPeopleToTagProps } from './AddPeopleToTag';
+import AddPeopleToTag from './AddPeopleToTag';
+import i18n from 'utils/i18nForTest';
+import { MOCKS, MOCKS_ERROR } from './AddPeopleToTagsMocks';
+
+const link = new StaticMockLink(MOCKS, true);
+const link2 = new StaticMockLink(MOCKS_ERROR, true);
+
+async function wait(ms = 500): Promise<void> {
+  await act(() => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
+  });
+}
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    success: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+const translations = {
+  ...JSON.parse(
+    JSON.stringify(i18n.getDataByLanguage('en')?.translation.manageTag ?? {}),
+  ),
+  ...JSON.parse(JSON.stringify(i18n.getDataByLanguage('en')?.common ?? {})),
+  ...JSON.parse(JSON.stringify(i18n.getDataByLanguage('en')?.errors ?? {})),
+};
+
+const props: InterfaceAddPeopleToTagProps = {
+  addPeopleToTagModalIsOpen: true,
+  hideAddPeopleToTagModal: () => {},
+  refetchAssignedMembersData: () => {},
+  t: (key: string) => translations[key],
+  tCommon: (key: string) => translations[key],
+};
+
+const renderAddPeopleToTagModal = (
+  props: InterfaceAddPeopleToTagProps,
+  link: ApolloLink,
+): RenderResult => {
+  return render(
+    <MockedProvider addTypename={false} link={link}>
+      <MemoryRouter initialEntries={['/orgtags/123/manageTag/1']}>
+        <Provider store={store}>
+          <I18nextProvider i18n={i18n}>
+            <Routes>
+              <Route
+                path="/orgtags/:orgId/managetag/:tagId"
+                element={<AddPeopleToTag {...props} />}
+              />
+            </Routes>
+          </I18nextProvider>
+        </Provider>
+      </MemoryRouter>
+    </MockedProvider>,
+  );
+};
+
+describe('Organisation Tags Page', () => {
+  beforeEach(() => {
+    jest.mock('react-router-dom', () => ({
+      ...jest.requireActual('react-router-dom'),
+      useParams: () => ({ orgId: 'orgId' }),
+    }));
+    // cache.reset();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    cleanup();
+  });
+
+  test('Component loads correctly', async () => {
+    const { getByText } = renderAddPeopleToTagModal(props, link);
+
+    await wait();
+
+    await waitFor(() => {
+      expect(getByText(translations.addPeople)).toBeInTheDocument();
+    });
+  });
+
+  test('Renders error component when when query is unsuccessful', async () => {
+    const { queryByText } = renderAddPeopleToTagModal(props, link2);
+
+    await wait();
+
+    await waitFor(() => {
+      expect(queryByText(translations.addPeople)).not.toBeInTheDocument();
+    });
+  });
+
+  test('Selects and deselects members to assign to', async () => {
+    renderAddPeopleToTagModal(props, link);
+
+    await wait();
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('selectMemberBtn')[0]).toBeInTheDocument();
+    });
+    userEvent.click(screen.getAllByTestId('selectMemberBtn')[0]);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('selectMemberBtn')[1]).toBeInTheDocument();
+    });
+    userEvent.click(screen.getAllByTestId('selectMemberBtn')[1]);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByTestId('clearSelectedMember')[0],
+      ).toBeInTheDocument();
+    });
+    userEvent.click(screen.getAllByTestId('clearSelectedMember')[0]);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('deselectMemberBtn')[0]).toBeInTheDocument();
+    });
+    userEvent.click(screen.getAllByTestId('deselectMemberBtn')[0]);
+  });
+
+  test('Renders more members with infinite scroll', async () => {
+    const { getByText } = renderAddPeopleToTagModal(props, link);
+
+    await wait();
+
+    await waitFor(() => {
+      expect(getByText(translations.addPeople)).toBeInTheDocument();
+    });
+
+    // Find the infinite scroll div by test ID or another selector
+    const scrollableDiv = screen.getByTestId('scrollableDiv');
+
+    // Set scroll position to the bottom
+    fireEvent.scroll(scrollableDiv, {
+      target: { scrollY: scrollableDiv.scrollHeight },
+    });
+
+    await waitFor(() => {
+      expect(getByText(translations.addPeople)).toBeInTheDocument();
+    });
+  });
+
+  test('Assigns tag to multiple people', async () => {
+    renderAddPeopleToTagModal(props, link);
+
+    await wait();
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('selectMemberBtn')[0]).toBeInTheDocument();
+    });
+    userEvent.click(screen.getAllByTestId('selectMemberBtn')[0]);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('selectMemberBtn')[1]).toBeInTheDocument();
+    });
+    userEvent.click(screen.getAllByTestId('selectMemberBtn')[1]);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('selectMemberBtn')[2]).toBeInTheDocument();
+    });
+    userEvent.click(screen.getAllByTestId('selectMemberBtn')[2]);
+
+    userEvent.click(screen.getByTestId('assignPeopleBtn'));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        translations.successfullyAssignedToPeople,
+      );
+    });
+  });
+});

--- a/src/components/AddPeopleToTag/AddPeopleToTag.tsx
+++ b/src/components/AddPeopleToTag/AddPeopleToTag.tsx
@@ -1,0 +1,371 @@
+import type { ApolloError } from '@apollo/client';
+import { useMutation, useQuery } from '@apollo/client';
+import type { GridCellParams, GridColDef } from '@mui/x-data-grid';
+import { DataGrid } from '@mui/x-data-grid';
+import Loader from 'components/Loader/Loader';
+import { USER_TAGS_MEMBERS_TO_ASSIGN_TO } from 'GraphQl/Queries/userTagQueries';
+import type { ChangeEvent } from 'react';
+import React, { useState } from 'react';
+import { Modal, Form, Button } from 'react-bootstrap';
+import { useParams } from 'react-router-dom';
+import type { InterfaceQueryUserTagsMembersToAssignTo } from 'utils/interfaces';
+import styles from './AddPeopleToTag.module.css';
+import { dataGridStyle } from 'utils/organizationTagsUtils';
+import { Stack } from '@mui/material';
+import { toast } from 'react-toastify';
+import { ADD_PEOPLE_TO_TAG } from 'GraphQl/Mutations/TagMutations';
+import InfiniteScroll from 'react-infinite-scroll-component';
+import { WarningAmberRounded } from '@mui/icons-material';
+
+/**
+ * Props for the `AddPeopleToTag` component.
+ */
+export interface InterfaceAddPeopleToTagProps {
+  addPeopleToTagModalIsOpen: boolean;
+  hideAddPeopleToTagModal: () => void;
+  refetchAssignedMembersData: () => void;
+  t: (key: string) => string;
+  tCommon: (key: string) => string;
+}
+
+interface InterfaceMemberData {
+  _id: string;
+  firstName: string;
+  lastName: string;
+}
+
+const AddPeopleToTag: React.FC<InterfaceAddPeopleToTagProps> = ({
+  addPeopleToTagModalIsOpen,
+  hideAddPeopleToTagModal,
+  refetchAssignedMembersData,
+  t,
+  tCommon,
+}) => {
+  const { tagId: currentTagId } = useParams();
+
+  const [assignToMembers, setAssignToMembers] = useState<InterfaceMemberData[]>(
+    [],
+  );
+
+  const {
+    data: userTagsMembersToAssignToData,
+    loading: userTagsMembersToAssignToLoading,
+    error: userTagsMembersToAssignToError,
+    fetchMore: fetchMoreMembersToAssignTo,
+  }: {
+    data?: {
+      getUserTag: InterfaceQueryUserTagsMembersToAssignTo;
+    };
+    loading: boolean;
+    error?: ApolloError;
+    fetchMore: (options: {
+      variables: {
+        after?: string | null;
+        first?: number | null;
+      };
+      updateQuery?: (
+        previousQueryResult: {
+          getUserTag: InterfaceQueryUserTagsMembersToAssignTo;
+        },
+        options: {
+          fetchMoreResult: {
+            getUserTag: InterfaceQueryUserTagsMembersToAssignTo;
+          };
+        },
+      ) => { getUserTag: InterfaceQueryUserTagsMembersToAssignTo };
+    }) => Promise<unknown>;
+  } = useQuery(USER_TAGS_MEMBERS_TO_ASSIGN_TO, {
+    variables: {
+      id: currentTagId,
+      first: 7,
+    },
+    skip: !addPeopleToTagModalIsOpen,
+  });
+
+  const loadMoreMembersToAssignTo = (): void => {
+    fetchMoreMembersToAssignTo({
+      variables: {
+        first: 7, // Load 7 more items
+        after:
+          userTagsMembersToAssignToData?.getUserTag.usersToAssignTo.pageInfo
+            .endCursor, // Fetch after the last loaded cursor
+      },
+      updateQuery: (
+        prevResult: { getUserTag: InterfaceQueryUserTagsMembersToAssignTo },
+        {
+          fetchMoreResult,
+        }: {
+          fetchMoreResult: {
+            getUserTag: InterfaceQueryUserTagsMembersToAssignTo;
+          };
+        },
+      ) => {
+        if (!fetchMoreResult) return prevResult;
+
+        return {
+          getUserTag: {
+            ...fetchMoreResult.getUserTag,
+            usersToAssignTo: {
+              ...fetchMoreResult.getUserTag.usersToAssignTo,
+              edges: [
+                ...prevResult.getUserTag.usersToAssignTo.edges,
+                ...fetchMoreResult.getUserTag.usersToAssignTo.edges,
+              ],
+            },
+          },
+        };
+      },
+    });
+  };
+
+  const userTagMembersToAssignTo =
+    userTagsMembersToAssignToData?.getUserTag.usersToAssignTo.edges.map(
+      (edge) => edge.node,
+    );
+
+  const handleAddOrRemoveMember = (member: InterfaceMemberData): void => {
+    setAssignToMembers((prevMembers) => {
+      const isAssigned = prevMembers.some((m) => m._id === member._id);
+      if (isAssigned) {
+        return prevMembers.filter((m) => m._id !== member._id);
+      } else {
+        return [...prevMembers, member];
+      }
+    });
+  };
+
+  const removeMember = (id: string): void => {
+    setAssignToMembers((prevMembers) =>
+      prevMembers.filter((m) => m._id !== id),
+    );
+  };
+
+  const [addPeople, { loading: addPeopleToTagLoading }] =
+    useMutation(ADD_PEOPLE_TO_TAG);
+
+  const addPeopleToCurrentTag = async (
+    e: ChangeEvent<HTMLFormElement>,
+  ): Promise<void> => {
+    e.preventDefault();
+
+    try {
+      const { data } = await addPeople({
+        variables: {
+          tagId: currentTagId,
+          userIds: assignToMembers.map((member) => member._id),
+        },
+      });
+
+      if (data) {
+        toast.success(t('successfullyAssignedToPeople'));
+        refetchAssignedMembersData();
+        hideAddPeopleToTagModal();
+        setAssignToMembers([]);
+      }
+    } catch (error: unknown) {
+      /* istanbul ignore next */
+      if (error instanceof Error) {
+        toast.error(error.message);
+      }
+    }
+  };
+
+  if (userTagsMembersToAssignToError) {
+    return (
+      <div className={`${styles.errorContainer} bg-white rounded-4 my-3`}>
+        <div className={styles.errorMessage}>
+          <WarningAmberRounded className={styles.errorIcon} fontSize="large" />
+          <h6 className="fw-bold text-danger text-center">
+            Error occured while loading members
+            <br />
+            {userTagsMembersToAssignToError.message}
+          </h6>
+        </div>
+      </div>
+    );
+  }
+
+  const columns: GridColDef[] = [
+    {
+      field: 'id',
+      headerName: '#',
+      minWidth: 100,
+      align: 'center',
+      headerAlign: 'center',
+      headerClassName: `${styles.tableHeader}`,
+      sortable: false,
+      renderCell: (params: GridCellParams) => {
+        return <div>{params.row.id}</div>;
+      },
+    },
+    {
+      field: 'userName',
+      headerName: 'User Name',
+      flex: 2,
+      minWidth: 100,
+      sortable: false,
+      headerClassName: `${styles.tableHeader}`,
+      renderCell: (params: GridCellParams) => {
+        return (
+          <div data-testid="memberName">
+            {params.row.firstName + ' ' + params.row.lastName}
+          </div>
+        );
+      },
+    },
+    {
+      field: 'actions',
+      headerName: 'Actions',
+      flex: 1,
+      align: 'center',
+      minWidth: 100,
+      headerAlign: 'center',
+      sortable: false,
+      headerClassName: `${styles.tableHeader}`,
+      renderCell: (params: GridCellParams) => {
+        const isToBeAssigned = assignToMembers.some(
+          (member) => member._id === params.row._id,
+        );
+
+        return (
+          <Button
+            size="sm"
+            onClick={() => handleAddOrRemoveMember(params.row)}
+            data-testid={
+              isToBeAssigned ? 'deselectMemberBtn' : 'selectMemberBtn'
+            }
+            variant={!isToBeAssigned ? 'primary' : 'danger'}
+          >
+            {isToBeAssigned ? 'x' : '+'}
+          </Button>
+        );
+      },
+    },
+  ];
+
+  return (
+    <>
+      <Modal
+        show={addPeopleToTagModalIsOpen}
+        onHide={hideAddPeopleToTagModal}
+        backdrop="static"
+        aria-labelledby="contained-modal-title-vcenter"
+        centered
+      >
+        <Modal.Header
+          className="bg-primary"
+          data-testid="modalOrganizationHeader"
+          closeButton
+        >
+          <Modal.Title className="text-white">{t('addPeople')}</Modal.Title>
+        </Modal.Header>
+        <Form onSubmitCapture={addPeopleToCurrentTag}>
+          <Modal.Body>
+            {userTagsMembersToAssignToLoading ? (
+              <Loader size="sm" />
+            ) : (
+              <>
+                <div
+                  className={`d-flex flex-wrap align-items-center border bg-light-subtle rounded-3 p-2 ${styles.scrollContainer}`}
+                >
+                  {assignToMembers.length === 0 ? (
+                    <div className="text-center text-body-tertiary">
+                      No one selected
+                    </div>
+                  ) : (
+                    assignToMembers.map((member) => (
+                      <div
+                        key={member._id}
+                        className={`badge bg-dark-subtle text-secondary-emphasis lh-lg my-2 ms-2 d-flex align-items-center ${styles.memberBadge}`}
+                      >
+                        {member.firstName} {member.lastName}
+                        <i
+                          className={`${styles.removeFilterIcon} fa fa-times ms-2 text-body-tertiary`}
+                          onClick={() => removeMember(member._id)}
+                          data-testid="clearSelectedMember"
+                        />
+                      </div>
+                    ))
+                  )}
+                </div>
+
+                <div
+                  id="scrollableDiv"
+                  data-testid="scrollableDiv"
+                  style={{
+                    height: 300,
+                    overflow: 'auto',
+                  }}
+                >
+                  <InfiniteScroll
+                    dataLength={userTagMembersToAssignTo?.length ?? 0} // This is important field to render the next data
+                    next={loadMoreMembersToAssignTo}
+                    hasMore={
+                      userTagsMembersToAssignToData?.getUserTag.usersToAssignTo
+                        .pageInfo.hasNextPage ?? false
+                    }
+                    loader={
+                      <div className="simpleLoader">
+                        <div className="spinner" />
+                      </div>
+                    }
+                    scrollableTarget="scrollableDiv"
+                  >
+                    <DataGrid
+                      disableColumnMenu
+                      columnBufferPx={7}
+                      hideFooter={true}
+                      getRowId={(row) => row._id}
+                      slots={{
+                        noRowsOverlay: /* istanbul ignore next */ () => (
+                          <Stack
+                            height="100%"
+                            alignItems="center"
+                            justifyContent="center"
+                          >
+                            {t('assignedToAll')}
+                          </Stack>
+                        ),
+                      }}
+                      sx={dataGridStyle}
+                      getRowClassName={() => `${styles.rowBackground}`}
+                      autoHeight
+                      rowHeight={65}
+                      rows={userTagMembersToAssignTo?.map(
+                        (membersToAssignTo, index) => ({
+                          id: index + 1,
+                          ...membersToAssignTo,
+                        }),
+                      )}
+                      columns={columns}
+                      isRowSelectable={() => false}
+                    />
+                  </InfiniteScroll>
+                </div>
+              </>
+            )}
+          </Modal.Body>
+          <Modal.Footer>
+            <Button
+              onClick={hideAddPeopleToTagModal}
+              variant="outline-secondary"
+              data-testid="closeAddPeopleToTagModal"
+            >
+              {tCommon('cancel')}
+            </Button>
+            <Button
+              type="submit"
+              disabled={addPeopleToTagLoading}
+              variant="primary"
+              data-testid="assignPeopleBtn"
+            >
+              {t('assignPeople')}
+            </Button>
+          </Modal.Footer>
+        </Form>
+      </Modal>
+    </>
+  );
+};
+
+export default AddPeopleToTag;

--- a/src/components/AddPeopleToTag/AddPeopleToTag.tsx
+++ b/src/components/AddPeopleToTag/AddPeopleToTag.tsx
@@ -176,7 +176,7 @@ const AddPeopleToTag: React.FC<InterfaceAddPeopleToTagProps> = ({
         <div className={styles.errorMessage}>
           <WarningAmberRounded className={styles.errorIcon} fontSize="large" />
           <h6 className="fw-bold text-danger text-center">
-            Error occured while loading members
+            {t('errorOccurredWhileLoadingMembers')}
             <br />
             {userTagsMembersToAssignToError.message}
           </h6>
@@ -200,7 +200,7 @@ const AddPeopleToTag: React.FC<InterfaceAddPeopleToTagProps> = ({
     },
     {
       field: 'userName',
-      headerName: 'User Name',
+      headerName: t('userName'),
       flex: 2,
       minWidth: 100,
       sortable: false,
@@ -215,7 +215,7 @@ const AddPeopleToTag: React.FC<InterfaceAddPeopleToTagProps> = ({
     },
     {
       field: 'actions',
-      headerName: 'Actions',
+      headerName: t('actions'),
       flex: 1,
       align: 'center',
       minWidth: 100,
@@ -270,7 +270,7 @@ const AddPeopleToTag: React.FC<InterfaceAddPeopleToTagProps> = ({
                 >
                   {assignToMembers.length === 0 ? (
                     <div className="text-center text-body-tertiary">
-                      No one selected
+                      {t('noOneSelected')}
                     </div>
                   ) : (
                     assignToMembers.map((member) => (

--- a/src/components/AddPeopleToTag/AddPeopleToTag.tsx
+++ b/src/components/AddPeopleToTag/AddPeopleToTag.tsx
@@ -16,6 +16,7 @@ import { toast } from 'react-toastify';
 import { ADD_PEOPLE_TO_TAG } from 'GraphQl/Mutations/TagMutations';
 import InfiniteScroll from 'react-infinite-scroll-component';
 import { WarningAmberRounded } from '@mui/icons-material';
+import { useTranslation } from 'react-i18next';
 
 /**
  * Props for the `AddPeopleToTag` component.
@@ -42,6 +43,8 @@ const AddPeopleToTag: React.FC<InterfaceAddPeopleToTagProps> = ({
   tCommon,
 }) => {
   const { tagId: currentTagId } = useParams();
+
+  const { t: tErrors } = useTranslation('error');
 
   const [assignToMembers, setAssignToMembers] = useState<InterfaceMemberData[]>(
     [],
@@ -164,9 +167,9 @@ const AddPeopleToTag: React.FC<InterfaceAddPeopleToTagProps> = ({
       }
     } catch (error: unknown) {
       /* istanbul ignore next */
-      if (error instanceof Error) {
-        toast.error(error.message);
-      }
+      const errorMessage =
+        error instanceof Error ? error.message : tErrors('unknownError');
+      toast.error(errorMessage);
     }
   };
 

--- a/src/components/AddPeopleToTag/AddPeopleToTag.tsx
+++ b/src/components/AddPeopleToTag/AddPeopleToTag.tsx
@@ -10,7 +10,10 @@ import { Modal, Form, Button } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
 import type { InterfaceQueryUserTagsMembersToAssignTo } from 'utils/interfaces';
 import styles from './AddPeopleToTag.module.css';
-import { dataGridStyle } from 'utils/organizationTagsUtils';
+import {
+  ADD_PEOPLE_TO_TAGS_QUERY_LIMIT,
+  dataGridStyle,
+} from 'utils/organizationTagsUtils';
 import { Stack } from '@mui/material';
 import { toast } from 'react-toastify';
 import { ADD_PEOPLE_TO_TAG } from 'GraphQl/Mutations/TagMutations';
@@ -80,7 +83,7 @@ const AddPeopleToTag: React.FC<InterfaceAddPeopleToTagProps> = ({
   } = useQuery(USER_TAGS_MEMBERS_TO_ASSIGN_TO, {
     variables: {
       id: currentTagId,
-      first: 7,
+      first: ADD_PEOPLE_TO_TAGS_QUERY_LIMIT,
     },
     skip: !addPeopleToTagModalIsOpen,
   });
@@ -88,7 +91,7 @@ const AddPeopleToTag: React.FC<InterfaceAddPeopleToTagProps> = ({
   const loadMoreMembersToAssignTo = (): void => {
     fetchMoreMembersToAssignTo({
       variables: {
-        first: 7, // Load 7 more items
+        first: ADD_PEOPLE_TO_TAGS_QUERY_LIMIT,
         after:
           userTagsMembersToAssignToData?.getUserTag.usersToAssignTo.pageInfo
             .endCursor, // Fetch after the last loaded cursor

--- a/src/components/AddPeopleToTag/AddPeopleToTagsMocks.ts
+++ b/src/components/AddPeopleToTag/AddPeopleToTagsMocks.ts
@@ -1,0 +1,169 @@
+import { ADD_PEOPLE_TO_TAG } from 'GraphQl/Mutations/TagMutations';
+import { USER_TAGS_MEMBERS_TO_ASSIGN_TO } from 'GraphQl/Queries/userTagQueries';
+
+export const MOCKS = [
+  {
+    request: {
+      query: USER_TAGS_MEMBERS_TO_ASSIGN_TO,
+      variables: {
+        id: '1',
+        first: 7,
+      },
+    },
+    result: {
+      data: {
+        getUserTag: {
+          name: 'tag1',
+          usersToAssignTo: {
+            edges: [
+              {
+                node: {
+                  _id: '1',
+                  firstName: 'member',
+                  lastName: '1',
+                },
+                cursor: '1',
+              },
+              {
+                node: {
+                  _id: '2',
+                  firstName: 'member',
+                  lastName: '2',
+                },
+                cursor: '2',
+              },
+              {
+                node: {
+                  _id: '3',
+                  firstName: 'member',
+                  lastName: '3',
+                },
+                cursor: '3',
+              },
+              {
+                node: {
+                  _id: '4',
+                  firstName: 'member',
+                  lastName: '4',
+                },
+                cursor: '4',
+              },
+              {
+                node: {
+                  _id: '5',
+                  firstName: 'member',
+                  lastName: '5',
+                },
+                cursor: '5',
+              },
+              {
+                node: {
+                  _id: '6',
+                  firstName: 'member',
+                  lastName: '6',
+                },
+                cursor: '6',
+              },
+              {
+                node: {
+                  _id: '7',
+                  firstName: 'member',
+                  lastName: '7',
+                },
+                cursor: '7',
+              },
+            ],
+            pageInfo: {
+              startCursor: '1',
+              endCursor: '7',
+              hasNextPage: true,
+              hasPreviousPage: false,
+            },
+            totalCount: 10,
+          },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: USER_TAGS_MEMBERS_TO_ASSIGN_TO,
+      variables: {
+        id: '1',
+        first: 7,
+        after: '7',
+      },
+    },
+    result: {
+      data: {
+        getUserTag: {
+          name: 'tag1',
+          usersToAssignTo: {
+            edges: [
+              {
+                node: {
+                  _id: '8',
+                  firstName: 'member',
+                  lastName: '8',
+                },
+                cursor: '8',
+              },
+              {
+                node: {
+                  _id: '9',
+                  firstName: 'member',
+                  lastName: '9',
+                },
+                cursor: '9',
+              },
+              {
+                node: {
+                  _id: '10',
+                  firstName: 'member',
+                  lastName: '10',
+                },
+                cursor: '10',
+              },
+            ],
+            pageInfo: {
+              startCursor: '8',
+              endCursor: '10',
+              hasNextPage: false,
+              hasPreviousPage: true,
+            },
+            totalCount: 10,
+          },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: ADD_PEOPLE_TO_TAG,
+      variables: {
+        tagId: '1',
+        userIds: ['1', '3', '5'],
+      },
+    },
+    result: {
+      data: {
+        addPeopleToUserTag: {
+          _id: '1',
+        },
+      },
+    },
+  },
+];
+
+export const MOCKS_ERROR = [
+  {
+    request: {
+      query: USER_TAGS_MEMBERS_TO_ASSIGN_TO,
+      variables: {
+        id: '1',
+        first: 7,
+      },
+    },
+    error: new Error('Mock Graphql Error'),
+  },
+];

--- a/src/screens/ManageTag/ManageTag.test.tsx
+++ b/src/screens/ManageTag/ManageTag.test.tsx
@@ -60,6 +60,7 @@ const cache = new InMemoryCache({
         getUserTag: {
           keyArgs: false,
           merge(existing = {}, incoming) {
+            console.log(existing);
             return incoming;
           },
         },
@@ -99,7 +100,7 @@ const renderManageTag = (link: ApolloLink): RenderResult => {
   );
 };
 
-describe('Organisation Tags Page', () => {
+describe('Manage Tag Page', () => {
   beforeEach(() => {
     jest.mock('react-router-dom', () => ({
       ...jest.requireActual('react-router-dom'),
@@ -290,7 +291,9 @@ describe('Organisation Tags Page', () => {
     userEvent.click(screen.getByTestId('unassignTagModalSubmitBtn'));
 
     await waitFor(() => {
-      expect(toast.success).toBeCalledWith(translations.successfullyUnassigned);
+      expect(toast.success).toHaveBeenCalledWith(
+        translations.successfullyUnassigned,
+      );
     });
   });
 });

--- a/src/screens/ManageTag/ManageTag.tsx
+++ b/src/screens/ManageTag/ManageTag.tsx
@@ -23,6 +23,7 @@ import {
   USER_TAG_ANCESTORS,
   USER_TAGS_ASSIGNED_MEMBERS,
 } from 'GraphQl/Queries/userTagQueries';
+import AddPeopleToTag from 'components/AddPeopleToTag/AddPeopleToTag';
 
 /**
  * Component that renders the Manage Tag screen when the app navigates to '/orgtags/:orgId/managetag/:tagId'.
@@ -432,41 +433,13 @@ function ManageTag(): JSX.Element {
       </Row>
 
       {/* Add People To Tag Modal */}
-      <Modal
-        show={addPeopleToTagModalIsOpen}
-        onHide={hideAddPeopleToTagModal}
-        backdrop="static"
-        aria-labelledby="contained-modal-title-vcenter"
-        centered
-      >
-        <Modal.Header
-          className="bg-primary"
-          data-testid="modalOrganizationHeader"
-          closeButton
-        >
-          <Modal.Title className="text-white">{t('addPeople')}</Modal.Title>
-        </Modal.Header>
-        <Form>
-          <Modal.Body></Modal.Body>
-
-          <Modal.Footer>
-            <Button
-              variant="secondary"
-              onClick={(): void => hideAddPeopleToTagModal()}
-              data-testid="closeAddPeopleToTagModal"
-            >
-              {tCommon('cancel')}
-            </Button>
-            <Button
-              type="submit"
-              value="add"
-              data-testid="addPeopleToTagModalSubmitBtn"
-            >
-              {t('add')}
-            </Button>
-          </Modal.Footer>
-        </Form>
-      </Modal>
+      <AddPeopleToTag
+        addPeopleToTagModalIsOpen={addPeopleToTagModalIsOpen}
+        hideAddPeopleToTagModal={hideAddPeopleToTagModal}
+        refetchAssignedMembersData={userTagAssignedMembersRefetch}
+        t={t}
+        tCommon={tCommon}
+      />
 
       {/* Unassign Tag Modal */}
       <Modal

--- a/src/screens/ManageTag/ManageTagMocks.ts
+++ b/src/screens/ManageTag/ManageTagMocks.ts
@@ -2,6 +2,7 @@ import { UNASSIGN_USER_TAG } from 'GraphQl/Mutations/TagMutations';
 import {
   USER_TAG_ANCESTORS,
   USER_TAGS_ASSIGNED_MEMBERS,
+  USER_TAGS_MEMBERS_TO_ASSIGN_TO,
 } from 'GraphQl/Queries/userTagQueries';
 
 export const MOCKS = [
@@ -178,6 +179,89 @@ export const MOCKS = [
               hasPreviousPage: false,
             },
             totalCount: 6,
+          },
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: USER_TAGS_MEMBERS_TO_ASSIGN_TO,
+      variables: {
+        id: '1',
+        first: 7,
+      },
+    },
+    result: {
+      data: {
+        getUserTag: {
+          name: 'tag1',
+          usersToAssignTo: {
+            edges: [
+              {
+                node: {
+                  _id: '1',
+                  firstName: 'member',
+                  lastName: '1',
+                },
+                cursor: '1',
+              },
+              {
+                node: {
+                  _id: '2',
+                  firstName: 'member',
+                  lastName: '2',
+                },
+                cursor: '2',
+              },
+              {
+                node: {
+                  _id: '3',
+                  firstName: 'member',
+                  lastName: '3',
+                },
+                cursor: '3',
+              },
+              {
+                node: {
+                  _id: '4',
+                  firstName: 'member',
+                  lastName: '4',
+                },
+                cursor: '4',
+              },
+              {
+                node: {
+                  _id: '5',
+                  firstName: 'member',
+                  lastName: '5',
+                },
+                cursor: '5',
+              },
+              {
+                node: {
+                  _id: '6',
+                  firstName: 'member',
+                  lastName: '6',
+                },
+                cursor: '6',
+              },
+              {
+                node: {
+                  _id: '7',
+                  firstName: 'member',
+                  lastName: '7',
+                },
+                cursor: '7',
+              },
+            ],
+            pageInfo: {
+              startCursor: '1',
+              endCursor: '7',
+              hasNextPage: true,
+              hasPreviousPage: false,
+            },
+            totalCount: 10,
           },
         },
       },

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -232,33 +232,40 @@ interface InterfaceTagData {
   totalCount: number;
 }
 
+interface InterfaceTagMembersData {
+  edges: {
+    node: {
+      _id: string;
+      firstName: string;
+      lastName: string;
+    };
+  }[];
+  pageInfo: {
+    startCursor: string;
+    endCursor: string;
+    hasNextPage: boolean;
+    hasPreviousPage: boolean;
+  };
+  totalCount: number;
+}
+
 export interface InterfaceQueryOrganizationUserTags {
   userTags: InterfaceTagData;
 }
 
 export interface InterfaceQueryUserTagsAssignedMembers {
   name: string;
-  usersAssignedTo: {
-    edges: {
-      node: {
-        _id: string;
-        firstName: string;
-        lastName: string;
-      };
-    }[];
-    pageInfo: {
-      startCursor: string;
-      endCursor: string;
-      hasNextPage: boolean;
-      hasPreviousPage: boolean;
-    };
-    totalCount: number;
-  };
+  usersAssignedTo: InterfaceTagMembersData;
 }
 
 export interface InterfaceQueryUserTagChildTags {
   name: string;
   childTags: InterfaceTagData;
+}
+
+export interface InterfaceQueryUserTagsMembersToAssignTo {
+  name: string;
+  usersToAssignTo: InterfaceTagMembersData;
 }
 
 export interface InterfaceQueryOrganizationAdvertisementListItem {

--- a/src/utils/organizationTagsUtils.ts
+++ b/src/utils/organizationTagsUtils.ts
@@ -21,3 +21,5 @@ export const dataGridStyle = {
     borderRadius: '0.1rem',
   },
 };
+
+export const ADD_PEOPLE_TO_TAGS_QUERY_LIMIT = 7;


### PR DESCRIPTION

### What kind of change does this PR introduce?

Added functionality to add people to a tag.

### Issue Number:

Fixes #2302 

### Did you add tests for your changes?

Yes

### Snapshots/Videos:

https://github.com/user-attachments/assets/0f0a063e-5384-49e2-b37a-c72094438a81

### Additional Context:

Api issue: PalisadoesFoundation/talawa-api#2552

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added new translation keys for tag management in English, French, Hindi, Spanish, and Chinese, enhancing user feedback for tag assignments.
	- Introduced a new component for managing user assignments to tags, streamlining the user interface.
	- Implemented a new GraphQL mutation for adding users to tags and a query for retrieving unassigned members.

- **Bug Fixes**
	- Updated test assertions for improved accuracy in verifying success notifications.

- **Documentation**
	- Enhanced mock data for testing user tag assignments.

- **Style**
	- Added new styles for the `AddPeopleToTag` component to improve user interface presentation.

- **Tests**
	- Established a comprehensive suite of unit tests for the `AddPeopleToTag` component to ensure functionality under various conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->