### PR TITLE
Improved Code Coverage in src/screens/BlockUser/BlockUser.tsx

### DIFF
--- a/src/screens/BlockUser/BlockUser.spec.tsx
+++ b/src/screens/BlockUser/BlockUser.spec.tsx
@@ -360,9 +360,16 @@ describe('Testing Block/Unblock user screen', () => {
         </BrowserRouter>
       </MockedProvider>,
     );
+
+    userEvent.click(screen.getByTestId('userFilter'));
+    userEvent.click(screen.getByTestId('showBlockedMembers'));
+    await wait();
+
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.queryByText('Sam Smith')).not.toBeInTheDocument();
+
     userEvent.click(screen.getByTestId('userFilter'));
     userEvent.click(screen.getByTestId('showMembers'));
-
     await wait();
 
     expect(screen.getByText('John Doe')).toBeInTheDocument();
@@ -397,6 +404,25 @@ describe('Testing Block/Unblock user screen', () => {
         </BrowserRouter>
       </MockedProvider>,
     );
+
+    userEvent.click(screen.getByTestId('userFilter'));
+    userEvent.click(screen.getByTestId('showMembers'));
+    await wait();
+
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.getByText('Sam Smith')).toBeInTheDocument();
+
+    // Open Dropdown
+    userEvent.click(screen.getByTestId('nameFilter'));
+    // Select option and enter first name
+    userEvent.click(screen.getByTestId('searchByLastName'));
+    const firstNameInput = screen.getByPlaceholderText(/Search by Last Name/i);
+    userEvent.type(firstNameInput, 'doe{enter}');
+
+    await wait(700);
+
+    expect(screen.getByText('John Doe')).toBeInTheDocument();
+    expect(screen.queryByText('Sam Smith')).not.toBeInTheDocument();
 
     await wait();
     const searchBar = screen.getByTestId(/searchByName/i);

--- a/src/screens/BlockUser/BlockUser.tsx
+++ b/src/screens/BlockUser/BlockUser.tsx
@@ -104,13 +104,11 @@ const Requests = (): JSX.Element => {
             orgId: currentUrl,
           },
         });
-        /* istanbul ignore next */
         if (data) {
           toast.success(t('blockedSuccessfully') as string);
           memberRefetch();
         }
       } catch (error: unknown) {
-        /* istanbul ignore next */
         errorHandler(t, error);
       }
     },
@@ -127,13 +125,11 @@ const Requests = (): JSX.Element => {
             orgId: currentUrl,
           },
         });
-        /* istanbul ignore next */
         if (data) {
           toast.success(t('Un-BlockedSuccessfully') as string);
           memberRefetch();
         }
       } catch (error: unknown) {
-        /* istanbul ignore next */
         errorHandler(t, error);
       }
     },


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR will remove all `/* istanbul ignore */` from codebase, and increased code coverage by writing 2 more test scenarios.

**Issue Number:**
Fixes #3022

**Did you add tests for your changes?**
Yes

**Snapshots/Videos:**
<img width="1107" alt="Screenshot 2024-12-29 at 21 52 11" src="https://github.com/user-attachments/assets/68d87c7a-efeb-4112-bfc3-dd9310c0c6e1" />


**If relevant, did you update the documentation?**
N/A

**Summary**
**Does this PR introduce a breaking change?**
No

**Other information**
N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated error handling in user blocking and unblocking functions.
  - Standardized success message translations for blocking and unblocking users.

- **Tests**
  - Refined test cases for filtering blocked and unblocked users.
  - Improved test assertions for user visibility based on filter selections.
  - Added test cases for error handling during user block/unblock actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->