### PR TITLE
Refactor: jest to vitest of itemDeleteModal : fixes #2557

### DIFF
--- a/src/screens/OrganizationActionItems/ItemDeleteModal.spec.tsx
+++ b/src/screens/OrganizationActionItems/ItemDeleteModal.spec.tsx
@@ -3,7 +3,13 @@ import type { ApolloLink } from '@apollo/client';
 import { MockedProvider } from '@apollo/react-testing';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import type { RenderResult } from '@testing-library/react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  act,
+} from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
@@ -16,11 +22,12 @@ import { toast } from 'react-toastify';
 import ItemDeleteModal, {
   type InterfaceItemDeleteModalProps,
 } from './ItemDeleteModal';
+import { vi } from 'vitest';
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    success: jest.fn(),
-    error: jest.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
   },
 }));
 
@@ -34,8 +41,8 @@ const t = JSON.parse(
 
 const itemProps: InterfaceItemDeleteModalProps = {
   isOpen: true,
-  hide: jest.fn(),
-  actionItemsRefetch: jest.fn(),
+  hide: vi.fn(),
+  actionItemsRefetch: vi.fn(),
   actionItem: {
     _id: 'actionItemId1',
     assignee: null,
@@ -102,7 +109,9 @@ describe('Testing ItemDeleteModal', () => {
     renderItemDeleteModal(link1, itemProps);
     expect(screen.getByTestId('deleteyesbtn')).toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId('deleteyesbtn'));
+    await act(() => {
+      fireEvent.click(screen.getByTestId('deleteyesbtn'));
+    });
 
     await waitFor(() => {
       expect(itemProps.actionItemsRefetch).toHaveBeenCalled();


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactoring

**Issue Number:**

There are multiple test files in this directory. So it needs multiple PRs to close the issue. This PR fixes one such file inside that directory `itemDeleteModal.spec.tsx`

Fixes #2557

**Snapshots/Videos:**

<!--Add snapshots or videos wherever possible.-->

![image](https://github.com/user-attachments/assets/5bbfdec9-7209-4cbf-9b66-6bd835191f37)

**Summary**

Refactored the `ItemDeleteModal.tsx` tests from jest to vitest in `ItemDeleteModal.spec.tsx`

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced handling of asynchronous actions in the `ItemDeleteModal` tests.
	- Updated mocking framework for toast notifications from Jest to Vitest.
	- Modified properties in the `itemProps` object to reflect the new mocking approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->