### PR TITLE
Migrated src/screens/SubTags from Jest to Vitest

### DIFF
--- a/src/screens/SubTags/SubTags.spec.tsx
+++ b/src/screens/SubTags/SubTags.spec.tsx
@@ -22,7 +22,6 @@ import SubTags from './SubTags';
 import { MOCKS, MOCKS_ERROR_SUB_TAGS } from './SubTagsMocks';
 import { InMemoryCache, type ApolloLink } from '@apollo/client';
 import { vi, beforeEach, afterEach, expect, it } from 'vitest';
-import '@testing-library/jest-dom/vitest';
 
 const translations = {
   ...JSON.parse(

--- a/src/screens/SubTags/SubTags.spec.tsx
+++ b/src/screens/SubTags/SubTags.spec.tsx
@@ -11,7 +11,6 @@ import {
   waitForElementToBeRemoved,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import 'jest-location-mock';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -22,6 +21,8 @@ import i18n from 'utils/i18nForTest';
 import SubTags from './SubTags';
 import { MOCKS, MOCKS_ERROR_SUB_TAGS } from './SubTagsMocks';
 import { InMemoryCache, type ApolloLink } from '@apollo/client';
+import { vi, beforeEach, afterEach, expect, it } from 'vitest';
+import '@testing-library/jest-dom/vitest';
 
 const translations = {
   ...JSON.parse(
@@ -44,10 +45,10 @@ async function wait(ms = 500): Promise<void> {
   });
 }
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    success: jest.fn(),
-    error: jest.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
   },
 }));
 
