### PR TITLE
Migrated src/components/DynamicDropDown from Jest to Vitest

### DIFF
--- a/src/components/DynamicDropDown/DynamicDropDown.spec.tsx
+++ b/src/components/DynamicDropDown/DynamicDropDown.spec.tsx
@@ -11,11 +11,12 @@ import { BrowserRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from 'utils/i18nForTest';
 import userEvent from '@testing-library/user-event';
+import { vi, expect, it } from 'vitest';
 
 describe('DynamicDropDown component', () => {
-  test('renders and handles selection correctly', async () => {
+  it('renders and handles selection correctly', async () => {
     const formData = { fieldName: 'value2' };
-    const setFormData = jest.fn();
+    const setFormData = vi.fn();
 
     render(
       <BrowserRouter>
@@ -60,10 +61,10 @@ describe('DynamicDropDown component', () => {
       expect(dropdownButton).toHaveTextContent('Label 2');
     });
   });
-  test('calls custom handleChange function when provided', async () => {
+  it('calls custom handleChange function when provided', async () => {
     const formData = { fieldName: 'value1' };
-    const setFormData = jest.fn();
-    const customHandleChange = jest.fn();
+    const setFormData = vi.fn();
+    const customHandleChange = vi.fn();
 
     render(
       <BrowserRouter>
@@ -103,9 +104,9 @@ describe('DynamicDropDown component', () => {
     );
     expect(setFormData).not.toHaveBeenCalled();
   });
-  test('handles keyboard navigation correctly', async () => {
+  it('handles keyboard navigation correctly', async () => {
     const formData = { fieldName: 'value1' };
-    const setFormData = jest.fn();
+    const setFormData = vi.fn();
 
     render(
       <BrowserRouter>


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR will migrate the src/components/DynamicDropDown/DynamicDropDown.test.tsx from Jest to Vitest.

**Issue Number:**

Fixes #2839

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<img width="1163" alt="Screenshot 2024-12-25 at 10 17 55" src="https://github.com/user-attachments/assets/dff8b898-4b3f-4faa-b192-fe14cd03f11b" />

**If relevant, did you update the documentation?**

N/A

**Summary**
**Does this PR introduce a breaking change?**

No

**Other information**

N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the testing framework from Jest to Vitest.
	- Changed test function declarations from `test` to `it` for improved clarity.
	- Adjusted mock function implementations to use Vitest's mocking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->