### PR TITLE
Add code coverage disable check to GitHub workflows

### DIFF
--- a/.github/workflows/code_coverage_disable_check.py
+++ b/.github/workflows/code_coverage_disable_check.py
@@ -1,0 +1,122 @@
+"""Code Coverage Disable Checker Script.
+
+Methodology:
+
+    Recursively analyzes TypeScript files in the specified directories to ensure
+    they do not contain code coverage disable statements.
+
+    This script enforces proper code coverage practices in the project.
+
+NOTE:
+
+    This script complies with our python3 coding and documentation standards.
+    It complies with:
+
+        1) Pylint
+        2) Pydocstyle
+        3) Pycodestyle
+        4) Flake8
+
+"""
+
+import os
+import re
+import argparse
+import sys
+
+def has_code_coverage_disable(file_path):
+    """
+    Check if a TypeScript file contains code coverage disable statements.
+
+    Args:
+        file_path (str): Path to the TypeScript file.
+
+    Returns:
+        bool: True if code coverage disable statement is found, False otherwise.
+    """
+    code_coverage_disable_pattern = re.compile(r'(?://\s*istanbul\s+ignore(?:-next-line|-line)?|/\*\s*istanbul\s+ignore\s*(?:next|-line)\s*\*/)', re.IGNORECASE)
+    
+    try:
+        with open(file_path, 'r', encoding='utf-8') as file:
+            content = file.read()
+            return bool(code_coverage_disable_pattern.search(content))
+    except Exception as e:
+        print(f"Error reading file {file_path}: {e}")
+        return False
+
+def check_code_coverage(directories):
+    """
+    Recursively check TypeScript files for code coverage disable statements.
+
+    Args:
+        directories (list) : List of directories.
+
+    Returns:
+        bool: True if code coverage disable statement is found, False otherwise.
+    """
+    code_coverage_found = False
+
+    for directory in directories:
+        if not os.path.exists(directory):
+            print(f"Error: The specified directory '{directory}' does not exist.")
+            sys.exit(1)
+        for root, dirs, files in os.walk(directory):
+            for file_name in files:
+                if file_name.endswith('.tsx') and not file_name.endswith('.test.tsx'):
+                    file_path = os.path.join(root, file_name)
+                    if has_code_coverage_disable(file_path):
+                        print(f'File {file_path} contains code coverage disable statement.')
+                        code_coverage_found = True
+
+        setup_path = os.path.join(directory, 'setup.ts')
+        if os.path.exists(setup_path) and has_code_coverage_disable(setup_path):
+            print(f'Setup file {setup_path} contains code coverage disable statement.')
+            code_coverage_found = True
+
+    return code_coverage_found
+
+def arg_parser_resolver():
+    """Resolve the CLI arguments provided by the user.
+
+    Returns:
+        result: Parsed argument object
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--directory",
+        type=str,
+        nargs='+',
+        default=[os.getcwd()],
+        help="One or more directories to check for code coverage disable statements (default: current directory)."
+    )
+    return parser.parse_args()
+
+def main():
+    """
+    Execute the script's main functionality.
+
+    This function serves as the entry point for the script. It performs
+    the following tasks:
+    1. Validates and retrieves the directory to check from
+       command line arguments.
+    2. Recursively checks TypeScript files for code coverage disable statements.
+    3. Provides informative messages based on the analysis.
+    4. Exits with an error if code coverage disable statements are found.
+
+    Raises:
+        SystemExit: If an error occurs during execution.
+    """
+    args = arg_parser_resolver()
+    print("Directories to check: ", args.directory)
+    
+    # Check code coverage in the specified directory
+    code_coverage_found = check_code_coverage(args.directory)
+
+    if code_coverage_found:
+        print("Code coverage disable check failed. Exiting with error.")
+        sys.exit(1)
+
+    print("Code coverage disable check completed successfully.")
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -187,6 +187,22 @@ jobs:
         run: |
           python .github/workflows/eslint_disable_check.py
 
+  Check-Code-Coverage-Disable:
+    name: Check for code coverage disable
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      
+      - name: Run Python script
+        run: |
+          python .github/workflows/code_coverage_disable_check.py
+
   Test-Application:
     name: Test Application
     runs-on: ubuntu-latest


### PR DESCRIPTION
**What kind of change does this PR introduce?**

New Script:

1. Added .github/workflows/code_coverage_disable_check.py script.
Recursively scans specified directories for istanbul ignore patterns in .tsx and setup.ts files (excluding .test.tsx).
Supports multiple directories via --directory CLI argument with a default directory option.
GitHub Workflow:

2. Integrated the code_coverage_disable_check.py into the workflow.
Automatically runs during PR checks to ensure no code coverage disable statements are introduced.

**Issue Number:**

Fixes #2594

**Snapshots/Videos:**
![Screenshot 2024-12-22 014736](https://github.com/user-attachments/assets/f651993a-9ad6-4b55-a2b3-a4f67e846649)