### PR TITLE
feat: Workflow changes which will label issues automatically as per #2256

### DIFF
--- a/.github/workflows/auto-label.json5
+++ b/.github/workflows/auto-label.json5
@@ -1,0 +1,8 @@
+{
+  "labelsSynonyms": {
+    "dependencies": ["dependabot", "dependency", "dependencies"],
+    "security": ["security"],
+    "ui/ux": ["layout", "screen", "design", "figma"]
+  },
+  "defaultLabels": ["unapproved"],
+}

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -39,7 +39,6 @@ jobs:
               repo,
               issue_number
             });
-            console.log(labels.data, labels.data.reduce((a, c)=>console.log(c.name, c.name in ["security", "ui/ux", "dependencies"]), false))
             if(labels.data.reduce((a, c)=>a||["dependencies"].includes(c.name), false))
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -18,12 +18,44 @@ jobs:
     name: Adding Issue Label
     runs-on: ubuntu-latest
     steps:
-      - uses: Renato66/auto-label@v2.3.0
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github/workflows/auto-label.json5
+          sparse-checkout-cone-mode: false
+      - uses: Renato66/auto-label@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          ignore-comments: true
-          default-labels: '["unapproved"]'
-  
+      - uses: actions/github-script@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner,
+              repo,
+              issue_number
+            });
+            console.log(labels.data, labels.data.reduce((a, c)=>console.log(c.name, c.name in ["security", "ui/ux", "dependencies"]), false))
+            if(labels.data.reduce((a, c)=>a||["dependencies"].includes(c.name), false))
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ["good first issue", "security"]  
+              });
+            else if(labels.data.reduce((a, c)=>a||["security", "ui/ux"].includes(c.name), false))
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ["good first issue"]  
+              });
+
+
   Issue-Greeting:
     name: Greeting Message to User
     runs-on: ubuntu-latest

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -33,25 +33,25 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const issue_number = context.issue.number;
-
-            const labels = await github.rest.issues.listLabelsOnIssue({
+            const apiParams = {
               owner,
               repo,
               issue_number
-            });
+            };
+            const labels = await github.rest.issues.listLabelsOnIssue(apiParams);
             if(labels.data.reduce((a, c)=>a||["dependencies"].includes(c.name), false))
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                labels: ["good first issue", "security"]  
+                labels: ["good first issue", "security"]
               });
             else if(labels.data.reduce((a, c)=>a||["security", "ui/ux"].includes(c.name), false))
               await github.rest.issues.addLabels({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                labels: ["good first issue"]  
+                labels: ["good first issue"]
               });
 
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**
feature about issue workflows 

**Issue Number: **

Fixes #2256 

**Did you add tests for your changes?**
No
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
Results:
![image](https://github.com/user-attachments/assets/acf6993e-7acf-4d44-9851-6a2232304dcb)
![image](https://github.com/user-attachments/assets/0ce2bd6d-03ee-41b0-9250-c3ba40abfb49)

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**
As described in issue #2256 the workflows will be able to add automatic labels for  following conditions
**Dependencies**: When the words dependabot, dependency or dependencies are in the body of the issue Add the labels dependencies, security and good first issue
**Security**: When the word security are in the body of the issue Add the label security and good first issue
**Design**: When the words layout, screen, design or figma are in the body of the issue Add the label ui/ux and good first issue

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**
Added a extra step in the given `issue.yml` file which uses actions/github-script@v6 for solving following problem
**Problem** : We can not have same synonym for multiple labels if we add same synonym in multiple if we add same synonym in multiple lists of synonyms then it adds only single label in latest list refer [auto-lable/issue-93](https://github.com/Renato66/auto-label/issues/93)
**Soultution By me**:
1. We want to add `security` for same synonyms from `dependencies` and synonym `security`: we'll have only security as synonym in the `labelsSynonyms` and for same synonyms from `dependencies` we'll have github script to add the labels by detecting if  `dependencies` is label to issue
2. Same for `good first issue` if we have anyone label from `dependencies`, `security`, `ui/ux` assigned to issue

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new labeling system for issues, allowing for synonyms and default labels to enhance organization.
	- Automatically assigns labels like "good first issue" and "security" based on issue content.

- **Bug Fixes**
	- Updated the auto-labeling action to improve performance and accuracy in label management.

- **Chores**
	- Updated configuration files for better workflow management and streamlined processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->