### PR TITLE
refactor: jest to vitest of itemViewModal : fixes #2557

### DIFF
--- a/src/screens/OrganizationActionItems/ItemViewModal.spec.tsx
+++ b/src/screens/OrganizationActionItems/ItemViewModal.spec.tsx
@@ -18,11 +18,12 @@ import type {
   InterfaceUserInfo,
   InterfaceVolunteerGroupInfo,
 } from 'utils/interfaces';
+import { vi } from 'vitest';
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    success: jest.fn(),
-    error: jest.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
   },
 }));
 
@@ -86,7 +87,7 @@ const actionItemCategory = {
 const itemProps: InterfaceViewModalProps[] = [
   {
     isOpen: true,
-    hide: jest.fn(),
+    hide: vi.fn(),
     item: {
       _id: 'actionItemId1',
       assignee: createAssignee(assigneeWithoutImage),
@@ -108,7 +109,7 @@ const itemProps: InterfaceViewModalProps[] = [
   },
   {
     isOpen: true,
-    hide: jest.fn(),
+    hide: vi.fn(),
     item: {
       _id: 'actionItemId2',
       assignee: createAssignee(assigneeWithImage),
@@ -130,7 +131,7 @@ const itemProps: InterfaceViewModalProps[] = [
   },
   {
     isOpen: true,
-    hide: jest.fn(),
+    hide: vi.fn(),
     item: {
       _id: 'actionItemId2',
       assignee: null,
@@ -152,7 +153,7 @@ const itemProps: InterfaceViewModalProps[] = [
   },
   {
     isOpen: true,
-    hide: jest.fn(),
+    hide: vi.fn(),
     item: {
       _id: 'actionItemId2',
       assignee: null,
@@ -174,7 +175,7 @@ const itemProps: InterfaceViewModalProps[] = [
   },
   {
     isOpen: true,
-    hide: jest.fn(),
+    hide: vi.fn(),
     item: {
       _id: 'actionItemId2',
       assignee: null,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactoring

**Issue Number:**

There are multiple test files in this directory. So it needs multiple PRs to close the issue. This PR fixes one such file inside that directory `itemViewModal.spec.tsx`

Fixes #2557

**Snapshots/Videos:**

![image](https://github.com/user-attachments/assets/f3a5de73-a852-4b36-9e18-baf74ac3d46e)

**Summary**

Refactored the `itemViewModal.tsx` tests from jest to vitest in `itemViewModal.spec.tsx`

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the testing framework from Jest to Vitest for the `ItemViewModal` component tests.
	- Revised mock implementations for `react-toastify` to align with the new framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->