### PR TITLE
Refactored src/screens/UserPortal/Volunteer/Invitations from jest to Vitest

### DIFF
--- a/src/screens/UserPortal/Volunteer/Invitations/Invitations.spec.tsx
+++ b/src/screens/UserPortal/Volunteer/Invitations/Invitations.spec.tsx
@@ -21,13 +21,23 @@ import {
 } from './Invitations.mocks';
 import { toast } from 'react-toastify';
 import useLocalStorage from 'utils/useLocalstorage';
+import { vi, expect } from 'vitest';
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    success: jest.fn(),
-    error: jest.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
   },
 }));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => ({ orgId: 'orgId' }),
+    useNavigate: vi.fn(),
+  };
+});
 
 const { setItem } = useLocalStorage();
 
@@ -79,19 +89,12 @@ const renderInvitations = (link: ApolloLink): RenderResult => {
 };
 
 describe('Testing Invvitations Screen', () => {
-  beforeAll(() => {
-    jest.mock('react-router-dom', () => ({
-      ...jest.requireActual('react-router-dom'),
-      useParams: () => ({ orgId: 'orgId' }),
-    }));
-  });
-
   beforeEach(() => {
     setItem('userId', 'userId');
   });
 
   afterAll(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('should redirect to fallback URL if URL params are undefined', async () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactoring & BugFix

**Issue Number:**

Fixes #2583 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<img width="1296" alt="Screenshot 2024-12-22 at 9 26 21 PM" src="https://github.com/user-attachments/assets/3fae32aa-e46f-4153-8818-fb6a8733409c" />

<img width="999" alt="Screenshot 2024-12-22 at 9 26 01 PM" src="https://github.com/user-attachments/assets/70e87a0f-8bc1-4180-ae23-ecfdc63a81e6" />


**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

**Other information**

N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Transitioned testing framework from Jest to Vitest for the Invitations component.
	- Updated mocking methods for dependencies like `react-toastify` and `react-router-dom`.
	- Maintained the structure and logic of tests to ensure accurate validation of component functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->