### PR TITLE
Fixed Bug #2455

### DIFF
--- a/src/screens/UserPortal/People/People.spec.tsx
+++ b/src/screens/UserPortal/People/People.spec.tsx
@@ -11,6 +11,7 @@ import { Provider } from 'react-redux';
 import { store } from 'state/store';
 import i18nForTest from 'utils/i18nForTest';
 import { StaticMockLink } from 'utils/StaticMockLink';
+import type { InterfaceMember } from './People';
 import People from './People';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
@@ -165,6 +166,62 @@ describe('Testing People Screen [User Portal]', () => {
     await wait();
 
     expect(screen.queryAllByText('Noble Mittal')).not.toBe([]);
+  });
+
+  function compareProperties(
+    expectedProps: string[],
+    actualObject: object,
+  ): boolean {
+    const actualProps = Object.keys(actualObject);
+    return expectedProps.every((prop) => actualProps.includes(prop));
+  }
+
+  describe('InterfaceMember properties comparison', () => {
+    it('should have all required properties', () => {
+      const expectedProperties = [
+        'firstName',
+        'lastName',
+        'image',
+        '_id',
+        'email',
+        '__typename',
+      ];
+
+      const mockValidData: InterfaceMember = {
+        firstName: 'John',
+        lastName: 'Doe',
+        image: 'https://example.com/john.jpg',
+        _id: '1',
+        email: 'john.doe@example.com',
+        __typename: 'User',
+      };
+
+      const result = compareProperties(expectedProperties, mockValidData);
+      expect(result).toBe(true);
+    });
+
+    it('should fail if __typename is replaced with username', () => {
+      const expectedProperties = [
+        'firstName',
+        'lastName',
+        'image',
+        '_id',
+        'email',
+        '__typename', // Expect this property
+      ];
+
+      const mockInvalidData = {
+        firstName: 'John',
+        lastName: 'Doe',
+        image: 'https://example.com/john.jpg',
+        _id: '1',
+        email: 'john.doe@example.com',
+        username: 'Member', // Incorrect property
+      };
+
+      const result = compareProperties(expectedProperties, mockInvalidData);
+      expect(result).toBe(false);
+    });
   });
 
   it('Search works properly by pressing enter', async () => {

--- a/src/screens/UserPortal/People/People.tsx
+++ b/src/screens/UserPortal/People/People.tsx
@@ -28,7 +28,7 @@ interface InterfaceMember {
   image: string;
   _id: string;
   email: string;
-  userType: string;
+  __typename: string;
 }
 
 /**
@@ -243,7 +243,7 @@ export default function people(): JSX.Element {
                         image: member.image,
                         id: member._id,
                         email: member.email,
-                        role: member.userType,
+                        role: member.__typename,
                         sno: (index + 1).toString(),
                       };
                       return <PeopleCard key={index} {...cardProps} />;

--- a/src/screens/UserPortal/People/People.tsx
+++ b/src/screens/UserPortal/People/People.tsx
@@ -22,7 +22,7 @@ interface InterfaceOrganizationCardProps {
   sno: string;
 }
 
-interface InterfaceMember {
+export interface InterfaceMember {
   firstName: string;
   lastName: string;
   image: string;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Fixed User role not displaying bug in people section. This PR changes the interface that was causing mismatch.

**Issue Number:**

 #2455

**Did you add tests for your changes?**

yes

**Snapshots/Videos:**

![image](https://github.com/user-attachments/assets/74553365-f219-4e12-8fe0-09ba0afb4843)


**If relevant, did you update the documentation?**

No , not relevant

**Summary**

The people section without any role looks empty and error full so this PR solves it , when users like me use this software.
https://github.com/PalisadoesFoundation/talawa-admin/issues/2455

**Does this PR introduce a breaking change?**

Np

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated member role representation to use GraphQL typename instead of user-defined type.
- **Tests**
	- Introduced new tests to ensure the structure of `InterfaceMember` is maintained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->