### PR TITLE
Migrated src/components/ChangeLanguageDropdown from Jest to Vitest

### DIFF
--- a/src/components/ChangeLanguageDropdown/ChangeLanguageDropdown.spec.tsx
+++ b/src/components/ChangeLanguageDropdown/ChangeLanguageDropdown.spec.tsx
@@ -11,6 +11,7 @@ import { MockedProvider } from '@apollo/react-testing';
 import { UPDATE_USER_MUTATION } from 'GraphQl/Mutations/mutations';
 import { StaticMockLink } from 'utils/StaticMockLink';
 import useLocalStorage from 'utils/useLocalstorage';
+import { describe, expect, it } from 'vitest';
 // import { Provider } from 'react-redux';
 // import { store } from 'state/store';
 const { setItem } = useLocalStorage();
@@ -52,7 +53,7 @@ const MOCKS = [
 
 const link = new StaticMockLink(MOCKS, true);
 describe('Testing Change Language Dropdown', () => {
-  test('Component Should be rendered properly', async () => {
+  it('Component Should be rendered properly', async () => {
     const { getByTestId } = render(
       <MockedProvider addTypename={false} link={link}>
         <BrowserRouter>
@@ -81,7 +82,7 @@ describe('Testing Change Language Dropdown', () => {
     });
   });
 
-  test('Component Should accept props properly', async () => {
+  it('Component Should accept props properly', async () => {
     const props = {
       parentContainerStyle: 'parentContainerStyle',
       btnStyle: 'btnStyle',
@@ -103,7 +104,7 @@ describe('Testing Change Language Dropdown', () => {
     getByTestId('dropdown-btn-0').className.includes(props.btnTextStyle);
   });
 
-  test('Testing when language cookie is not set', async () => {
+  it('Testing when language cookie is not set', async () => {
     Object.defineProperty(window.document, 'cookie', {
       writable: true,
       value: 'i18next=',
@@ -121,7 +122,7 @@ describe('Testing Change Language Dropdown', () => {
     expect(cookies.get('i18next')).toBe('');
   });
 
-  test('Testing change language functionality', async () => {
+  it('Testing change language functionality', async () => {
     Object.defineProperty(window.document, 'cookie', {
       writable: true,
       value: 'i18next=sp',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR will migrate src/components/ChangeLanguageDropdown/ChangeLanguageDropdown.test.tsx from Jest to Vitest.

**Issue Number:**

Fixes #2808

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

<img width="1123" alt="Screenshot 2024-12-26 at 10 36 23" src="https://github.com/user-attachments/assets/f367b898-caa0-4b23-b256-bd57b7ca6650" />

**If relevant, did you update the documentation?**
N/A

**Summary**
**Does this PR introduce a breaking change?**
No

**Other information**
N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test cases for the Change Language Dropdown component to use the `it` function for better clarity.
	- Explicitly imported testing functions from the `vitest` framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->