@@ -107,19 +108,18 @@ const renderSubTags = (link: ApolloLink): RenderResult => {
 
 describe('Organisation Tags Page', () => {
   beforeEach(() => {
-    jest.mock('react-router-dom', () => ({
-      ...jest.requireActual('react-router-dom'),
-      useParams: () => ({ orgId: 'orgId' }),
+    vi.mock('react-router-dom', async () => ({
+      ...(await vi.importActual('react-router-dom')),
     }));
     cache.reset();
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
     cleanup();
   });
 
-  test('Component loads correctly', async () => {
+  it('Component loads correctly', async () => {
     const { getByText } = renderSubTags(link);
 
     await wait();
@@ -129,7 +129,7 @@ describe('Organisation Tags Page', () => {
     });
   });
 
-  test('render error component on unsuccessful subtags query', async () => {
+  it('render error component on unsuccessful subtags query', async () => {
     const { queryByText } = renderSubTags(link2);
 
     await wait();
@@ -139,7 +139,7 @@ describe('Organisation Tags Page', () => {
     });
   });
 
-  test('opens and closes the create tag modal', async () => {
+  it('opens and closes the create tag modal', async () => {
     renderSubTags(link);
 
     await wait();
@@ -161,7 +161,7 @@ describe('Organisation Tags Page', () => {
     );
   });
 
-  test('navigates to manage tag screen after clicking manage tag option', async () => {
+  it('navigates to manage tag screen after clicking manage tag option', async () => {
     renderSubTags(link);
 
     await wait();
@@ -176,7 +176,7 @@ describe('Organisation Tags Page', () => {
     });
   });
 
-  test('navigates to sub tags screen after clicking on a tag', async () => {
+  it('navigates to sub tags screen after clicking on a tag', async () => {
     renderSubTags(link);
 
     await wait();
@@ -191,7 +191,7 @@ describe('Organisation Tags Page', () => {
     });
   });
 
-  test('navigates to the different sub tag screen screen after clicking a tag in the breadcrumbs', async () => {
+  it('navigates to the different sub tag screen screen after clicking a tag in the breadcrumbs', async () => {
     renderSubTags(link);
 
     await wait();
@@ -206,7 +206,7 @@ describe('Organisation Tags Page', () => {
     });
   });
 
-  test('navigates to organization tags screen screen after clicking tha all tags option in the breadcrumbs', async () => {
+  it('navigates to organization tags screen screen after clicking tha all tags option in the breadcrumbs', async () => {
     renderSubTags(link);
 
     await wait();
@@ -221,7 +221,7 @@ describe('Organisation Tags Page', () => {
     });
   });
 
-  test('navigates to manage tags screen for the current tag after clicking tha manageCurrentTag button', async () => {
+  it('navigates to manage tags screen for the current tag after clicking tha manageCurrentTag button', async () => {
     renderSubTags(link);
 
     await wait();
@@ -236,7 +236,7 @@ describe('Organisation Tags Page', () => {
     });
   });
 
-  test('searchs for tags where the name matches the provided search input', async () => {
+  it('searchs for tags where the name matches the provided search input', async () => {
     renderSubTags(link);
 
     await wait();
@@ -257,7 +257,7 @@ describe('Organisation Tags Page', () => {
     });
   });
 
-  test('fetches the tags by the sort order, i.e. latest or oldest first', async () => {
+  it('fetches the tags by the sort order, i.e. latest or oldest first', async () => {
     renderSubTags(link);
 
     await wait();
@@ -314,7 +314,7 @@ describe('Organisation Tags Page', () => {
     });
   });
 
-  test('Fetches more sub tags with infinite scroll', async () => {
+  it('Fetches more sub tags with infinite scroll', async () => {
     const { getByText } = renderSubTags(link);
 
     await wait();
@@ -343,7 +343,7 @@ describe('Organisation Tags Page', () => {
     });
   });
 
-  test('adds a new sub tag to the current tag', async () => {
+  it('adds a new sub tag to the current tag', async () => {
     renderSubTags(link);
 
     await wait();

--- a/src/screens/SubTags/SubTags.tsx
+++ b/src/screens/SubTags/SubTags.tsx
@@ -93,7 +93,8 @@ function SubTags(): JSX.Element {
           fetchMoreResult?: { getChildTags: InterfaceQueryUserTagChildTags };
         },
       ) => {
-        if (!fetchMoreResult) /* istanbul ignore next */ return prevResult;
+        /* istanbul ignore next -- @preserve */
+        if (!fetchMoreResult) return prevResult;
 
         return {
           getChildTags: {
@@ -126,7 +127,7 @@ function SubTags(): JSX.Element {
         },
       });
 
-      /* istanbul ignore next */
+      /* istanbul ignore next -- @preserve */
       if (data) {
         toast.success(t('tagCreationSuccess') as string);
         subTagsRefetch();
@@ -134,7 +135,7 @@ function SubTags(): JSX.Element {
         setAddSubTagModalIsOpen(false);
       }
     } catch (error: unknown) {
-      /* istanbul ignore next */
+      /* istanbul ignore next -- @preserve */
       if (error instanceof Error) {
         toast.error(error.message);
       }
@@ -155,8 +156,8 @@ function SubTags(): JSX.Element {
   }
 
   const subTagsList =
-    subTagsData?.getChildTags.childTags.edges.map((edge) => edge.node) ??
-    /* istanbul ignore next */ [];
+    /* istanbul ignore next -- @preserve */
+    subTagsData?.getChildTags.childTags.edges.map((edge) => edge.node) ?? [];
 
   const parentTagName = subTagsData?.getChildTags.name;
 
@@ -394,7 +395,7 @@ function SubTags(): JSX.Element {
                   next={loadMoreSubTags}
                   hasMore={
                     subTagsData?.getChildTags.childTags.pageInfo.hasNextPage ??
-                    /* istanbul ignore next */
+                    /* istanbul ignore next -- @preserve */
                     false
                   }
                   loader={<InfiniteScrollLoader />}
@@ -406,15 +407,16 @@ function SubTags(): JSX.Element {
                     hideFooter={true}
                     getRowId={(row) => row.id}
                     slots={{
-                      noRowsOverlay: /* istanbul ignore next */ () => (
-                        <Stack
-                          height="100%"
-                          alignItems="center"
-                          justifyContent="center"
-                        >
-                          {t('noTagsFound')}
-                        </Stack>
-                      ),
+                      noRowsOverlay:
+                        /* istanbul ignore next -- @preserve */ () => (
+                          <Stack
+                            height="100%"
+                            alignItems="center"
+                            justifyContent="center"
+                          >
+                            {t('noTagsFound')}
+                          </Stack>
+                        ),
                     }}
                     sx={dataGridStyle}
                     getRowClassName={() => `${styles.rowBackground}`}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR migrates the test cases in src/screens/SubTags from Jest to Vitest, ensuring compatibility with Vitest and maintaining 100% test coverage. 

**Issue Number:**
Fixes #2570

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<img width="1178" alt="Screenshot 2024-12-23 at 23 45 36" src="https://github.com/user-attachments/assets/9e208926-5167-4c3c-9288-83b4aa9e9283" />

**If relevant, did you update the documentation?**

N/A

**Summary**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**

No

**Other information**

N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Transitioned testing framework from Jest to Vitest for improved compatibility.
	- Updated test cases to follow BDD-style syntax.
	- Enhanced mocking for external libraries used in tests.

- **Chores**
	- Improved comments and formatting in the SubTags component to enhance clarity for coverage reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->