### PR TITLE
Refactor: src/screens/UserPortal/People from Jest to Vitest

### DIFF
--- a/src/screens/UserPortal/People/People.spec.tsx
+++ b/src/screens/UserPortal/People/People.spec.tsx
@@ -13,6 +13,19 @@ import i18nForTest from 'utils/i18nForTest';
 import { StaticMockLink } from 'utils/StaticMockLink';
 import People from './People';
 import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+/**
+ * This file contains unit tests for the People component.
+ *
+ * The tests cover:
+ * - Proper rendering of the People screen and its elements.
+ * - Functionality of the search input and search button.
+ * - Correct behavior when switching between member and admin modes.
+ * - Integration with mocked GraphQL queries for testing data fetching.
+ *
+ * These tests use Vitest for test execution, MockedProvider for mocking GraphQL queries, and react-testing-library for rendering and interactions.
+ */
 
 const MOCKS = [
   {
@@ -113,27 +126,30 @@ async function wait(ms = 100): Promise<void> {
   });
 }
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => ({ orgId: '' }),
-}));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => ({ orgId: '' }),
+  };
+});
 
 describe('Testing People Screen [User Portal]', () => {
   Object.defineProperty(window, 'matchMedia', {
     writable: true,
-    value: jest.fn().mockImplementation((query) => ({
+    value: vi.fn().mockImplementation((query) => ({
       matches: false,
       media: query,
       onchange: null,
-      addListener: jest.fn(), // Deprecated
-      removeListener: jest.fn(), // Deprecated
-      addEventListener: jest.fn(),
-      removeEventListener: jest.fn(),
-      dispatchEvent: jest.fn(),
+      addListener: vi.fn(), // Deprecated
+      removeListener: vi.fn(), // Deprecated
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
     })),
   });
 
-  test('Screen should be rendered properly', async () => {
+  it('Screen should be rendered properly', async () => {
     render(
       <MockedProvider addTypename={false} link={link}>
         <BrowserRouter>
@@ -151,7 +167,7 @@ describe('Testing People Screen [User Portal]', () => {
     expect(screen.queryAllByText('Noble Mittal')).not.toBe([]);
   });
 
-  test('Search works properly by pressing enter', async () => {
+  it('Search works properly by pressing enter', async () => {
     render(
       <MockedProvider addTypename={false} link={link}>
         <BrowserRouter>
@@ -173,7 +189,7 @@ describe('Testing People Screen [User Portal]', () => {
     expect(screen.queryByText('Noble Mittal')).not.toBeInTheDocument();
   });
 
-  test('Search works properly by clicking search Btn', async () => {
+  it('Search works properly by clicking search Btn', async () => {
     render(
       <MockedProvider addTypename={false} link={link}>
         <BrowserRouter>
@@ -199,7 +215,7 @@ describe('Testing People Screen [User Portal]', () => {
     expect(screen.queryByText('Noble Mittal')).not.toBeInTheDocument();
   });
 
-  test('Mode is changed to Admins', async () => {
+  it('Mode is changed to Admins', async () => {
     render(
       <MockedProvider addTypename={false} link={link}>
         <BrowserRouter>


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
This PR migrates the test cases in src/screens/UserPortal/People from Jest to Vitest, ensuring compatibility with Vitest and maintaining 100% test coverage.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #2576 

**Did you add tests for your changes?**
yes
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**

![Screenshot from 2024-12-24 14-36-15](https://github.com/user-attachments/assets/29434a14-850e-4b4b-80ea-a706d154b0b1)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Transitioned unit tests for the `People` component from Jest to Vitest.
	- Updated mock implementations and test definitions to align with the new framework.
	- Added documentation comments for clarity on testing technologies used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->