### PR TITLE
Migrated src/components/RecurrenceOptions/* from Jest to Vitest.

### DIFF
--- a/src/components/RecurrenceOptions/CustomRecurrence.spec.tsx
+++ b/src/components/RecurrenceOptions/CustomRecurrence.spec.tsx
@@ -9,7 +9,6 @@ import {
 } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
-import 'jest-location-mock';
 import { I18nextProvider } from 'react-i18next';
 
 import OrganizationEvents from '../../screens/OrganizationEvents/OrganizationEvents';
@@ -23,6 +22,7 @@ import { ThemeProvider } from 'react-bootstrap';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { MOCKS } from '../../screens/OrganizationEvents/OrganizationEventsMocks';
+import { describe, test, expect, vi } from 'vitest';
 
 const theme = createTheme({
   palette: {
@@ -48,19 +48,19 @@ const translations = JSON.parse(
   ),
 );
 
-jest.mock('@mui/x-date-pickers/DateTimePicker', () => {
+vi.mock('@mui/x-date-pickers/DateTimePicker', async () => {
+  const actual = await vi.importActual('@mui/x-date-pickers/DesktopDateTimePicker');
   return {
-    DateTimePicker: jest.requireActual(
-      '@mui/x-date-pickers/DesktopDateTimePicker',
-    ).DesktopDateTimePicker,
+    DateTimePicker: actual.DesktopDateTimePicker,
   };
 });
 
-jest.mock('react-toastify', () => ({
+
+vi.mock('react-toastify', () => ({
   toast: {
-    success: jest.fn(),
-    warning: jest.fn(),
-    error: jest.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
   },
 }));
 

--- a/src/components/RecurrenceOptions/CustomRecurrence.spec.tsx
+++ b/src/components/RecurrenceOptions/CustomRecurrence.spec.tsx
@@ -49,12 +49,13 @@ const translations = JSON.parse(
 );
 
 vi.mock('@mui/x-date-pickers/DateTimePicker', async () => {
-  const actual = await vi.importActual('@mui/x-date-pickers/DesktopDateTimePicker');
+  const actual = await vi.importActual(
+    '@mui/x-date-pickers/DesktopDateTimePicker',
+  );
   return {
     DateTimePicker: actual.DesktopDateTimePicker,
   };
 });
-
 
 vi.mock('react-toastify', () => ({
   toast: {

--- a/src/components/RecurrenceOptions/RecurrenceOptions.spec.tsx
+++ b/src/components/RecurrenceOptions/RecurrenceOptions.spec.tsx
@@ -9,7 +9,6 @@ import {
 } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
-import 'jest-location-mock';
 import { I18nextProvider } from 'react-i18next';
 
 import OrganizationEvents from '../../screens/OrganizationEvents/OrganizationEvents';
@@ -23,6 +22,7 @@ import { ThemeProvider } from 'react-bootstrap';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { MOCKS } from '../../screens/OrganizationEvents/OrganizationEventsMocks';
+import { describe, test, expect, vi } from 'vitest';
 
 const theme = createTheme({
   palette: {
@@ -52,19 +52,19 @@ const translations = {
   ...JSON.parse(JSON.stringify(i18n.getDataByLanguage('en')?.errors ?? {})),
 };
 
-jest.mock('@mui/x-date-pickers/DateTimePicker', () => {
+vi.mock('@mui/x-date-pickers/DateTimePicker', async () => {
+  const actual = await vi.importActual('@mui/x-date-pickers/DesktopDateTimePicker');
   return {
-    DateTimePicker: jest.requireActual(
-      '@mui/x-date-pickers/DesktopDateTimePicker',
-    ).DesktopDateTimePicker,
+    DateTimePicker: actual.DesktopDateTimePicker,
   };
 });
 
-jest.mock('react-toastify', () => ({
+
+vi.mock('react-toastify', () => ({
   toast: {
-    success: jest.fn(),
-    warning: jest.fn(),
-    error: jest.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
   },
 }));
 

--- a/src/components/RecurrenceOptions/RecurrenceOptions.spec.tsx
+++ b/src/components/RecurrenceOptions/RecurrenceOptions.spec.tsx
@@ -53,12 +53,13 @@ const translations = {
 };
 
 vi.mock('@mui/x-date-pickers/DateTimePicker', async () => {
-  const actual = await vi.importActual('@mui/x-date-pickers/DesktopDateTimePicker');
+  const actual = await vi.importActual(
+    '@mui/x-date-pickers/DesktopDateTimePicker',
+  );
   return {
     DateTimePicker: actual.DesktopDateTimePicker,
   };
 });
-
 
 vi.mock('react-toastify', () => ({
   toast: {


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
This PR will migrate the src/components/RecurrenceOptions/* from Jest to Vitest.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**
Fixes #2807 

**Did you add tests for your changes?**
Yes
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
![image](https://github.com/user-attachments/assets/d22867cc-ba2d-4400-a24a-b0ba50dccde7)

<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**
No
<!--Add link to Talawa-Docs.-->

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->


<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Transitioned testing framework from Jest to Vitest in `CustomRecurrence.spec.tsx` and `RecurrenceOptions.spec.tsx`.
	- Updated mock implementations for `@mui/x-date-pickers/DateTimePicker` and `react-toastify`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->