### PR TITLE
Migrated src/components/OrgAdminListCard from Jest to Vitest

### DIFF
--- a/src/components/OrgAdminListCard/OrgAdminListCard.spec.tsx
+++ b/src/components/OrgAdminListCard/OrgAdminListCard.spec.tsx
@@ -9,6 +9,7 @@ import OrgAdminListCard from './OrgAdminListCard';
 import i18nForTest from 'utils/i18nForTest';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { StaticMockLink } from 'utils/StaticMockLink';
+import { vi, beforeEach, afterEach, expect, it, describe } from 'vitest';
 
 const MOCKS = [
   {
@@ -57,27 +58,28 @@ const renderOrgAdminListCard = (props: {
     </MockedProvider>,
   );
 };
-jest.mock('i18next-browser-languagedetector', () => ({
-  init: jest.fn(),
+vi.mock('i18next-browser-languagedetector', async () => ({
+  ...(await vi.importActual('i18next-browser-languagedetector')),
+  init: vi.fn(),
   type: 'languageDetector',
-  detect: jest.fn(() => 'en'),
-  cacheUserLanguage: jest.fn(),
+  detect: vi.fn(() => 'en'),
+  cacheUserLanguage: vi.fn(),
 }));
 describe('Testing Organization Admin List Card', () => {
-  global.alert = jest.fn();
+  global.alert = vi.fn();
 
   beforeEach(() => {
     Object.defineProperty(window, 'location', {
       writable: true,
-      value: { reload: jest.fn() },
+      value: { reload: vi.fn() },
     });
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
   });
 
-  test('should render props and text elements test for the page component', async () => {
+  it('should render props and text elements test for the page component', async () => {
     const props = {
       toggleRemoveModal: () => true,
       id: '456',
@@ -92,7 +94,7 @@ describe('Testing Organization Admin List Card', () => {
     await wait(2000);
   });
 
-  test('Should not render text elements when props value is not passed', async () => {
+  it('Should not render text elements when props value is not passed', async () => {
     const props = {
       toggleRemoveModal: () => true,
       id: undefined,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR will migrate the src/components/OrgAdminListCard/OrgAdminListCard.test.tsx from Jest to Vitest

**Issue Number:**

Fixes #2811

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<img width="1142" alt="Screenshot 2024-12-26 at 09 55 34" src="https://github.com/user-attachments/assets/d8f1242b-042b-43b2-8ec9-e61bdd117538" />

**If relevant, did you update the documentation?**
N/A

**Summary**
**Does this PR introduce a breaking change?**

No

**Other information**

N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Transitioned testing framework from Jest to Vitest for improved mocking and testing capabilities.
	- Updated test syntax and mocking functions to align with Vitest standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->