### PR TITLE
Bugfix: Prevent unnecessary page reload after deleting a user

### DIFF
--- a/src/components/OrgPeopleListCard/OrgPeopleListCard.tsx
+++ b/src/components/OrgPeopleListCard/OrgPeopleListCard.tsx
@@ -59,9 +59,7 @@ function orgPeopleListCard(
       /* istanbul ignore next */
       if (data) {
         toast.success(t('memberRemoved') as string);
-        setTimeout(() => {
-          window.location.reload();
-        }, 2000);
+        props.toggleRemoveModal();
       }
     } catch (error: unknown) {
       /* istanbul ignore next */


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix: Prevent unnecessary page reload after deleting a user from the organization


**Issue Number:**

Fixes #2700

**Did you add tests for your changes?**

Yes. The existing tests cover this functionality, and the updated code passes all tests.

**Snapshots/Videos:**

[fix-2700.webm](https://github.com/user-attachments/assets/83123f26-4140-45bc-8b80-10bdc6419e46)

**If relevant, did you update the documentation?**

**Summary**

The motivation for this change is to improve the user experience by preventing unnecessary page reloads after deleting a user from the organization. The modal is now closed without reloading the entire page

**Does this PR introduce a breaking change?**

No

**Other information**

N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved member removal process by closing the modal instead of reloading the page upon successful removal.
  
- **Bug Fixes**
	- Enhanced error handling during the member removal process.

- **Tests**
	- Updated testing strategy with improved error handling and component rendering tests for the OrgPeopleListCard component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->