### PR TITLE
refactor: jest to vitest of itemUpdateStatusModal : fixes #2557

### DIFF
--- a/src/screens/OrganizationActionItems/ItemUpdateStatusModal.spec.tsx
+++ b/src/screens/OrganizationActionItems/ItemUpdateStatusModal.spec.tsx
@@ -16,11 +16,12 @@ import { toast } from 'react-toastify';
 import ItemUpdateStatusModal, {
   type InterfaceItemUpdateStatusModalProps,
 } from './ItemUpdateStatusModal';
+import { vi } from 'vitest';
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    success: jest.fn(),
-    error: jest.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
   },
 }));
 
@@ -35,8 +36,8 @@ const t = JSON.parse(
 const itemProps: InterfaceItemUpdateStatusModalProps[] = [
   {
     isOpen: true,
-    hide: jest.fn(),
-    actionItemsRefetch: jest.fn(),
+    hide: vi.fn(),
+    actionItemsRefetch: vi.fn(),
     actionItem: {
       _id: 'actionItemId1',
       assignee: null,
@@ -75,8 +76,8 @@ const itemProps: InterfaceItemUpdateStatusModalProps[] = [
   },
   {
     isOpen: true,
-    hide: jest.fn(),
-    actionItemsRefetch: jest.fn(),
+    hide: vi.fn(),
+    actionItemsRefetch: vi.fn(),
     actionItem: {
       _id: 'actionItemId1',
       assignee: null,
@@ -148,8 +149,8 @@ const itemProps: InterfaceItemUpdateStatusModalProps[] = [
   },
   {
     isOpen: true,
-    hide: jest.fn(),
-    actionItemsRefetch: jest.fn(),
+    hide: vi.fn(),
+    actionItemsRefetch: vi.fn(),
     actionItem: {
       _id: 'actionItemId1',
       assignee: {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactoring

**Issue Number:**

There are multiple test files in this directory. So it needs multiple PRs to close the issue. This PR fixes one such file inside that directory `ItemUpdateStatusModal.spec.tsx`

Fixes #2557

**Snapshots/Videos:**

![image](https://github.com/user-attachments/assets/0cdcbcc6-038b-413a-a84c-d37cc3a956be)

**Summary**

Refactored the `ItemUpdateStatusModal.tsx` tests from jest to vitest in `ItemUpdateStatusModal.spec.tsx`

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the testing framework from Jest to Vitest for the `ItemUpdateStatusModal` component.
	- Adjusted mock implementations for success and error notifications.
	- Ensured tests for updating action item statuses and error handling remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->