### PR TITLE
Refactor src/components/UserProfileSettings/* from Jest to Vitest

### DIFF
--- a/src/components/UserProfileSettings/DeleteUser.spec.tsx
+++ b/src/components/UserProfileSettings/DeleteUser.spec.tsx
@@ -4,21 +4,26 @@ import { MockedProvider } from '@apollo/react-testing';
 import { BrowserRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from 'utils/i18nForTest';
-import OtherSettings from './OtherSettings';
+import DeleteUser from './DeleteUser';
+import { describe, it, expect } from 'vitest';
 
 describe('Delete User component', () => {
-  test('renders delete user correctly', () => {
-    const { getByText } = render(
+  it('renders delete user correctly', () => {
+    const { getByText, getAllByText } = render(
       <MockedProvider addTypename={false}>
         <BrowserRouter>
           <I18nextProvider i18n={i18nForTest}>
-            <OtherSettings />
+            <DeleteUser />
           </I18nextProvider>
         </BrowserRouter>
       </MockedProvider>,
     );
 
-    expect(getByText('Other Settings')).toBeInTheDocument();
-    expect(getByText('Change Language')).toBeInTheDocument();
+    expect(
+      getByText(
+        'By clicking on Delete User button your user will be permanently deleted along with its events, tags and all related data.',
+      ),
+    ).toBeInTheDocument();
+    expect(getAllByText('Delete User')[0]).toBeInTheDocument();
   });
 });

--- a/src/components/UserProfileSettings/OtherSettings.spec.tsx
+++ b/src/components/UserProfileSettings/OtherSettings.spec.tsx
@@ -4,25 +4,22 @@ import { MockedProvider } from '@apollo/react-testing';
 import { BrowserRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from 'utils/i18nForTest';
-import DeleteUser from './DeleteUser';
+import OtherSettings from './OtherSettings';
+import { describe, it, expect } from 'vitest';
 
 describe('Delete User component', () => {
-  test('renders delete user correctly', () => {
-    const { getByText, getAllByText } = render(
+  it('renders delete user correctly', () => {
+    const { getByText } = render(
       <MockedProvider addTypename={false}>
         <BrowserRouter>
           <I18nextProvider i18n={i18nForTest}>
-            <DeleteUser />
+            <OtherSettings />
           </I18nextProvider>
         </BrowserRouter>
       </MockedProvider>,
     );
 
-    expect(
-      getByText(
-        'By clicking on Delete User button your user will be permanently deleted along with its events, tags and all related data.',
-      ),
-    ).toBeInTheDocument();
-    expect(getAllByText('Delete User')[0]).toBeInTheDocument();
+    expect(getByText('Other Settings')).toBeInTheDocument();
+    expect(getByText('Change Language')).toBeInTheDocument();
   });
 });

--- a/src/components/UserProfileSettings/UserProfile.spec.tsx
+++ b/src/components/UserProfileSettings/UserProfile.spec.tsx
@@ -5,9 +5,10 @@ import { MockedProvider } from '@apollo/react-testing';
 import { BrowserRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from 'utils/i18nForTest';
+import { describe, it, expect } from 'vitest';
 
 describe('UserProfile component', () => {
-  test('renders user profile details correctly', () => {
+  it('renders user profile details correctly', () => {
     const userDetails = {
       firstName: 'Christopher',
       lastName: 'Doe',


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

This PR Refactor src/components/UserProfileSettings/* from Jest to Vitest:
- `DeleteUser`
- `OtherSettings`
- `UserProfile`

**Issue Number:**

Fixes #2796

**Snapshots/Videos:**
<img width="844" alt="Jest to Vitest #2796" src="https://github.com/user-attachments/assets/baaa7a25-8d0b-46f5-b714-1b1592418d2c" />


**If relevant, did you update the documentation?**

No

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated test cases for the `DeleteUser`, `OtherSettings`, and `UserProfile` components to use the `it` function from the `vitest` testing library, ensuring consistency in testing practices. 

- **Documentation**
	- Improved clarity in test descriptions for better understanding of test intentions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->