### PR TITLE
[REFACTOR]: Jest to Vitest migration for askForCustomPort.test.ts

### DIFF
--- a/src/setup/askForCustomPort/askForCustomPort.spec.ts
+++ b/src/setup/askForCustomPort/askForCustomPort.spec.ts
@@ -1,33 +1,34 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import inquirer from 'inquirer';
 import { askForCustomPort, validatePort } from './askForCustomPort';
 
-jest.mock('inquirer');
+vi.mock('inquirer');
 
 describe('askForCustomPort', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   describe('basic port validation', () => {
-    test('should return default port if user provides no input', async () => {
-      jest
-        .spyOn(inquirer, 'prompt')
-        .mockResolvedValueOnce({ customPort: '4321' });
+    it('should return default port if user provides no input', async () => {
+      vi.spyOn(inquirer, 'prompt').mockResolvedValueOnce({
+        customPort: '4321',
+      });
 
       const result = await askForCustomPort();
       expect(result).toBe(4321);
     });
 
-    test('should return user-provided port', async () => {
-      jest
-        .spyOn(inquirer, 'prompt')
-        .mockResolvedValueOnce({ customPort: '8080' });
+    it('should return user-provided port', async () => {
+      vi.spyOn(inquirer, 'prompt').mockResolvedValueOnce({
+        customPort: '8080',
+      });
 
       const result = await askForCustomPort();
       expect(result).toBe(8080);
     });
 
-    test('should return validation error if port not between 1 and 65535', () => {
+    it('should return validation error if port not between 1 and 65535', () => {
       expect(validatePort('abcd')).toBe(
         'Please enter a valid port number between 1 and 65535.',
       );
@@ -41,9 +42,8 @@ describe('askForCustomPort', () => {
   });
 
   describe('retry mechanism', () => {
-    test('should handle invalid port input and prompt again', async () => {
-      jest
-        .spyOn(inquirer, 'prompt')
+    it('should handle invalid port input and prompt again', async () => {
+      vi.spyOn(inquirer, 'prompt')
         .mockResolvedValueOnce({ customPort: 'abcd' })
         .mockResolvedValueOnce({ customPort: '8080' });
 
@@ -51,9 +51,8 @@ describe('askForCustomPort', () => {
       expect(result).toBe(8080);
     });
 
-    test('should return default port after maximum retry attempts', async () => {
-      jest
-        .spyOn(inquirer, 'prompt')
+    it('should return default port after maximum retry attempts', async () => {
+      vi.spyOn(inquirer, 'prompt')
         .mockResolvedValueOnce({ customPort: 'invalid-port-attempt1' })
         .mockResolvedValueOnce({ customPort: 'invalid-port-attempt2' })
         .mockResolvedValueOnce({ customPort: 'invalid-port-attempt3' })
@@ -67,9 +66,8 @@ describe('askForCustomPort', () => {
   });
 
   describe('reserved ports', () => {
-    test('should return user-provided port after confirming reserved port', async () => {
-      jest
-        .spyOn(inquirer, 'prompt')
+    it('should return user-provided port after confirming reserved port', async () => {
+      vi.spyOn(inquirer, 'prompt')
         .mockResolvedValueOnce({ customPort: '80' })
         .mockResolvedValueOnce({ confirmPort: true });
 
@@ -77,9 +75,8 @@ describe('askForCustomPort', () => {
       expect(result).toBe(80);
     });
 
-    test('should re-prompt user for port if reserved port confirmation is denied', async () => {
-      jest
-        .spyOn(inquirer, 'prompt')
+    it('should re-prompt user for port if reserved port confirmation is denied', async () => {
+      vi.spyOn(inquirer, 'prompt')
         .mockResolvedValueOnce({ customPort: '80' })
         .mockResolvedValueOnce({ confirmPort: false })
         .mockResolvedValueOnce({ customPort: '8080' });
@@ -88,9 +85,8 @@ describe('askForCustomPort', () => {
       expect(result).toBe(8080);
     });
 
-    test('should return default port if reserved port confirmation is denied after maximum retry attempts', async () => {
-      jest
-        .spyOn(inquirer, 'prompt')
+    it('should return default port if reserved port confirmation is denied after maximum retry attempts', async () => {
+      vi.spyOn(inquirer, 'prompt')
         .mockResolvedValueOnce({ customPort: '80' })
         .mockResolvedValueOnce({ confirmPort: false })
         .mockResolvedValueOnce({ customPort: '80' })


### PR DESCRIPTION

**What kind of change does this PR introduce?**

This PR migrates the test cases in src/setup/askForCustomPort.test.ts from Jest to Vitest, ensuring compatibility with Vitest .

✅ Replace Jest-specific functions and mocks with Vitest equivalents
✅ Ensure all tests in src/setup/askForCustomPort.test.ts  from Jest to Vitest.pass after migration using npm run test:vitest
✅ Maintain the test coverage for the file as 100% after migration
✅ Upload a video or photo for this specific file coverage is 100% in the PR description

**Issue Number:**

Fixes #2748 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

![image](https://github.com/user-attachments/assets/75e56a11-dc2a-47ad-97c8-e8d56b101d1a)


**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Transitioned testing framework from Jest to Vitest for improved performance.
	- Updated test cases to utilize Vitest syntax while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->