### PR TITLE
Migrated src/components/EventStats/* from Jest to Vitest

### DIFF
--- a/src/components/EventStats/EventStats.spec.tsx
+++ b/src/components/EventStats/EventStats.spec.tsx
@@ -4,13 +4,15 @@ import { MockedProvider } from '@apollo/react-testing';
 import { EventStats } from './EventStats';
 import { BrowserRouter } from 'react-router-dom';
 import { EVENT_FEEDBACKS } from 'GraphQl/Queries/Queries';
+import { vi, describe, expect, it } from 'vitest';
 
-// Mock the modules for PieChart rendering as they require a trasformer being used (which is not done by Jest)
+// Mock the modules for PieChart rendering as they require a trasformer being used (which is not done by Vitest)
 // These modules are used by the Feedback component
-jest.mock('@mui/x-charts/PieChart', () => ({
-  pieArcLabelClasses: jest.fn(),
-  PieChart: jest.fn().mockImplementation(() => <>Test</>),
-  pieArcClasses: jest.fn(),
+vi.mock('@mui/x-charts/PieChart', async () => ({
+  ...(await vi.importActual('@mui/x-charts/PieChart')),
+  pieArcLabelClasses: vi.fn(),
+  PieChart: vi.fn().mockImplementation(() => <>Test</>),
+  pieArcClasses: vi.fn(),
 }));
 
 const mockData = [
@@ -43,10 +45,10 @@ describe('Testing Event Stats', () => {
   const props = {
     eventId: 'eventStats123',
     show: true,
-    handleClose: jest.fn(),
+    handleClose: vi.fn(),
   };
 
-  test('The stats should be rendered properly', async () => {
+  it('The stats should be rendered properly', async () => {
     const { queryByText } = render(
       <MockedProvider mocks={mockData} addTypename={false}>
         <BrowserRouter>

--- a/src/components/EventStats/EventStatsWrapper.spec.tsx
+++ b/src/components/EventStats/EventStatsWrapper.spec.tsx
@@ -7,6 +7,7 @@ import { EVENT_FEEDBACKS } from 'GraphQl/Queries/Queries';
 import { vi, describe, expect, it } from 'vitest';
 
 // Mock the modules for PieChart rendering as they require a trasformer being used (which is not done by Vitest)
+// These modules are used by the Feedback component
 vi.mock('@mui/x-charts/PieChart', async () => ({
   ...(await vi.importActual('@mui/x-charts/PieChart')),
   pieArcLabelClasses: vi.fn(),
@@ -39,15 +40,6 @@ const mockData = [
     },
   },
 ];
-
-// Mock the modules for PieChart rendering as they require a trasformer being used (which is not done by Vitest)
-// These modules are used by the Feedback component
-vi.mock('@mui/x-charts/PieChart', async () => ({
-  ...(await vi.importActual('@mui/x-charts/PieChart')),
-  pieArcLabelClasses: vi.fn(),
-  PieChart: vi.fn().mockImplementation(() => <>Test</>),
-  pieArcClasses: vi.fn(),
-}));
 
 describe('Testing Event Stats Wrapper', () => {
   const props = {

--- a/src/components/EventStats/EventStatsWrapper.spec.tsx
+++ b/src/components/EventStats/EventStatsWrapper.spec.tsx
@@ -4,12 +4,14 @@ import { MockedProvider } from '@apollo/react-testing';
 import { EventStatsWrapper } from './EventStatsWrapper';
 import { BrowserRouter } from 'react-router-dom';
 import { EVENT_FEEDBACKS } from 'GraphQl/Queries/Queries';
+import { vi, describe, expect, it } from 'vitest';
 
-// Mock the modules for PieChart rendering as they require a trasformer being used (which is not done by Jest)
-jest.mock('@mui/x-charts/PieChart', () => ({
-  pieArcLabelClasses: jest.fn(),
-  PieChart: jest.fn().mockImplementation(() => <>Test</>),
-  pieArcClasses: jest.fn(),
+// Mock the modules for PieChart rendering as they require a trasformer being used (which is not done by Vitest)
+vi.mock('@mui/x-charts/PieChart', async () => ({
+  ...(await vi.importActual('@mui/x-charts/PieChart')),
+  pieArcLabelClasses: vi.fn(),
+  PieChart: vi.fn().mockImplementation(() => <>Test</>),
+  pieArcClasses: vi.fn(),
 }));
 
 const mockData = [
@@ -38,12 +40,13 @@ const mockData = [
   },
 ];
 
-// Mock the modules for PieChart rendering as they require a trasformer being used (which is not done by Jest)
+// Mock the modules for PieChart rendering as they require a trasformer being used (which is not done by Vitest)
 // These modules are used by the Feedback component
-jest.mock('@mui/x-charts/PieChart', () => ({
-  pieArcLabelClasses: jest.fn(),
-  PieChart: jest.fn().mockImplementation(() => <>Test</>),
-  pieArcClasses: jest.fn(),
+vi.mock('@mui/x-charts/PieChart', async () => ({
+  ...(await vi.importActual('@mui/x-charts/PieChart')),
+  pieArcLabelClasses: vi.fn(),
+  PieChart: vi.fn().mockImplementation(() => <>Test</>),
+  pieArcClasses: vi.fn(),
 }));
 
 describe('Testing Event Stats Wrapper', () => {
@@ -51,7 +54,7 @@ describe('Testing Event Stats Wrapper', () => {
     eventId: 'eventStats123',
   };
 
-  test('The button to open and close the modal should work properly', async () => {
+  it('The button to open and close the modal should work properly', async () => {
     const { queryByText, queryByRole } = render(
       <MockedProvider mocks={mockData} addTypename={false}>
         <BrowserRouter>

--- a/src/components/EventStats/Statistics/AverageRating.spec.tsx
+++ b/src/components/EventStats/Statistics/AverageRating.spec.tsx
@@ -7,6 +7,7 @@ import { store } from 'state/store';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from 'utils/i18nForTest';
 import { ToastContainer } from 'react-toastify';
+import { describe, expect, it } from 'vitest';
 
 const props = {
   data: {
@@ -35,7 +36,7 @@ const props = {
 };
 
 describe('Testing Average Rating Card', () => {
-  test('The component should be rendered and the Score should be shown', async () => {
+  it('The component should be rendered and the Score should be shown', async () => {
     const { queryByText } = render(
       <BrowserRouter>
         <Provider store={store}>

--- a/src/components/EventStats/Statistics/Feedback.spec.tsx
+++ b/src/components/EventStats/Statistics/Feedback.spec.tsx
@@ -1,14 +1,23 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
-import { ReviewStats } from './Review';
+import { FeedbackStats } from './Feedback';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { store } from 'state/store';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from 'utils/i18nForTest';
 import { ToastContainer } from 'react-toastify';
+import { vi, describe, expect, it } from 'vitest';
 
-const nonEmptyReviewProps = {
+// Mock the modules for PieChart rendering as they require a trasformer being used (which is not done by Vitest)
+vi.mock('@mui/x-charts/PieChart', async () => ({
+  ...(await vi.importActual('@mui/x-charts/PieChart')),
+  pieArcLabelClasses: vi.fn(),
+  PieChart: vi.fn().mockImplementation(() => <>Test</>),
+  pieArcClasses: vi.fn(),
+}));
+
+const nonEmptyProps = {
   data: {
     event: {
       _id: '123',
@@ -34,61 +43,63 @@ const nonEmptyReviewProps = {
   },
 };
 
-const emptyReviewProps = {
+const emptyProps = {
   data: {
     event: {
       _id: '123',
-      feedback: [
-        {
-          _id: 'feedback3',
-          review: null,
-          rating: 5,
-        },
-      ],
+      feedback: [],
       averageFeedbackScore: 5,
     },
   },
 };
 
-describe('Testing Review Statistics Card', () => {
-  test('The component should be rendered and the reviews should be shown if present', async () => {
+describe('Testing Feedback Statistics Card', () => {
+  it('The component should be rendered and the feedback should be shown if present', async () => {
     const { queryByText } = render(
       <BrowserRouter>
         <Provider store={store}>
           <I18nextProvider i18n={i18nForTest}>
             <ToastContainer />
-            <ReviewStats {...nonEmptyReviewProps} />
+            <FeedbackStats {...nonEmptyProps} />
           </I18nextProvider>
         </Provider>
       </BrowserRouter>,
     );
-
-    await waitFor(() => expect(queryByText('Reviews')).toBeInTheDocument());
 
     await waitFor(() =>
-      expect(queryByText('Filled by 2 people.')).toBeInTheDocument(),
+      expect(queryByText('Feedback Analysis')).toBeInTheDocument(),
     );
-
-    await waitFor(() => expect(queryByText('review2')).toBeInTheDocument());
-  });
-
-  test('The component should be rendered and message should be shown if no review is present', async () => {
-    const { queryByText } = render(
-      <BrowserRouter>
-        <Provider store={store}>
-          <I18nextProvider i18n={i18nForTest}>
-            <ToastContainer />
-            <ReviewStats {...emptyReviewProps} />
-          </I18nextProvider>
-        </Provider>
-      </BrowserRouter>,
-    );
-
-    await waitFor(() => expect(queryByText('Reviews')).toBeInTheDocument());
 
     await waitFor(() =>
       expect(
-        queryByText('Waiting for people to talk about the event...'),
+        queryByText('3 people have filled feedback for this event.'),
+      ).toBeInTheDocument(),
+    );
+
+    await waitFor(() => {
+      expect(queryByText('Test')).toBeInTheDocument();
+    });
+  });
+
+  it('The component should be rendered and message should be shown if no feedback is present', async () => {
+    const { queryByText } = render(
+      <BrowserRouter>
+        <Provider store={store}>
+          <I18nextProvider i18n={i18nForTest}>
+            <ToastContainer />
+            <FeedbackStats {...emptyProps} />
+          </I18nextProvider>
+        </Provider>
+      </BrowserRouter>,
+    );
+
+    await waitFor(() =>
+      expect(queryByText('Feedback Analysis')).toBeInTheDocument(),
+    );
+
+    await waitFor(() =>
+      expect(
+        queryByText('Please ask attendees to submit feedback for insights!'),
       ).toBeInTheDocument(),
     );
   });

--- a/src/components/EventStats/Statistics/Review.spec.tsx
+++ b/src/components/EventStats/Statistics/Review.spec.tsx
@@ -1,21 +1,15 @@
 import React from 'react';
 import { render, waitFor } from '@testing-library/react';
-import { FeedbackStats } from './Feedback';
+import { ReviewStats } from './Review';
 import { BrowserRouter } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { store } from 'state/store';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from 'utils/i18nForTest';
 import { ToastContainer } from 'react-toastify';
+import { describe, expect, it } from 'vitest';
 
-// Mock the modules for PieChart rendering as they require a trasformer being used (which is not done by Jest)
-jest.mock('@mui/x-charts/PieChart', () => ({
-  pieArcLabelClasses: jest.fn(),
-  PieChart: jest.fn().mockImplementation(() => <>Test</>),
-  pieArcClasses: jest.fn(),
-}));
-
-const nonEmptyProps = {
+const nonEmptyReviewProps = {
   data: {
     event: {
       _id: '123',
@@ -41,63 +35,61 @@ const nonEmptyProps = {
   },
 };
 
-const emptyProps = {
+const emptyReviewProps = {
   data: {
     event: {
       _id: '123',
-      feedback: [],
+      feedback: [
+        {
+          _id: 'feedback3',
+          review: null,
+          rating: 5,
+        },
+      ],
       averageFeedbackScore: 5,
     },
   },
 };
 
-describe('Testing Feedback Statistics Card', () => {
-  test('The component should be rendered and the feedback should be shown if present', async () => {
+describe('Testing Review Statistics Card', () => {
+  it('The component should be rendered and the reviews should be shown if present', async () => {
     const { queryByText } = render(
       <BrowserRouter>
         <Provider store={store}>
           <I18nextProvider i18n={i18nForTest}>
             <ToastContainer />
-            <FeedbackStats {...nonEmptyProps} />
+            <ReviewStats {...nonEmptyReviewProps} />
           </I18nextProvider>
         </Provider>
       </BrowserRouter>,
     );
 
-    await waitFor(() =>
-      expect(queryByText('Feedback Analysis')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(queryByText('Reviews')).toBeInTheDocument());
 
     await waitFor(() =>
-      expect(
-        queryByText('3 people have filled feedback for this event.'),
-      ).toBeInTheDocument(),
+      expect(queryByText('Filled by 2 people.')).toBeInTheDocument(),
     );
 
-    await waitFor(() => {
-      expect(queryByText('Test')).toBeInTheDocument();
-    });
+    await waitFor(() => expect(queryByText('review2')).toBeInTheDocument());
   });
 
-  test('The component should be rendered and message should be shown if no feedback is present', async () => {
+  it('The component should be rendered and message should be shown if no review is present', async () => {
     const { queryByText } = render(
       <BrowserRouter>
         <Provider store={store}>
           <I18nextProvider i18n={i18nForTest}>
             <ToastContainer />
-            <FeedbackStats {...emptyProps} />
+            <ReviewStats {...emptyReviewProps} />
           </I18nextProvider>
         </Provider>
       </BrowserRouter>,
     );
 
-    await waitFor(() =>
-      expect(queryByText('Feedback Analysis')).toBeInTheDocument(),
-    );
+    await waitFor(() => expect(queryByText('Reviews')).toBeInTheDocument());
 
     await waitFor(() =>
       expect(
-        queryByText('Please ask attendees to submit feedback for insights!'),
+        queryByText('Waiting for people to talk about the event...'),
       ).toBeInTheDocument(),
     );
   });


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR will migrate src/components/EventStats/* from Jest to Vitest

**Issue Number:**
Fixes #2794

**Did you add tests for your changes?**
Yes

**Snapshots/Videos:**

<img width="1104" alt="Screenshot 2024-12-28 at 17 41 50" src="https://github.com/user-attachments/assets/2a4a7f67-99ff-48bb-8da8-14f8561b50af" />


**If relevant, did you update the documentation?**
No

**Summary**
**Does this PR introduce a breaking change?**
No

**Other information**
N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Migrated test files from Jest to Vitest testing framework across multiple components.
	- Updated test syntax and mocking methods to align with Vitest conventions.
	- Replaced `test` functions with `it` for more descriptive test case naming.
	- Updated import statements to use Vitest testing utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->