### PR TITLE
[REFACTOR]: Jest to Vitest migration for EditCustomFieldDropDown.test.tsx

### DIFF
--- a/src/components/EditCustomFieldDropDown/EditCustomFieldDropDown.spec.tsx
+++ b/src/components/EditCustomFieldDropDown/EditCustomFieldDropDown.spec.tsx
@@ -8,6 +8,7 @@ import availableFieldTypes from 'utils/fieldTypes';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from 'utils/i18nForTest';
 import type { InterfaceCustomFieldData } from 'utils/interfaces';
+import { describe, it, expect } from 'vitest';
 
 async function wait(ms = 100): Promise<void> {
   await act(() => {
@@ -18,7 +19,7 @@ async function wait(ms = 100): Promise<void> {
 }
 
 describe('Testing Custom Field Dropdown', () => {
-  test('Component Should be rendered properly', async () => {
+  it('Component Should be rendered properly', async () => {
     const customFieldData = {
       type: 'Number',
       name: 'Age',
@@ -26,11 +27,10 @@ describe('Testing Custom Field Dropdown', () => {
 
     const setCustomFieldData: Dispatch<
       SetStateAction<InterfaceCustomFieldData>
-    > = (val) => {
-      {
-        val;
-      }
+    > = () => {
+      // Intentionally left blank for testing purposes
     };
+
     const props = {
       customFieldData: customFieldData as InterfaceCustomFieldData,
       setCustomFieldData: setCustomFieldData,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR migrates the test cases in src/component/EditCustomFieldDropDown.test.tsx from Jest to Vitest, ensuring compatibility with Vitest .

✅ Replace Jest-specific functions and mocks with Vitest equivalents
✅ Ensure all tests in src/component/EditCustomFieldDropDown.test.tsx from Jest to Vitest.pass after migration using npm run test:vitest
✅ Maintain the test coverage for the file as 100% after migration
✅ Upload a video or photo for this specific file coverage is 100% in the PR description

**Issue Number:**

Fixes #2821 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

![image](https://github.com/user-attachments/assets/9bb1f02a-e0f6-4d9b-b1c9-d34246318c6b)

**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated testing framework from `test` to `it` for improved consistency.
	- Modified the implementation of `setCustomFieldData` to a no-op function for testing purposes.
	- Added new import statements for the `vitest` testing framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->