### PR TITLE
Refactor: src/screens/SubTags from Jest to Vitest

### DIFF
--- a/src/screens/SubTags/SubTags.tsx
+++ b/src/screens/SubTags/SubTags.tsx
@@ -127,6 +127,7 @@ function SubTags(): JSX.Element {
         },
       });
 
+      /* istanbul ignore next -- @preserve */
       if (data) {
         toast.success(t('tagCreationSuccess') as string);
         subTagsRefetch();
@@ -134,6 +135,7 @@ function SubTags(): JSX.Element {
         setAddSubTagModalIsOpen(false);
       }
     } catch (error: unknown) {
+      /* istanbul ignore next -- @preserve */
       if (error instanceof Error) {
         toast.error(error.message);
       }
@@ -154,7 +156,8 @@ function SubTags(): JSX.Element {
   }
 
   const subTagsList =
-    subTagsData?.getChildTags.childTags.edges.map((edge) => edge.node) ?? [];
+    subTagsData?.getChildTags.childTags.edges.map((edge) => edge.node) ??
+    /* istanbul ignore next -- @preserve */ [];
 
   const parentTagName = subTagsData?.getChildTags.name;
 
@@ -392,6 +395,7 @@ function SubTags(): JSX.Element {
                   next={loadMoreSubTags}
                   hasMore={
                     subTagsData?.getChildTags.childTags.pageInfo.hasNextPage ??
+                    /* istanbul ignore next -- @preserve */
                     false
                   }
                   loader={<InfiniteScrollLoader />}
@@ -403,15 +407,16 @@ function SubTags(): JSX.Element {
                     hideFooter={true}
                     getRowId={(row) => row.id}
                     slots={{
-                      noRowsOverlay: /* istanbul ignore next */ () => (
-                        <Stack
-                          height="100%"
-                          alignItems="center"
-                          justifyContent="center"
-                        >
-                          {t('noTagsFound')}
-                        </Stack>
-                      ),
+                      noRowsOverlay:
+                        /* istanbul ignore next -- @preserve */ () => (
+                          <Stack
+                            height="100%"
+                            alignItems="center"
+                            justifyContent="center"
+                          >
+                            {t('noTagsFound')}
+                          </Stack>
+                        ),
                     }}
                     sx={dataGridStyle}
                     getRowClassName={() => `${styles.rowBackground}`}

--- a/src/screens/SubTags/SubTags.tsx
+++ b/src/screens/SubTags/SubTags.tsx
@@ -93,7 +93,8 @@ function SubTags(): JSX.Element {
           fetchMoreResult?: { getChildTags: InterfaceQueryUserTagChildTags };
         },
       ) => {
-        if (!fetchMoreResult) /* istanbul ignore next */ return prevResult;
+        /* istanbul ignore if -- @preserve */
+        if (!fetchMoreResult) return prevResult;
 
         return {
           getChildTags: {
@@ -126,7 +127,6 @@ function SubTags(): JSX.Element {
         },
       });
 
-      /* istanbul ignore next */
       if (data) {
         toast.success(t('tagCreationSuccess') as string);
         subTagsRefetch();
@@ -134,7 +134,6 @@ function SubTags(): JSX.Element {
         setAddSubTagModalIsOpen(false);
       }
     } catch (error: unknown) {
-      /* istanbul ignore next */
       if (error instanceof Error) {
         toast.error(error.message);
       }
@@ -155,8 +154,7 @@ function SubTags(): JSX.Element {
   }
 
   const subTagsList =
-    subTagsData?.getChildTags.childTags.edges.map((edge) => edge.node) ??
-    /* istanbul ignore next */ [];
+    subTagsData?.getChildTags.childTags.edges.map((edge) => edge.node) ?? [];
 
   const parentTagName = subTagsData?.getChildTags.name;
 
@@ -394,7 +392,6 @@ function SubTags(): JSX.Element {
                   next={loadMoreSubTags}
                   hasMore={
                     subTagsData?.getChildTags.childTags.pageInfo.hasNextPage ??
-                    /* istanbul ignore next */
                     false
                   }
                   loader={<InfiniteScrollLoader />}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR migrates the test cases in src/screens/SubTags from Jest to Vitest, ensuring compatibility with Vitest and maintaining 100% test coverage. 
Added few more test case and some 'istanbul ignore next' comments

**Issue Number:**
Fixes #2570

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<img width="876" alt="Screenshot 2024-12-23 at 21 27 11" src="https://github.com/user-attachments/assets/9679cad6-f16f-44a3-bdf0-82932adb458b" />

**If relevant, did you update the documentation?**

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

**Other information**

N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
	- Transitioned the testing framework from Jest to Vitest for the `SubTags` component.
	- Updated test cases to include error handling for invalid organization IDs.
	- Enhanced flexibility in the test rendering function by adding an `initialRoute` parameter.

- **Bug Fixes**
	- Improved error handling and control flow in the `SubTags` component, clarifying code comments without changing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->