### PR TITLE
Refactor: Vitest to src/components/EventCalendar/*

### DIFF
--- a/src/components/EventCalendar/EventCalendar.spec.tsx
+++ b/src/components/EventCalendar/EventCalendar.spec.tsx
@@ -13,6 +13,7 @@ import i18nForTest from 'utils/i18nForTest';
 import { StaticMockLink } from 'utils/StaticMockLink';
 import { weekdays, months } from './constants';
 import { BrowserRouter as Router } from 'react-router-dom';
+import { vi } from 'vitest';
 
 const eventData = [
   {
@@ -122,7 +123,7 @@ describe('Calendar', () => {
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   it('should render the current month and year', () => {

--- a/src/components/EventCalendar/EventHeader.spec.tsx
+++ b/src/components/EventCalendar/EventHeader.spec.tsx
@@ -4,11 +4,20 @@ import EventHeader from './EventHeader';
 import { ViewType } from '../../screens/OrganizationEvents/OrganizationEvents';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from 'utils/i18nForTest';
+import { vi } from 'vitest';
 
 describe('EventHeader Component', () => {
   const viewType = ViewType.MONTH;
-  const handleChangeView = jest.fn();
-  const showInviteModal = jest.fn();
+
+  /**
+   * Mock function to handle view type changes.
+   */
+  const handleChangeView = vi.fn();
+
+  /**
+   * Mock function to handle the display of the invite modal.
+   */
+  const showInviteModal = vi.fn();
 
   it('renders correctly', () => {
     const { getByTestId } = render(


### PR DESCRIPTION


**What kind of change does this PR introduce?**

Added Vitest to src/components/EventCalendar/*


**Issue Number: 2805**

Fixes #2805       <!--Add related issue number here.-->

**Did you add tests for your changes?**
Yes


**Snapshots/Videos:**
![Screenshot 2024-12-26 224721](https://github.com/user-attachments/assets/372a3de5-ecbd-4105-afeb-5fe75cc0f0f5)



**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**

Migrated the testing framework to Vitest.
Updated all test files and configurations to be compatible with Vitest's syntax and features.


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes
<!--Yes or No-->




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated mock functions in the `EventHeader` component tests to use Vitest instead of Jest.
  
- **Chores**
	- Replaced Jest mock clearing with Vitest in the `EventCalendar` component tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->