### PR TITLE
Fixed Tag and SubTag modal footer button alignment

### DIFF
--- a/src/style/app.module.css
+++ b/src/style/app.module.css
@@ -154,6 +154,7 @@
 }
 
 .closeButton {
+  margin-bottom: 10px;
   color: var(--delete-button-color);
   margin-right: 5px;
   background-color: var(--delete-button-bg);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Added "margin-bottom: 10px;" in .closeButton class in app.module.css which fixed the alignment issue in footer buttons of Tag and SubTag modal.

**Issue Number:**

Fixes #2778

**Did you add tests for your changes?**

N/A

**Snapshots/Videos:**

<img width="1470" alt="Screenshot 2024-12-25 at 09 34 50" src="https://github.com/user-attachments/assets/f1ed7e43-c400-40cf-9aa8-99f38f3c9241" />

<img width="1470" alt="Screenshot 2024-12-25 at 09 35 25" src="https://github.com/user-attachments/assets/23f38cf4-89ea-497d-9d36-7a4b320335a9" />


**If relevant, did you update the documentation?**
N/A

**Summary**
**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the spacing for the close button by adding a margin-bottom of 10px.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->