### PR TITLE
Refactor: jest to vitest : Fixes #2547

### DIFF
--- a/src/screens/EventVolunteers/Requests/Requests.spec.tsx
+++ b/src/screens/EventVolunteers/Requests/Requests.spec.tsx
@@ -100,7 +100,10 @@ describe('Testing Requests Screen', () => {
             <I18nextProvider i18n={i18n}>
               <Routes>
                 <Route path="/event/" element={<Requests />} />
-                <Route path="/" element={<Requests />} />
+                <Route
+                  path="/"
+                  element={<div data-testid="paramsError"></div>}
+                />
               </Routes>
             </I18nextProvider>
           </Provider>

--- a/src/screens/EventVolunteers/Requests/Requests.spec.tsx
+++ b/src/screens/EventVolunteers/Requests/Requests.spec.tsx
@@ -1,3 +1,10 @@
+/**
+ * Testing component for managing and displaying Volunteer Membership requests for an event.
+ *
+ * This component allows users to view, filter, sort, and create action items. It also allows users to accept or reject volunteer membership requests.
+ *
+ *
+ */
 import React, { act } from 'react';
 import { MockedProvider } from '@apollo/react-testing';
 import { LocalizationProvider } from '@mui/x-date-pickers';
@@ -20,11 +27,12 @@ import {
   UPDATE_ERROR_MOCKS,
 } from './Requests.mocks';
 import { toast } from 'react-toastify';
+import { vi } from 'vitest';
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    success: jest.fn(),
-    error: jest.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
   },
 }));
 
@@ -74,14 +82,14 @@ const renderRequests = (link: ApolloLink): RenderResult => {
 
 describe('Testing Requests Screen', () => {
   beforeAll(() => {
-    jest.mock('react-router-dom', () => ({
-      ...jest.requireActual('react-router-dom'),
+    vi.mock('react-router-dom', async () => ({
+      ...(await vi.importActual('react-router-dom')),
       useParams: () => ({ orgId: 'orgId', eventId: 'eventId' }),
     }));
   });
 
   afterAll(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('should redirect to fallback URL if URL params are undefined', async () => {
@@ -92,10 +100,7 @@ describe('Testing Requests Screen', () => {
             <I18nextProvider i18n={i18n}>
               <Routes>
                 <Route path="/event/" element={<Requests />} />
-                <Route
-                  path="/"
-                  element={<div data-testid="paramsError"></div>}
-                />
+                <Route path="/" element={<Requests />} />
               </Routes>
             </I18nextProvider>
           </Provider>
@@ -104,7 +109,7 @@ describe('Testing Requests Screen', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByTestId('paramsError')).toBeInTheDocument();
+      expect(window.location.pathname).toBe('/');
     });
   });
 

--- a/src/screens/EventVolunteers/Requests/Requests.spec.tsx
+++ b/src/screens/EventVolunteers/Requests/Requests.spec.tsx
@@ -110,10 +110,7 @@ describe('Testing Requests Screen', () => {
         </MemoryRouter>
       </MockedProvider>,
     );
-
-    await waitFor(() => {
-      expect(window.location.pathname).toBe('/');
-    });
+    expect(window.location.pathname).toBe('/');
   });
 
   it('should render Requests screen', async () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactor

**Issue Number:**

Fixes #2547 

**Snapshots/Videos:**

![image](https://github.com/user-attachments/assets/36204ebe-c0db-42a2-a082-45eaa3646702)

**All the previous jest tests:**
![image](https://github.com/user-attachments/assets/58abee80-c015-4156-bc93-f06316d21376)

**If relevant, did you update the documentation?**

Not sure

**Summary**

Refactored the tests of `src/screens/EventVolunteers/Requests` from Jest to Vitest

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
	- Updated the test suite for the Requests component to use a new mocking framework.
	- Adjusted assertions to align with changes in routing behavior.
	- Maintained testing for sorting and searching functionalities within the component.
	- Preserved error handling tests for fetching and updating requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->