### PR TITLE
Refactor : src/screens/OrgContribution component from Jest to Vitest

### DIFF
--- a/src/screens/OrgContribution/OrgContribution.spec.tsx
+++ b/src/screens/OrgContribution/OrgContribution.spec.tsx
@@ -1,9 +1,9 @@
-import React, { act } from 'react';
+import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
-import 'jest-location-mock';
+import { vi, describe, test, expect } from 'vitest';
 import { I18nextProvider } from 'react-i18next';
 
 import OrgContribution from './OrgContribution';
@@ -12,15 +12,19 @@ import i18nForTest from 'utils/i18nForTest';
 import { StaticMockLink } from 'utils/StaticMockLink';
 const link = new StaticMockLink([], true);
 async function wait(ms = 100): Promise<void> {
-  await act(() => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
   });
 }
 
 describe('Organisation Contribution Page', () => {
   test('should render props and text elements test for the screen', async () => {
+    Object.defineProperty(window, 'location', {
+      value: {
+        assign: vi.fn(),
+      },
+      writable: true,
+    });
     window.location.assign('/orglist');
 
     const { container } = render(
@@ -37,11 +41,10 @@ describe('Organisation Contribution Page', () => {
 
     expect(container.textContent).not.toBe('Loading data...');
     await wait();
-
     expect(container.textContent).toMatch('Filter by Name');
     expect(container.textContent).toMatch('Filter by Trans. ID');
     expect(container.textContent).toMatch('Recent Stats');
     expect(container.textContent).toMatch('Contribution');
-    expect(window.location).toBeAt('/orglist');
+    expect(window.location.assign).toHaveBeenCalledWith('/orglist');
   });
 });


### PR DESCRIPTION
What kind of change does this PR introduce?

Refactoring

Issue Number: #2564 

There are multiple test files in this directory. So it needs multiple PRs to close the issue. This PR fixes one such file inside that directory OrgContribution.spec.tsx

Fixes https://github.com/PalisadoesFoundation/talawa-admin/issues/2564

Summary

Refactored the OrgContribution.
![Screenshot from 2024-12-23 02-07-33](https://github.com/user-attachments/assets/4e2a0e00-e84b-47d3-97e2-57958e990ac9)
spec.tsx tests from jest to vitest 
Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated testing framework from Jest to Vitest.
	- Simplified asynchronous handling in tests.
	- Enhanced mocking of `window.location.assign` for improved assertion tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->