### PR TITLE
convert test from jest to vitest #2832

### DIFF
--- a/src/components/Loader/Loader.spec.tsx
+++ b/src/components/Loader/Loader.spec.tsx
@@ -1,26 +1,23 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Loader from './Loader';
-import { describe, it } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 describe('Testing Loader component', () => {
-  it('Component should be rendered properly', () => {
+  it('should render the component properly', () => {
     render(<Loader />);
-
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
 
-  it('Component should render on custom sizes', () => {
+  it('should render the component with custom sizes', () => {
     render(<Loader size="sm" />);
-
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
 
-  it('Component should render with large size', () => {
+  it('should render the component with large size', () => {
     render(<Loader size="lg" />);
-
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });

--- a/src/components/Loader/Loader.spec.tsx
+++ b/src/components/Loader/Loader.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Loader from './Loader';
-import {describe,it} from 'vitest';
+import { describe, it } from 'vitest';
 
 describe('Testing Loader component', () => {
   it('Component should be rendered properly', () => {

--- a/src/components/Loader/Loader.spec.tsx
+++ b/src/components/Loader/Loader.spec.tsx
@@ -1,23 +1,24 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Loader from './Loader';
+import {describe,it} from 'vitest';
 
 describe('Testing Loader component', () => {
-  test('Component should be rendered properly', () => {
+  it('Component should be rendered properly', () => {
     render(<Loader />);
 
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
 
-  test('Component should render on custom sizes', () => {
+  it('Component should render on custom sizes', () => {
     render(<Loader size="sm" />);
 
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
 
-  test('Component should render with large size', () => {
+  it('Component should render with large size', () => {
     render(<Loader size="lg" />);
 
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();


### PR DESCRIPTION
What kind of change does this PR introduce?
This PR will migrate the src/components/Loader/Loader.test.tsx from Jest to Vitest https://github.com/PalisadoesFoundation/talawa-admin/issues/2832

Issue Number:
Fixes https://github.com/PalisadoesFoundation/talawa-admin/issues/2832

Did you add tests for your changes?
Yes

Snapshots/Videos:
![Screenshot 2024-12-25 145819](https://github.com/user-attachments/assets/79bef66f-9408-4918-870e-c1af9e0ad335)

If relevant, did you update the documentation?
No

Does this PR introduce a breaking change?
No

Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?
Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Updated test cases for the Loader component to use the `it` function from the `vitest` testing framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->