### PR TITLE
Refactor Tests: Migrate src/screens/UserPortal/UserScreen/UserScreen.tsx from Jest to Vitest

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import { nodePolyfills } from 'vite-plugin-node-polyfills';
 import tsconfigPaths from 'vite-tsconfig-paths';
+import svgrPlugin from 'vite-plugin-svgr';
 
 export default defineConfig({
   plugins: [
@@ -10,6 +11,7 @@ export default defineConfig({
       include: ['events'],
     }),
     tsconfigPaths(),
+    svgrPlugin(),
   ],
   test: {
     include: ['src/**/*.spec.{js,jsx,ts,tsx}'],


### PR DESCRIPTION
What kind of change does this PR introduce?
It is a refactor of changing the test case migration of jest to vitest.

Issue Number:
Fixes issue no . #2580 

Did you add tests for your changes?
Yes after changing the code to vitest i ran the command npm run vitest and it is successfully completed. I will provide screenshots.

**Snapshots/Videos:**
![Screenshot (22)](https://github.com/user-attachments/assets/844e9b79-9176-40af-8c96-29cf3243c6b8)

Summary
In this Pr the screen is now tested with vitest . which is more faster than jest which is previously used. And one by one all the screens are migrating to vitest so this is one of them.

Does this PR introduce a breaking change?
No this does not affect the existing code flow.

Have you read the [contributing guide]

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated unit tests for the UserScreen component to improve clarity and structure.
	- Switched testing framework from Jest to Vitest.
	- Enhanced test descriptions and added a `beforeEach` block for consistency.
	- Verified rendering of titles for different routes and clarified tests for LeftDrawer functionality.

- **Chores**
	- Added `svgrPlugin` to the Vitest configuration for handling SVG files as React components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->