### PR TITLE
Updated the calender to not accomodate future dates

### DIFF
--- a/src/screens/UserPortal/Settings/Settings.spec.tsx
+++ b/src/screens/UserPortal/Settings/Settings.spec.tsx
@@ -410,3 +410,34 @@ describe('Testing Settings Screen [User Portal]', () => {
     });
   });
 });
+
+it('prevents selecting future dates for birth date', async () => {
+  await act(async () => {
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <Settings />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+  });
+
+  const birthDateInput = screen.getByLabelText(
+    'Birth Date',
+  ) as HTMLInputElement;
+  const today = new Date().toISOString().split('T')[0];
+
+  // Trying future date
+  fireEvent.change(birthDateInput, { target: { value: '2100-01-01' } });
+
+  // Checking if value is not updated to future date
+  expect(birthDateInput.value).not.toBe('2100-01-01');
+
+  // Checking if value set correctly
+  fireEvent.change(birthDateInput, { target: { value: today } });
+  expect(birthDateInput.value).toBe(today);
+});

--- a/src/screens/UserPortal/Settings/Settings.spec.tsx
+++ b/src/screens/UserPortal/Settings/Settings.spec.tsx
@@ -430,12 +430,14 @@ it('prevents selecting future dates for birth date', async () => {
     'Birth Date',
   ) as HTMLInputElement;
   const today = new Date().toISOString().split('T')[0];
+  const futureDate = new Date();
+  futureDate.setFullYear(futureDate.getFullYear() + 100);
+  const futureDateString = futureDate.toISOString().split('T')[0];
 
   // Trying future date
-  fireEvent.change(birthDateInput, { target: { value: '2100-01-01' } });
-
+  fireEvent.change(birthDateInput, { target: { value: futureDateString } });
   // Checking if value is not updated to future date
-  expect(birthDateInput.value).not.toBe('2100-01-01');
+  expect(birthDateInput.value).not.toBe(futureDateString);
 
   // Checking if value set correctly
   fireEvent.change(birthDateInput, { target: { value: today } });

--- a/src/screens/UserPortal/Settings/Settings.tsx
+++ b/src/screens/UserPortal/Settings/Settings.tsx
@@ -449,6 +449,7 @@ export default function settings(): JSX.Element {
                           handleFieldChange('birthDate', e.target.value)
                         }
                         className={`${styles.cardControl}`}
+                        max={new Date().toISOString().split('T')[0]}
                       />
                     </Col>
                   </Row>

--- a/src/screens/UserPortal/Settings/Settings.tsx
+++ b/src/screens/UserPortal/Settings/Settings.tsx
@@ -126,6 +126,19 @@ export default function settings(): JSX.Element {
    * @param value - The new value for the field.
    */
   const handleFieldChange = (fieldName: string, value: string): void => {
+    // If the field is 'birthDate', validate the date
+    if (fieldName === 'birthDate') {
+      const today = new Date();
+      const selectedDate = new Date(value);
+
+      // Prevent updating the state if the selected date is in the future
+      if (selectedDate > today) {
+        console.error('Future dates are not allowed for the birth date.');
+        return; // Exit without updating the state
+      }
+    }
+
+    // Update state if the value passes validation
     setisUpdated(true);
     setUserDetails((prevState) => ({
       ...prevState,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

It restricts the user from selecting a future date as their date of birth from the calendar.

**Issue Number:**

Fixes https://github.com/PalisadoesFoundation/talawa-admin/issues/2732

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![image](https://github.com/user-attachments/assets/7bf97aef-b040-48c8-957e-040fe96bce44)


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Added a restriction on the birth date input field to prevent selection of future dates.

- **Bug Fixes**
	- Enhanced input validation for the birth date field.

- **Tests**
	- Introduced a test case to validate that future dates cannot be selected for the birth date input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->