### PR TITLE
fixed :#2750 Refactor: src/setup/askForTalawaApiUrl/setupTalawaWebSocketUrl.test.ts from Jest to Vitest 

### DIFF
--- a/src/setup/askForTalawaApiUrl/setupTalawaWebSocketUrl.spec.ts
+++ b/src/setup/askForTalawaApiUrl/setupTalawaWebSocketUrl.spec.ts
@@ -1,15 +1,20 @@
 import fs from 'fs';
+import { vi } from 'vitest';
 import inquirer from 'inquirer';
 import { askForTalawaApiUrl } from './askForTalawaApiUrl';
 
-jest.mock('fs');
-jest.mock('inquirer', () => ({
-  prompt: jest.fn(),
-}));
+vi.mock('fs');
+vi.mock('inquirer', async () => {
+  const actual = await vi.importActual('inquirer');
+  return {
+    ...actual,
+    prompt: vi.fn(),
+  };
+});
 
 describe('WebSocket URL Configuration', () => {
   beforeEach(() => {
-    jest.resetAllMocks();
+    vi.clearAllMocks();
   });
 
   test('should convert http URL to ws WebSocket URL', async () => {
@@ -27,12 +32,12 @@ describe('WebSocket URL Configuration', () => {
   });
 
   test('should retain default WebSocket URL if no new endpoint is provided', async () => {
-    jest
-      .spyOn(inquirer, 'prompt')
-      .mockResolvedValueOnce({ endpoint: 'http://localhost:4000/graphql/' });
+    vi.spyOn(inquirer, 'prompt').mockResolvedValueOnce({
+      endpoint: 'http://localhost:4000/graphql/',
+    });
     await askForTalawaApiUrl();
 
-    const writeFileSyncSpy = jest.spyOn(fs, 'writeFileSync');
+    const writeFileSyncSpy = vi.spyOn(fs, 'writeFileSync');
     expect(writeFileSyncSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the master branch:

- develop: For unstable code: New features and bug fixes.
- master: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR DEVELOP BRANCH. THE DEFAULT IS MAIN, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST MAIN WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number**: #2750 

**Fixes** :

 Refactored the testing framework from Jest to Vitest in src/setup/checkConnection/checkConnection.test.ts.
Updated import statements, mocking methods, and assertions to align with Vitest conventions.
Verified compatibility with the existing codebase using Vitest.

Renamed the test file:
From checkConnection.test.ts → checkConnection.spec.ts to follow the naming convention for Vitest.
Ran all tests successfully under the Vitest environment.

**Did you add tests for your changes?**

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
<img width="933" alt="image" src="https://github.com/user-attachments/assets/a46ee491-e5dc-4adb-9f92-6f913a0f11a4" />

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

The test file was initially using Jest, but as part of the migration to Vitest, the following updates were made:
- Replaced Jest-specific functions and mocks with their Vitest equivalents.
- Renamed the test file to follow the `.spec.*` suffix.
- Ensured all tests pass with `npm run test:vitest`.
- Maintained 100% test coverage for the file.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->



<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Migrated testing framework from Jest to Vitest for improved testing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->