### PR TITLE
Fix: Links of sidebar_menu now working at view_profile_section

### DIFF
--- a/src/components/ProfileDropdown/ProfileDropdown.spec.tsx
+++ b/src/components/ProfileDropdown/ProfileDropdown.spec.tsx
@@ -238,6 +238,34 @@ describe('ProfileDropdown Component', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/user/settings');
   });
 
+  test('navigates to /member/:orgId for non-user roles when orgId is not present', async () => {
+    window.history.pushState({}, 'Test page', '/orglist');
+    setItem('SuperAdmin', true); // Set as admin
+    setItem('id', '123');
+
+    render(
+      <MockedProvider mocks={MOCKS} addTypename={false}>
+        <BrowserRouter>
+          <I18nextProvider i18n={i18nForTest}>
+            <Routes>
+              <Route path="/orglist" element={<ProfileDropdown />} />
+            </Routes>
+          </I18nextProvider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    await act(async () => {
+      userEvent.click(screen.getByTestId('togDrop'));
+    });
+
+    await act(async () => {
+      userEvent.click(screen.getByTestId('profileBtn'));
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/member/');
+  });
+
   test('navigates to /member/:userID for non-user roles', async () => {
     window.history.pushState({}, 'Test page', '/321');
     setItem('SuperAdmin', true); // Set as admin

--- a/src/components/ProfileDropdown/ProfileDropdown.spec.tsx
+++ b/src/components/ProfileDropdown/ProfileDropdown.spec.tsx
@@ -1,7 +1,7 @@
 import React, { act } from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import ProfileDropdown from './ProfileDropdown';
 import { MockedProvider } from '@apollo/react-testing';
 import { REVOKE_REFRESH_TOKEN } from 'GraphQl/Mutations/mutations';
@@ -239,6 +239,7 @@ describe('ProfileDropdown Component', () => {
   });
 
   test('navigates to /member/:userID for non-user roles', async () => {
+    window.history.pushState({}, 'Test page', '/321');
     setItem('SuperAdmin', true); // Set as admin
     setItem('id', '123');
 
@@ -246,7 +247,9 @@ describe('ProfileDropdown Component', () => {
       <MockedProvider mocks={MOCKS} addTypename={false}>
         <BrowserRouter>
           <I18nextProvider i18n={i18nForTest}>
-            <ProfileDropdown />
+            <Routes>
+              <Route path="/:orgId" element={<ProfileDropdown />} />
+            </Routes>
           </I18nextProvider>
         </BrowserRouter>
       </MockedProvider>,
@@ -260,6 +263,6 @@ describe('ProfileDropdown Component', () => {
       userEvent.click(screen.getByTestId('profileBtn'));
     });
 
-    expect(mockNavigate).toHaveBeenCalledWith('/member/123');
+    expect(mockNavigate).toHaveBeenCalledWith('/member/321');
   });
 });

--- a/src/components/ProfileDropdown/ProfileDropdown.tsx
+++ b/src/components/ProfileDropdown/ProfileDropdown.tsx
@@ -1,7 +1,7 @@
 import Avatar from 'components/Avatar/Avatar';
 import React from 'react';
 import { ButtonGroup, Dropdown } from 'react-bootstrap';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import useLocalStorage from 'utils/useLocalstorage';
 import styles from './ProfileDropdown.module.css';
 import { REVOKE_REFRESH_TOKEN } from 'GraphQl/Mutations/mutations';
@@ -36,8 +36,8 @@ const profileDropdown = (): JSX.Element => {
   const firstName = getItem('FirstName');
   const lastName = getItem('LastName');
   const userImage = getItem('UserImage');
-  const userID = getItem('id');
   const navigate = useNavigate();
+  const { orgId } = useParams();
 
   const logout = async (): Promise<void> => {
     try {
@@ -103,7 +103,7 @@ const profileDropdown = (): JSX.Element => {
           onClick={() =>
             userRole === 'User'
               ? navigate(`/user/settings`)
-              : navigate(`/member/${userID}`)
+              : navigate(`/member/${orgId || ''}`)
           }
           aria-label="View Profile"
         >


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR will fix the issue, when at view_profile page left-side menu links are not working, also separate test is also added for the same so that it will not break again.

**Issue Number:**
Fixes #3000

**Did you add tests for your changes?**
Yes

**Snapshots/Videos:**

<img width="1196" alt="Screenshot 2024-12-30 at 19 40 35" src="https://github.com/user-attachments/assets/080651a2-1532-46cd-b17a-a524c6a8037d" />

https://github.com/user-attachments/assets/99c7526c-d063-44c5-a1f4-fc6ce02bd075


**If relevant, did you update the documentation?**
N/A

**Summary**
**Does this PR introduce a breaking change?**
No

**Other information**
When we click on the `view profile` link it was routing page to `/member/:userId` but now it is fixed to `/member/:orgId`. Also when `orgId` is not available then route to `/member/`.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Updated profile dropdown to use URL parameters for navigation.
	- Improved routing logic for profile navigation based on organization ID.

- **Bug Fixes**
	- Removed reliance on local storage for user ID.
	- Enhanced error handling for logout process.

- **Tests**
	- Added routing context to profile dropdown tests.
	- Expanded test coverage for navigation scenarios, including error logging on logout failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->