### PR TITLE
Migrate src/screens/UserPortal/Donate/Donate.test.tsx Tests from Jest to Vitest

### DIFF
--- a/src/screens/UserPortal/Donate/Donate.spec.tsx
+++ b/src/screens/UserPortal/Donate/Donate.spec.tsx
@@ -1,8 +1,14 @@
+/**
+ * Unit tests for the Donate component.
+ *
+ * This file contains tests for the Donate component to ensure it behaves as expected
+ * under various scenarios.
+ */
 import React, { act } from 'react';
 import { render, screen } from '@testing-library/react';
 import { MockedProvider } from '@apollo/react-testing';
 import { I18nextProvider } from 'react-i18next';
-
+import { vi } from 'vitest';
 import {
   ORGANIZATION_DONATION_CONNECTION_LIST,
   USER_ORGANIZATION_CONNECTION,
@@ -132,35 +138,35 @@ async function wait(ms = 100): Promise<void> {
   });
 }
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => ({ orgId: '' }),
+vi.mock('react-router-dom', async () => ({
+  ...(await vi.importActual('react-router-dom')),
+  useParams: vi.fn(() => ({ orgId: '' })),
 }));
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    error: jest.fn(),
-    success: jest.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
   },
 }));
 
 describe('Testing Donate Screen [User Portal]', () => {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
-    value: jest.fn().mockImplementation((query) => ({
+    value: vi.fn().mockImplementation((query) => ({
       matches: false,
       media: query,
       onchange: null,
-      addListener: jest.fn(), // Deprecated
-      removeListener: jest.fn(), // Deprecated
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      dispatchEvent: jest.fn(),
+      addListener: vi.fn(), // Deprecated
+      removeListener: vi.fn(), // Deprecated
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
     })),
   });
 
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   test('Screen should be rendered properly', async () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR migrates the test cases in src/screens/UserPortal/Donate/Donate.test.tsx from Jest to Vitest, ensuring compatibility with Vitest .

✅ Replace Jest-specific functions and mocks with Vitest equivalents
✅ Ensure all tests in src/screens/UserPortal/Donate/Donate.test.tsx pass after migration using npm run test:vitest
✅ Maintain the test coverage for the file as 100% after migration
✅ Upload a video or photo for this specific file coverage is 100% in the PR description

**Issue Number:**

Fixes #2573 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

![image](https://github.com/user-attachments/assets/86324695-e307-4735-8ca7-fe43537acb3c)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated unit tests for the `Donate` component to use the `vitest` framework.
	- Enhanced mocking for `window.matchMedia` and error handling assertions.
	- Added documentation comments to clarify the purpose of the tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->