### PR TITLE
Migrate to vitest

### DIFF
--- a/src/components/LeftDrawerOrg/LeftDrawerOrg.spec.tsx
+++ b/src/components/LeftDrawerOrg/LeftDrawerOrg.spec.tsx
@@ -1,7 +1,7 @@
+import '@testing-library/jest-dom';
 import React, { act } from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import 'jest-localstorage-mock';
 import { I18nextProvider } from 'react-i18next';
 import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 
@@ -15,6 +15,7 @@ import { ORGANIZATIONS_LIST } from 'GraphQl/Queries/Queries';
 import { StaticMockLink } from 'utils/StaticMockLink';
 import { REVOKE_REFRESH_TOKEN } from 'GraphQl/Mutations/mutations';
 import useLocalStorage from 'utils/useLocalstorage';
+import { vi, describe, test, expect } from 'vitest';
 
 const { setItem } = useLocalStorage();
 
@@ -65,7 +66,7 @@ const props: InterfaceLeftDrawerProps = {
     },
   ],
   hideDrawer: false,
-  setHideDrawer: jest.fn(),
+  setHideDrawer: vi.fn(),
 };
 
 const MOCKS = [
@@ -244,11 +245,11 @@ const defaultScreens = [
   'All Organizations',
 ];
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    success: jest.fn(),
-    warn: jest.fn(),
-    error: jest.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
   },
 }));
 
@@ -275,7 +276,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  jest.clearAllMocks();
+  vi.clearAllMocks();
   localStorage.clear();
 });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     svgrPlugin(),
   ],
   test: {
-    include: ['src/components/LeftDrawerOrg/*.spec.{js,jsx,ts,tsx}'],
+    include: ['src/**/*.spec.{js,jsx,ts,tsx}'],
     globals: true,
     environment: 'jsdom',
     setupFiles: 'vitest.setup.ts',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
     svgrPlugin(),
   ],
   test: {
-    include: ['src/**/*.spec.{js,jsx,ts,tsx}'],
+    include: ['src/components/LeftDrawerOrg/*.spec.{js,jsx,ts,tsx}'],
     globals: true,
     environment: 'jsdom',
     setupFiles: 'vitest.setup.ts',


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Replace Jest-specific functions and mocks with Vitest equivalents in LeftDrawerOrg.test.tsx testing file

**Issue Number:**

Fixes #2833 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![ML19](https://github.com/user-attachments/assets/022309b4-f5df-456e-a5d1-b93035463273)


**If relevant, did you update the documentation?**

No

**Summary**
- Sir Made changes as specified by you.
-Made Changes as per the context provide also svg images are passed in test and all 9/9 test passed.
-Migrated test for ChangeLanguageDropdown.tsx from jest to vitest.


**Does this PR introduce a breaking change?**

No

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Transitioned testing framework from Jest to Vitest.
	- Updated mocking functions and cleanup methods to align with Vitest standards.
	- Maintained existing test structure and functionality for the `LeftDrawerOrg` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->