### PR TITLE
Refactor jest to vitest #2832

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,6 @@
   "extends": [
     "plugin:react/recommended",
     "eslint:recommended",
-    "plugin:jest/recommended",
     "plugin:prettier/recommended",
     "plugin:@typescript-eslint/recommended",
     "eslint-config-prettier",
@@ -30,7 +29,6 @@
   "plugins": [
     "react",
     "@typescript-eslint",
-    "jest",
     "import",
     "eslint-plugin-tsdoc",
     "prettier"
@@ -127,8 +125,6 @@
 
     "react/jsx-equals-spacing": ["warn", "never"],
     "react/no-this-in-sfc": "error",
-
-    "jest/expect-expect": 0,
 
     "react/no-unstable-nested-components": ["error", { "allowAsProps": true }],
     "react/function-component-definition": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,6 +8,7 @@
   "extends": [
     "plugin:react/recommended",
     "eslint:recommended",
+    "plugin:jest/recommended",
     "plugin:prettier/recommended",
     "plugin:@typescript-eslint/recommended",
     "eslint-config-prettier",
@@ -29,6 +30,7 @@
   "plugins": [
     "react",
     "@typescript-eslint",
+    "jest",
     "import",
     "eslint-plugin-tsdoc",
     "prettier"
@@ -125,6 +127,8 @@
 
     "react/jsx-equals-spacing": ["warn", "never"],
     "react/no-this-in-sfc": "error",
+
+    "jest/expect-expect": 0,
 
     "react/no-unstable-nested-components": ["error", { "allowAsProps": true }],
     "react/function-component-definition": [

--- a/src/components/Loader/Loader.spec.tsx
+++ b/src/components/Loader/Loader.spec.tsx
@@ -4,20 +4,23 @@ import Loader from './Loader';
 import { describe, it, expect } from 'vitest';
 
 describe('Testing Loader component', () => {
-  it('should render the component properly', () => {
+  it('Component should be rendered properly', () => {
     render(<Loader />);
+
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
 
-  it('should render the component with custom sizes', () => {
+  it('Component should render on custom sizes', () => {
     render(<Loader size="sm" />);
+
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
 
-  it('should render the component with large size', () => {
+  it('Component should render with large size', () => {
     render(<Loader size="lg" />);
+
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });

--- a/src/components/Loader/Loader.spec.tsx
+++ b/src/components/Loader/Loader.spec.tsx
@@ -1,26 +1,23 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Loader from './Loader';
-import { describe, it } from 'vitest';
+import { describe, it, expect } from 'vitest';
 
 describe('Testing Loader component', () => {
-  it('Component should be rendered properly', () => {
+  it('should render the component properly', () => {
     render(<Loader />);
-
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
 
-  it('Component should render on custom sizes', () => {
+  it('should render the component with custom sizes', () => {
     render(<Loader size="sm" />);
-
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
 
-  it('Component should render with large size', () => {
+  it('should render the component with large size', () => {
     render(<Loader size="lg" />);
-
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });

--- a/src/components/Loader/Loader.spec.tsx
+++ b/src/components/Loader/Loader.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Loader from './Loader';
-import {describe,it} from 'vitest';
+import { describe, it } from 'vitest';
 
 describe('Testing Loader component', () => {
   it('Component should be rendered properly', () => {

--- a/src/components/Loader/Loader.spec.tsx
+++ b/src/components/Loader/Loader.spec.tsx
@@ -1,23 +1,24 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import Loader from './Loader';
+import {describe,it} from 'vitest';
 
 describe('Testing Loader component', () => {
-  test('Component should be rendered properly', () => {
+  it('Component should be rendered properly', () => {
     render(<Loader />);
 
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
 
-  test('Component should render on custom sizes', () => {
+  it('Component should render on custom sizes', () => {
     render(<Loader size="sm" />);
 
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
   });
 
-  test('Component should render with large size', () => {
+  it('Component should render with large size', () => {
     render(<Loader size="lg" />);
 
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();


### PR DESCRIPTION
What kind of change does this PR introduce?
This PR will migrate the src/components/Loader/Loader.test.tsx from Jest to Vitest https://github.com/PalisadoesFoundation/talawa-admin/issues/2832

Issue Number:
Fixes https://github.com/PalisadoesFoundation/talawa-admin/issues/2832

Did you add tests for your changes?
Yes

Snapshots/Videos:
![Screenshot 2024-12-25 145819](https://github.com/user-attachments/assets/3ab8e18c-469c-4de6-959a-4660ea85bbbe)
If relevant, did you update the documentation?
No

Does this PR introduce a breaking change?
No

Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?
Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated the test suite for the Loader component to use the `it` function for defining test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->