### PR TITLE
Migrated src/components/EventRegistrantsModal/* from Jest to Vitest.

### DIFF
--- a/src/components/EventRegistrantsModal/AddOnSpotAttendee.spec.tsx
+++ b/src/components/EventRegistrantsModal/AddOnSpotAttendee.spec.tsx
@@ -11,23 +11,27 @@ import { Provider } from 'react-redux';
 import { I18nextProvider } from 'react-i18next';
 import { store } from 'state/store';
 import i18nForTest from '../../utils/i18nForTest';
+import { describe, expect, vi } from 'vitest';
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    success: jest.fn(),
-    error: jest.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
   },
 }));
 
 const mockProps = {
   show: true,
-  handleClose: jest.fn(),
-  reloadMembers: jest.fn(),
+  handleClose: vi.fn(),
+  reloadMembers: vi.fn(),
 };
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useParams: () => ({ eventId: '123', orgId: '123' }),
-}));
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => ({ eventId: '123', orgId: '123' }),
+  };
+});
 
 const MOCKS = [
   {
@@ -80,7 +84,7 @@ const renderAddOnSpotAttendee = (): RenderResult => {
 
 describe('AddOnSpotAttendee Component', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('renders the component with all form fields', async () => {

--- a/src/components/EventRegistrantsModal/EventRegistrantsModal.spec.tsx
+++ b/src/components/EventRegistrantsModal/EventRegistrantsModal.spec.tsx
@@ -15,6 +15,7 @@ import i18nForTest from 'utils/i18nForTest';
 import { ToastContainer } from 'react-toastify';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { describe, test, expect, vi } from 'vitest';
 
 const queryMockWithoutRegistrant = [
   {
@@ -160,7 +161,7 @@ describe('Testing Event Registrants Modal', () => {
     show: true,
     eventId: 'event123',
     orgId: 'org123',
-    handleClose: jest.fn(),
+    handleClose: vi.fn(),
   };
 
   test('The modal should be rendered, correct text must be displayed when there are no attendees and add attendee mutation must function properly', async () => {

--- a/src/components/EventRegistrantsModal/EventRegistrantsWrapper.spec.tsx
+++ b/src/components/EventRegistrantsModal/EventRegistrantsWrapper.spec.tsx
@@ -11,6 +11,7 @@ import i18nForTest from 'utils/i18nForTest';
 import { ToastContainer } from 'react-toastify';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
+import { describe, test, expect } from 'vitest';
 
 const queryMock = [
   {


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
This PR will migrate the src/components/EventRegistrantsModal/* from Jest to Vitest.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
Fixes #2797 

**Did you add tests for your changes?**
Yes
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
![image](https://github.com/user-attachments/assets/f0f19c25-c511-445e-a0ef-09f9ea158570)

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
No
<!--Add link to Talawa-Docs.-->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->


<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated testing framework from Jest to Vitest across multiple components.
	- Adjusted mock implementations for `react-toastify` and `react-router-dom`.
	- Maintained existing test logic and assertions while enhancing the test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->