### PR TITLE
Refactor: jest to vitest of itemModal : fixes #2557

### DIFF
--- a/src/screens/OrganizationActionItems/ItemModal.spec.tsx
+++ b/src/screens/OrganizationActionItems/ItemModal.spec.tsx
@@ -21,12 +21,13 @@ import { StaticMockLink } from 'utils/StaticMockLink';
 import { toast } from 'react-toastify';
 import type { InterfaceItemModalProps } from './ItemModal';
 import ItemModal from './ItemModal';
+import { vi } from 'vitest';
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    success: jest.fn(),
-    error: jest.fn(),
-    warning: jest.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
   },
 }));
 
@@ -45,28 +46,28 @@ const t = {
 const itemProps: InterfaceItemModalProps[] = [
   {
     isOpen: true,
-    hide: jest.fn(),
+    hide: vi.fn(),
     orgId: 'orgId',
     eventId: undefined,
-    actionItemsRefetch: jest.fn(),
+    actionItemsRefetch: vi.fn(),
     editMode: false,
     actionItem: null,
   },
   {
     isOpen: true,
-    hide: jest.fn(),
+    hide: vi.fn(),
     orgId: 'orgId',
     eventId: 'eventId',
-    actionItemsRefetch: jest.fn(),
+    actionItemsRefetch: vi.fn(),
     editMode: false,
     actionItem: null,
   },
   {
     isOpen: true,
-    hide: jest.fn(),
+    hide: vi.fn(),
     orgId: 'orgId',
     eventId: undefined,
-    actionItemsRefetch: jest.fn(),
+    actionItemsRefetch: vi.fn(),
     editMode: true,
     actionItem: {
       _id: 'actionItemId1',
@@ -106,10 +107,10 @@ const itemProps: InterfaceItemModalProps[] = [
   },
   {
     isOpen: true,
-    hide: jest.fn(),
+    hide: vi.fn(),
     orgId: 'orgId',
     eventId: undefined,
-    actionItemsRefetch: jest.fn(),
+    actionItemsRefetch: vi.fn(),
     editMode: true,
     actionItem: {
       _id: 'actionItemId2',
@@ -149,10 +150,10 @@ const itemProps: InterfaceItemModalProps[] = [
   },
   {
     isOpen: true,
-    hide: jest.fn(),
+    hide: vi.fn(),
     orgId: 'orgId',
     eventId: 'eventId',
-    actionItemsRefetch: jest.fn(),
+    actionItemsRefetch: vi.fn(),
     editMode: true,
     actionItem: {
       _id: 'actionItemId2',
@@ -202,10 +203,10 @@ const itemProps: InterfaceItemModalProps[] = [
   },
   {
     isOpen: true,
-    hide: jest.fn(),
+    hide: vi.fn(),
     orgId: 'orgId',
     eventId: 'eventId',
-    actionItemsRefetch: jest.fn(),
+    actionItemsRefetch: vi.fn(),
     editMode: true,
     actionItem: {
       _id: 'actionItemId2',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactoring

**Issue Number:**

There are multiple test files in this directory. So it needs multiple PRs to close the issue. This PR fixes one such file inside that directory `itemModal.spec.tsx`

Fixes #2557

**Snapshots/Videos:**

![image](https://github.com/user-attachments/assets/977d5485-ff62-45e7-9e7b-c0aaea2cdbe0)

**Summary**

Refactored the `itemModal.tsx` tests from jest to vitest in `itemModal.spec.tsx`

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated testing framework from Jest to Vitest for the `ItemModal` component tests.
	- Adjusted mocking methods for `react-toastify` to use `vi.fn()` instead of `jest.fn()`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->