### PR TITLE
fixed:2479 Refactor: src/components/AddOn/core/AddOnRegister/AddOnRegister.test.tsx from Jest to Vitest

### DIFF
--- a/src/components/AddOn/core/AddOnRegister/AddOnRegister.spec.tsx
+++ b/src/components/AddOn/core/AddOnRegister/AddOnRegister.spec.tsx
@@ -20,6 +20,7 @@ import i18nForTest from 'utils/i18nForTest';
 import { I18nextProvider } from 'react-i18next';
 import { toast } from 'react-toastify';
 import useLocalStorage from 'utils/useLocalstorage';
+import { vi } from 'vitest';
 
 const { getItem } = useLocalStorage();
 
@@ -74,26 +75,30 @@ const pluginData = {
   pluginDesc: 'Test Description',
 };
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    success: jest.fn(),
+    success: vi.fn(),
   },
 }));
 
-const mockNavigate = jest.fn();
+const mockNavigate = vi.fn();
 let mockId: string | undefined = 'id';
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => ({ orgId: mockId }),
-  useNavigate: () => mockNavigate,
-}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await import('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => ({ orgId: mockId }),
+    useNavigate: () => mockNavigate,
+  };
+});
 
 describe('Testing AddOnRegister', () => {
   const props = {
     id: '6234d8bf6ud937ddk70ecc5c9',
   };
 
-  test('should render modal and take info to add plugin for registered organization', async () => {
+  it('should render modal and take info to add plugin for registered organization', async () => {
     await act(async () => {
       render(
         <ApolloProvider client={client}>
@@ -127,7 +132,7 @@ describe('Testing AddOnRegister', () => {
     );
   });
 
-  test('Expect toast.success to be called on successful plugin addition', async () => {
+  it('Expect toast.success to be called on successful plugin addition', async () => {
     await act(async () => {
       render(
         <MockedProvider addTypename={false} mocks={mocks}>
@@ -158,7 +163,7 @@ describe('Testing AddOnRegister', () => {
     expect(toast.success).toHaveBeenCalledWith('Plugin added Successfully');
   });
 
-  test('Expect the window to reload after successful plugin addition', async () => {
+  it('Expect the window to reload after successful plugin addition', async () => {
     await act(async () => {
       render(
         <MockedProvider addTypename={false} mocks={mocks}>
@@ -189,7 +194,7 @@ describe('Testing AddOnRegister', () => {
     expect(mockNavigate).toHaveBeenCalledWith(0);
   });
 
-  test('should be redirected to /orglist if orgId is undefined', async () => {
+  it('should be redirected to /orglist if orgId is undefined', async () => {
     mockId = undefined;
     render(
       <ApolloProvider client={client}>


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the master branch:

- develop: For unstable code: New features and bug fixes.
- master: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR DEVELOP BRANCH. THE DEFAULT IS MAIN, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST MAIN WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number**: #2479

**Fixes** :

 Refactored the testing framework from Jest to Vitest in src/components/AddOn/core/AddOnRegister/AddOnRegister.test.tsx
Updated import statements, mocking methods, and assertions to align with Vitest conventions.
Verified compatibility with the existing codebase using Vitest.

Renamed the test file:
From checkConnection.test.ts → checkConnection.spec.ts to follow the naming convention for Vitest.
Ran all tests successfully under the Vitest environment.

**Did you add tests for your changes?**

<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
![image](https://github.com/user-attachments/assets/f870a55e-faa0-4c4a-9714-1373a2fe0a7e)

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

The test file was initially using Jest, but as part of the migration to Vitest, the following updates were made:
- Replaced Jest-specific functions and mocks with their Vitest equivalents.
- Renamed the test file to follow the `.spec.*` suffix.
- Ensured all tests pass with `npm run test:vitest`.
- Maintained 100% test coverage for the file.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->



<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
	- Migrated testing framework from Jest to Vitest for improved testing capabilities.
	- Updated test function syntax for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->