### PR TITLE
Refactor: src/screens/OrganizationTags/OrganizationTags.test.tsx from Jest to Vitest

### DIFF
--- a/src/components/UsersTableItem/UserTableItem.spec.tsx
+++ b/src/components/UsersTableItem/UserTableItem.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { act } from 'react';
 import { MockedProvider } from '@apollo/react-testing';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
@@ -9,19 +9,21 @@ import type { InterfaceQueryUserListItem } from 'utils/interfaces';
 import { MOCKS, MOCKS2, MOCKS_UPDATE } from './UserTableItemMocks';
 import UsersTableItem from './UsersTableItem';
 import { BrowserRouter } from 'react-router-dom';
-import useLocalStorage from 'utils/useLocalstorage';
-import userEvent from '@testing-library/user-event';
-import { vi, beforeEach, afterEach, describe, it, expect } from 'vitest';
-
 const link = new StaticMockLink(MOCKS, true);
 const link2 = new StaticMockLink(MOCKS2, true);
 const link3 = new StaticMockLink(MOCKS_UPDATE, true);
+import useLocalStorage from 'utils/useLocalstorage';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import type * as RouterTypes from 'react-router-dom';
 
 const { setItem } = useLocalStorage();
 
 async function wait(ms = 100): Promise<void> {
-  await new Promise((resolve) => {
-    setTimeout(resolve, ms);
+  await act(() => {
+    return new Promise((resolve) => {
+      setTimeout(resolve, ms);
+    });
   });
 }
 const resetAndRefetchMock = vi.fn();
@@ -43,10 +45,15 @@ Object.defineProperty(window, 'location', {
 
 const mockNavgatePush = vi.fn();
 
-jest.mock('react-router-dom', () => ({
-  ...jest.requireActual('react-router-dom'),
-  useNavigate: () => mockNavgatePush,
-}));
+vi.mock('react-router-dom', async () => {
+  const actual = (await vi.importActual(
+    'react-router-dom',
+  )) as typeof RouterTypes;
+  return {
+    ...actual,
+    useNavigate: () => mockNavgatePush,
+  };
+});
 
 beforeEach(() => {
   setItem('SuperAdmin', true);

--- a/src/components/UsersTableItem/UserTableItem.spec.tsx
+++ b/src/components/UsersTableItem/UserTableItem.spec.tsx
@@ -1,4 +1,4 @@
-import React, { act } from 'react';
+import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
@@ -9,21 +9,19 @@ import type { InterfaceQueryUserListItem } from 'utils/interfaces';
 import { MOCKS, MOCKS2, MOCKS_UPDATE } from './UserTableItemMocks';
 import UsersTableItem from './UsersTableItem';
 import { BrowserRouter } from 'react-router-dom';
+import useLocalStorage from 'utils/useLocalstorage';
+import userEvent from '@testing-library/user-event';
+import { vi, beforeEach, afterEach, describe, it, expect } from 'vitest';
+
 const link = new StaticMockLink(MOCKS, true);
 const link2 = new StaticMockLink(MOCKS2, true);
 const link3 = new StaticMockLink(MOCKS_UPDATE, true);
-import useLocalStorage from 'utils/useLocalstorage';
-import userEvent from '@testing-library/user-event';
-import { vi } from 'vitest';
-import type * as RouterTypes from 'react-router-dom';
 
 const { setItem } = useLocalStorage();
 
 async function wait(ms = 100): Promise<void> {
-  await act(() => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
+  await new Promise((resolve) => {
+    setTimeout(resolve, ms);
   });
 }
 const resetAndRefetchMock = vi.fn();
@@ -45,15 +43,10 @@ Object.defineProperty(window, 'location', {
 
 const mockNavgatePush = vi.fn();
 
-vi.mock('react-router-dom', async () => {
-  const actual = (await vi.importActual(
-    'react-router-dom',
-  )) as typeof RouterTypes;
-  return {
-    ...actual,
-    useNavigate: () => mockNavgatePush,
-  };
-});
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavgatePush,
+}));
 
 beforeEach(() => {
   setItem('SuperAdmin', true);

--- a/src/screens/OrganizationTags/OrganizationTags.spec.tsx
+++ b/src/screens/OrganizationTags/OrganizationTags.spec.tsx
@@ -11,7 +11,7 @@ import {
   waitForElementToBeRemoved,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import 'jest-location-mock';
+import { vi } from 'vitest';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -44,10 +44,10 @@ async function wait(ms = 500): Promise<void> {
   });
 }
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    success: jest.fn(),
-    error: jest.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
   },
 }));
 
@@ -77,14 +77,17 @@ const renderOrganizationTags = (link: ApolloLink): RenderResult => {
 
 describe('Organisation Tags Page', () => {
   beforeEach(() => {
-    jest.mock('react-router-dom', () => ({
-      ...jest.requireActual('react-router-dom'),
-      useParams: () => ({ orgId: 'orgId' }),
-    }));
+    vi.mock('react-router-dom', async () => {
+      const actual = await vi.importActual('react-router-dom');
+      return {
+        ...actual,
+        useParams: () => ({ orgId: 'orgId' }),
+      };
+    });
   });
 
   afterEach(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
     cleanup();
   });
 
@@ -129,7 +132,6 @@ describe('Organisation Tags Page', () => {
       screen.queryByTestId('closeCreateTagModal'),
     );
   });
-
   test('navigates to sub tags screen after clicking on a tag', async () => {
     renderOrganizationTags(link);
 

--- a/src/screens/OrganizationTags/OrganizationTagsMocks.ts
+++ b/src/screens/OrganizationTags/OrganizationTagsMocks.ts
@@ -7,7 +7,7 @@ export const MOCKS = [
     request: {
       query: ORGANIZATION_USER_TAGS_LIST,
       variables: {
-        id: '123',
+        id: 'orgId',
         first: TAGS_QUERY_DATA_CHUNK_SIZE,
         where: { name: { starts_with: '' } },
         sortedBy: { id: 'DESCENDING' },
@@ -187,7 +187,7 @@ export const MOCKS = [
     request: {
       query: ORGANIZATION_USER_TAGS_LIST,
       variables: {
-        id: '123',
+        id: 'orgId',
         first: TAGS_QUERY_DATA_CHUNK_SIZE,
         after: '10',
         where: { name: { starts_with: '' } },
@@ -248,7 +248,7 @@ export const MOCKS = [
     request: {
       query: ORGANIZATION_USER_TAGS_LIST,
       variables: {
-        id: '123',
+        id: 'orgId',
         first: TAGS_QUERY_DATA_CHUNK_SIZE,
         where: { name: { starts_with: 'searchUserTag' } },
         sortedBy: { id: 'DESCENDING' },
@@ -322,7 +322,7 @@ export const MOCKS = [
     request: {
       query: ORGANIZATION_USER_TAGS_LIST,
       variables: {
-        id: '123',
+        id: 'orgId',
         first: TAGS_QUERY_DATA_CHUNK_SIZE,
         where: { name: { starts_with: 'searchUserTag' } },
         sortedBy: { id: 'ASCENDING' },
@@ -397,7 +397,7 @@ export const MOCKS = [
       query: CREATE_USER_TAG,
       variables: {
         name: 'userTag 12',
-        organizationId: '123',
+        organizationId: 'orgId',
       },
     },
     result: {
@@ -415,7 +415,7 @@ export const MOCKS_ERROR = [
     request: {
       query: ORGANIZATION_USER_TAGS_LIST,
       variables: {
-        id: '123',
+        id: 'orgId',
         first: TAGS_QUERY_DATA_CHUNK_SIZE,
         where: { name: { starts_with: '' } },
         sortedBy: { id: 'DESCENDING' },


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactor: src/screens/OrganizationTags/OrganizationTags.test.tsx from Jest to Vitest

**Issue Number:**

Fixes #3071

**Did you add tests for your changes?**

yes

**Snapshot**

![image](https://github.com/user-attachments/assets/df70446b-a8ad-41b9-bf55-42c7e257df7e)


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Testing**
	- Migrated test suite from Jest to Vitest
	- Updated mocking strategies for `react-toastify` and `react-router-dom`

- **Refactor**
	- Updated mock constants to use dynamic organization ID references
<!-- end of auto-generated comment: release notes by coderabbit.ai -->