### PR TITLE
refactored: src/screens/OrgSettings from Jest to Vitest(fixes: #2567)

### DIFF
--- a/.github/workflows/check-tsdoc.js
+++ b/.github/workflows/check-tsdoc.js
@@ -23,6 +23,7 @@ async function findTsxFiles(dir) {
       } else if (
         filePath.endsWith('.tsx') &&
         !filePath.endsWith('.test.tsx') &&
+        !filePath.endsWith('.spec.tsx') &&
         !filesToSkip.includes(path.relative(dir, filePath))
       ) {
         results.push(filePath);

--- a/src/screens/OrgSettings/OrgSettings.spec.tsx
+++ b/src/screens/OrgSettings/OrgSettings.spec.tsx
@@ -19,16 +19,11 @@ const link1 = new StaticMockLink(MOCKS);
 
 const mockRouterParams = (orgId: string | undefined): void => {
   vi.doMock('react-router-dom', async () => {
-    try {
-      const actual = await vi.importActual('react-router-dom');
-      return {
-        ...actual,
-        useParams: () => ({ orgId }),
-      };
-    } catch (error) {
-      console.error('Failed to mock router params:', error);
-      throw error;
-    }
+    const actual = await vi.importActual('react-router-dom');
+    return {
+      ...actual,
+      useParams: () => ({ orgId }),
+    };
   });
 };
 const renderOrganisationSettings = (

--- a/src/screens/OrgSettings/OrgSettings.spec.tsx
+++ b/src/screens/OrgSettings/OrgSettings.spec.tsx
@@ -17,6 +17,9 @@ import { MOCKS } from './OrgSettings.mocks';
 
 const link1 = new StaticMockLink(MOCKS);
 
+/**
+ * Mocks the `useParams` function from `react-router-dom` to simulate URL parameters.
+ */
 const mockRouterParams = (orgId: string | undefined): void => {
   vi.doMock('react-router-dom', async () => {
     const actual = await vi.importActual('react-router-dom');

--- a/src/screens/OrgSettings/OrgSettings.spec.tsx
+++ b/src/screens/OrgSettings/OrgSettings.spec.tsx
@@ -16,7 +16,7 @@ import { MOCKS } from './OrgSettings.mocks';
 
 const link1 = new StaticMockLink(MOCKS);
 
-const renderOrganisationSettings = (link = link1, orgId = 'orgId'): void => {
+const mockRouterParams = (orgId: string | undefined): void => {
   vi.doMock('react-router-dom', async () => {
     const actual = await vi.importActual('react-router-dom');
     return {
@@ -24,7 +24,9 @@ const renderOrganisationSettings = (link = link1, orgId = 'orgId'): void => {
       useParams: () => ({ orgId }),
     };
   });
-
+};
+const renderOrganisationSettings = (link = link1, orgId = 'orgId'): void => {
+  mockRouterParams(orgId);
   render(
     <MockedProvider addTypename={false} link={link}>
       <MemoryRouter initialEntries={[`/orgsetting/${orgId}`]}>
@@ -50,7 +52,7 @@ const renderOrganisationSettings = (link = link1, orgId = 'orgId'): void => {
 
 describe('Organisation Settings Page', () => {
   afterEach(() => {
-    vi.restoreAllMocks();
+    vi.unmock('react-router-dom');
   });
 
   it('should redirect to fallback URL if URL params are undefined', async () => {
@@ -108,6 +110,7 @@ describe('Organisation Settings Page', () => {
     userEvent.click(screen.getByTestId('generalSettings'));
     await waitFor(() => {
       expect(screen.getByTestId('generalTab')).toBeInTheDocument();
+      expect(screen.getByTestId('generalTab')).toBeVisible();
     });
 
     userEvent.click(screen.getByTestId('actionItemCategoriesSettings'));

--- a/src/screens/OrgSettings/OrgSettings.spec.tsx
+++ b/src/screens/OrgSettings/OrgSettings.spec.tsx
@@ -18,7 +18,7 @@ import { MOCKS } from './OrgSettings.mocks';
 const link1 = new StaticMockLink(MOCKS);
 
 /**
- * Mocks the `useParams` function from `react-router-dom` to simulate URL parameters.
+ * Mocks the `useParams` function from `react-router-dom` to simulate URL parameter.
  */
 const mockRouterParams = (orgId: string | undefined): void => {
   vi.doMock('react-router-dom', async () => {

--- a/src/screens/OrgSettings/OrgSettings.spec.tsx
+++ b/src/screens/OrgSettings/OrgSettings.spec.tsx
@@ -16,10 +16,6 @@ import OrgSettings from './OrgSettings';
 import { MOCKS } from './OrgSettings.mocks';
 
 const link1 = new StaticMockLink(MOCKS);
-
-/**
- * Mocks the `useParams` function from `react-router-dom` to simulate URL parameter.
- */
 const mockRouterParams = (orgId: string | undefined): void => {
   vi.doMock('react-router-dom', async () => {
     const actual = await vi.importActual('react-router-dom');

--- a/src/screens/OrgSettings/OrgSettings.test.tsx
+++ b/src/screens/OrgSettings/OrgSettings.test.tsx
@@ -2,11 +2,10 @@ import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
 import type { RenderResult } from '@testing-library/react';
 import { render, screen, waitFor } from '@testing-library/react';
-import 'jest-location-mock';
+import { vi } from 'vitest';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-
 import { store } from 'state/store';
 import { StaticMockLink } from 'utils/StaticMockLink';
 import i18nForTest from 'utils/i18nForTest';
@@ -43,14 +42,14 @@ const renderOrganisationSettings = (link: ApolloLink): RenderResult => {
 
 describe('Organisation Settings Page', () => {
   beforeAll(() => {
-    jest.mock('react-router-dom', () => ({
-      ...jest.requireActual('react-router-dom'),
+    vi.mock('react-router-dom', () => ({
+      ...vi.importActual('react-router-dom'),
       useParams: () => ({ orgId: 'orgId' }),
     }));
   });
 
   afterAll(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('should redirect to fallback URL if URL params are undefined', async () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Refactoring
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #2567

**Did you add tests for your changes?**
No
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
<img width="936" alt="Screenshot 2024-12-10 at 4 40 49 PM" src="https://github.com/user-attachments/assets/93aac427-588c-4bdf-8fb6-12fe0aecb2d7">

<img width="890" alt="Screenshot 2024-12-10 at 5 44 44 PM" src="https://github.com/user-attachments/assets/4496f1e0-9654-417f-88a5-10abb2df918c">


<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
Not Relavant
<!--Add link to Talawa-Docs.-->

**Summary**
This PR migrates the existing tests for OrgSetting.tsx from Jest to Vitest
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Updated the test suite for the `OrgSettings` component for improved clarity and functionality.
	- Added new tests for dropdown rendering in settings tabs.
	- Adjusted existing tests for URL parameter handling and error message assertions.
	- Enhanced control flow by modifying test setup and teardown processes.
	- Improved file filtering to exclude test files from processing in documentation checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->