### PR TITLE
Migrated src/components/NotFound from Jest to Vitest

### DIFF
--- a/src/components/NotFound/NotFound.spec.tsx
+++ b/src/components/NotFound/NotFound.spec.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from 'utils/i18nForTest';
-
 import { render, screen } from '@testing-library/react';
 import NotFound from './NotFound';
+import { expect, it, describe } from 'vitest';
 
 describe('Tesing the NotFound Component', () => {
   it('renders the component with the correct title for posts', () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR will migrate the src/components/NotFound/NotFound.test.tsx from Jest to Vitest.

**Issue Number:**

Fixes #2829

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<img width="1154" alt="Screenshot 2024-12-25 at 17 26 28" src="https://github.com/user-attachments/assets/3945f3c1-ecef-4b06-a06f-77975d27d30f" />


**If relevant, did you update the documentation?**

N/A

**Summary**
**Does this PR introduce a breaking change?**

No

**Other information**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a testing suite for the NotFound component using the `vitest` framework.
	- Added test cases to verify rendering of the NotFound component with different titles. 

- **Bug Fixes**
	- Ensured the "Not Found!" message is correctly displayed in the document for various titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->