### PR TITLE
Bugfix: Prevent unnecessary page reload after deleting a user from th…

### DIFF
--- a/src/components/OrgPeopleListCard/OrgPeopleListCard.tsx
+++ b/src/components/OrgPeopleListCard/OrgPeopleListCard.tsx
@@ -59,9 +59,7 @@ function orgPeopleListCard(
       /* istanbul ignore next */
       if (data) {
         toast.success(t('memberRemoved') as string);
-        setTimeout(() => {
-          window.location.reload();
-        }, 2000);
+        props.toggleRemoveModal();
       }
     } catch (error: unknown) {
       /* istanbul ignore next */


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix: Prevent unnecessary page reload after deleting a user from the organization

**Issue Number:**

Fixes #2700 

**Did you add tests for your changes?**

Yes. The existing tests cover this functionality, and the updated code passes all tests.

**Snapshots/Videos:**

[Issue_solved.webm](https://github.com/user-attachments/assets/fb6449e3-9c79-4151-a820-0530d499742d)

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

The motivation for this change is to improve the user experience by preventing unnecessary page reloads after deleting a user from the organization. The modal is now closed without reloading the entire page

**Does this PR introduce a breaking change?**

No.

**Other information**

N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved member removal process within the Org People List Card component, allowing for a smoother user experience by closing the modal instead of reloading the page after a successful removal.

- **Bug Fixes**
	- Enhanced error handling during member removal to ensure better management of exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->