### PR TITLE
Refactor: src/screens/Leaderboard from Jest to Vitest

### DIFF
--- a/src/screens/Leaderboard/Leaderboard.spec.tsx
+++ b/src/screens/Leaderboard/Leaderboard.spec.tsx
@@ -16,6 +16,26 @@ import type { ApolloLink } from '@apollo/client';
 import { MOCKS, EMPTY_MOCKS, ERROR_MOCKS } from './Leaderboard.mocks';
 import { vi } from 'vitest';
 
+/**
+ * Unit tests for the Leaderboard component.
+ *
+ * This file verifies the Leaderboard's functionality in scenarios like URL handling, sorting, filtering,
+ * user interactions, and error states. Mocked dependencies and Apollo links ensure isolated testing
+ * of Redux, React Router, and internationalization integration.
+ *
+ * Key tests include:
+ * - Redirecting when parameters are missing.
+ * - Rendering with mock data, empty states, and errors.
+ * - Sorting and filtering for various timeframes.
+ * - Searching volunteers and navigating to the Member screen.
+ * - Handling errors during data fetching.
+ *
+ * Mock setups:
+ * - StaticMockLink for GraphQL responses.
+ * - Mocked `useParams` for route parameters.
+ * - Redux store and i18n for consistent state and translations.
+ */
+
 const link1 = new StaticMockLink(MOCKS);
 const link2 = new StaticMockLink(ERROR_MOCKS);
 const link3 = new StaticMockLink(EMPTY_MOCKS);

--- a/src/screens/Leaderboard/Leaderboard.spec.tsx
+++ b/src/screens/Leaderboard/Leaderboard.spec.tsx
@@ -7,13 +7,14 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useParams } from 'react-router-dom';
 import { store } from 'state/store';
 import { StaticMockLink } from 'utils/StaticMockLink';
 import i18n from 'utils/i18nForTest';
 import Leaderboard from './Leaderboard';
 import type { ApolloLink } from '@apollo/client';
 import { MOCKS, EMPTY_MOCKS, ERROR_MOCKS } from './Leaderboard.mocks';
+import { vi } from 'vitest';
 
 const link1 = new StaticMockLink(MOCKS);
 const link2 = new StaticMockLink(ERROR_MOCKS);
@@ -62,17 +63,21 @@ const renderLeaderboard = (link: ApolloLink): RenderResult => {
 
 describe('Testing Leaderboard Screen', () => {
   beforeAll(() => {
-    jest.mock('react-router-dom', () => ({
-      ...jest.requireActual('react-router-dom'),
-      useParams: () => ({ orgId: 'orgId' }),
-    }));
+    vi.mock('react-router-dom', async () => {
+      const originalModule = await vi.importActual('react-router-dom');
+      return {
+        ...originalModule,
+        useParams: vi.fn(),
+      };
+    });
   });
 
   afterAll(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('should redirect to fallback URL if URL params are undefined', async () => {
+    vi.mocked(useParams).mockReturnValue({ orgId: '' });
     render(
       <MockedProvider addTypename={false} link={link1}>
         <MemoryRouter initialEntries={['/leaderboard/']}>
@@ -96,6 +101,7 @@ describe('Testing Leaderboard Screen', () => {
   });
 
   it('should render Leaderboard screen', async () => {
+    vi.mocked(useParams).mockReturnValue({ orgId: 'orgId' });
     renderLeaderboard(link1);
 
     await waitFor(() => {
@@ -104,6 +110,7 @@ describe('Testing Leaderboard Screen', () => {
   });
 
   it('Check Sorting Functionality', async () => {
+    vi.mocked(useParams).mockReturnValue({ orgId: 'orgId' });
     renderLeaderboard(link1);
 
     await waitFor(() => {
@@ -134,6 +141,7 @@ describe('Testing Leaderboard Screen', () => {
   });
 
   it('Check Timeframe filter Functionality (All Time)', async () => {
+    vi.mocked(useParams).mockReturnValue({ orgId: 'orgId' });
     renderLeaderboard(link1);
 
     await waitFor(() => {
@@ -154,6 +162,7 @@ describe('Testing Leaderboard Screen', () => {
   });
 
   it('Check Timeframe filter Functionality (Weekly)', async () => {
+    vi.mocked(useParams).mockReturnValue({ orgId: 'orgId' });
     renderLeaderboard(link1);
 
     await waitFor(() => {
@@ -176,6 +185,7 @@ describe('Testing Leaderboard Screen', () => {
   });
 
   it('Check Timeframe filter Functionality (Monthly)', async () => {
+    vi.mocked(useParams).mockReturnValue({ orgId: 'orgId' });
     renderLeaderboard(link1);
 
     await waitFor(() => {
@@ -196,6 +206,7 @@ describe('Testing Leaderboard Screen', () => {
   });
 
   it('Check Timeframe filter Functionality (Yearly)', async () => {
+    vi.mocked(useParams).mockReturnValue({ orgId: 'orgId' });
     renderLeaderboard(link1);
 
     await waitFor(() => {
@@ -216,6 +227,7 @@ describe('Testing Leaderboard Screen', () => {
   });
 
   it('Search Volunteers', async () => {
+    vi.mocked(useParams).mockReturnValue({ orgId: 'orgId' });
     renderLeaderboard(link1);
 
     const searchInput = await screen.findByTestId('searchBy');
@@ -232,6 +244,7 @@ describe('Testing Leaderboard Screen', () => {
   });
 
   it('OnClick of Member navigate to Member Screen', async () => {
+    vi.mocked(useParams).mockReturnValue({ orgId: 'orgId' });
     renderLeaderboard(link1);
 
     const searchInput = await screen.findByTestId('searchBy');
@@ -246,6 +259,7 @@ describe('Testing Leaderboard Screen', () => {
   });
 
   it('should render Leaderboard screen with No Volunteers', async () => {
+    vi.mocked(useParams).mockReturnValue({ orgId: 'orgId' });
     renderLeaderboard(link3);
 
     await waitFor(() => {
@@ -255,6 +269,7 @@ describe('Testing Leaderboard Screen', () => {
   });
 
   it('Error while fetching volunteer data', async () => {
+    vi.mocked(useParams).mockReturnValue({ orgId: 'orgId' });
     renderLeaderboard(link2);
 
     await waitFor(() => {


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Migrated tests for Leaderboard component from Jest to Vitest. Updated test framework and adjusted test implementations accordingly. All tests now use Vitest for consistent testing environment and improved performance.


<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #2553 

**Did you add tests for your changes?**
yes
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**

![Screenshot from 2024-12-21 07-36-42](https://github.com/user-attachments/assets/84207f2a-1c80-4fcd-be80-32c1cedcdc42)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the testing framework from Jest to Vitest for the Leaderboard component.
	- Enhanced test cases with explicit mocking of routing parameters.
	- Improved documentation for test scenarios, covering various user interactions and error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->