### PR TITLE
Improve Code Coverage in src/components/UserPortal/CommentCard/CommentCard.tsx

### DIFF
--- a/src/components/UserPortal/CommentCard/CommentCard.spec.tsx
+++ b/src/components/UserPortal/CommentCard/CommentCard.spec.tsx
@@ -1,6 +1,6 @@
 import React, { act } from 'react';
 import { MockedProvider } from '@apollo/react-testing';
-import { render, screen} from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
@@ -12,7 +12,7 @@ import userEvent from '@testing-library/user-event';
 import { LIKE_COMMENT, UNLIKE_COMMENT } from 'GraphQl/Mutations/mutations';
 import useLocalStorage from 'utils/useLocalstorage';
 import { vi } from 'vitest';
-import {toast} from 'react-toastify';
+import { toast } from 'react-toastify';
 
 /**
  * Unit tests for the CommentCard component.
@@ -32,7 +32,6 @@ vi.mock('react-toastify', () => ({
     error: vi.fn(),
   },
 }));
-
 
 async function wait(ms = 100): Promise<void> {
   await act(() => {
@@ -74,7 +73,6 @@ const MOCKS = [
     },
   },
 ];
-
 
 const defaultProps = {
   id: '1',
@@ -299,11 +297,11 @@ describe('Testing CommentCard Component [User Portal]', () => {
             </I18nextProvider>
           </Provider>
         </BrowserRouter>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await wait();
-    
+
     userEvent.click(screen.getByTestId('likeCommentBtn'));
     await wait();
 
@@ -332,11 +330,11 @@ describe('Testing CommentCard Component [User Portal]', () => {
             </I18nextProvider>
           </Provider>
         </BrowserRouter>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await wait();
-    
+
     userEvent.click(screen.getByTestId('likeCommentBtn'));
     await wait();
 
@@ -371,11 +369,11 @@ describe('Testing CommentCard Component [User Portal]', () => {
             </I18nextProvider>
           </Provider>
         </BrowserRouter>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await wait();
-    
+
     const initialLikes = container.textContent?.match(/\d+ Likes/)?.[0];
     userEvent.click(screen.getByTestId('likeCommentBtn'));
     await wait();
@@ -412,11 +410,11 @@ describe('Testing CommentCard Component [User Portal]', () => {
             </I18nextProvider>
           </Provider>
         </BrowserRouter>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await wait();
-    
+
     const initialLikes = container.textContent?.match(/\d+ Likes/)?.[0];
     userEvent.click(screen.getByTestId('likeCommentBtn'));
     await wait();
@@ -454,20 +452,24 @@ describe('Testing CommentCard Component [User Portal]', () => {
             </I18nextProvider>
           </Provider>
         </BrowserRouter>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await wait();
-    
+
     userEvent.click(screen.getByTestId('likeCommentBtn'));
-    
+
     // HourglassBottomIcon should be visible during loading
-    expect(document.querySelector('[data-testid="HourglassBottomIcon"]')).toBeInTheDocument();
-    
+    expect(
+      document.querySelector('[data-testid="HourglassBottomIcon"]'),
+    ).toBeInTheDocument();
+
     await wait(150);
-    
+
     // After loading, ThumbUpIcon should be visible
-    expect(document.querySelector('[data-testid="ThumbUpIcon"]')).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-testid="ThumbUpIcon"]'),
+    ).toBeInTheDocument();
   });
 
   it('should not update state if mutation returns no data', async () => {
@@ -493,11 +495,11 @@ describe('Testing CommentCard Component [User Portal]', () => {
             </I18nextProvider>
           </Provider>
         </BrowserRouter>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     await wait();
-    
+
     const initialLikes = container.textContent?.match(/\d+ Likes/)?.[0];
     userEvent.click(screen.getByTestId('likeCommentBtn'));
     await wait();
@@ -515,7 +517,7 @@ describe('Testing CommentCard Component [User Portal]', () => {
       },
       result: {
         data: {
-          unlikeComment: null
+          unlikeComment: null,
         },
       },
     };
@@ -532,20 +534,20 @@ describe('Testing CommentCard Component [User Portal]', () => {
             </I18nextProvider>
           </Provider>
         </BrowserRouter>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const initialLikes = container.textContent?.match(/\d+ Likes/)?.[0];
-    
+
     await wait();
-    
+
     userEvent.click(screen.getByTestId('likeCommentBtn'));
     await wait();
 
     // Verify that the likes count hasn't changed
     const updatedLikes = container.textContent?.match(/\d+ Likes/)?.[0];
     expect(updatedLikes).toBe(initialLikes);
-    
+
     // Verify that the callback wasn't called
     expect(defaultProps.handleDislikeComment).not.toHaveBeenCalled();
   });
@@ -558,7 +560,7 @@ describe('Testing CommentCard Component [User Portal]', () => {
       },
       result: {
         data: {
-          likeComment: null
+          likeComment: null,
         },
       },
     };
@@ -575,20 +577,20 @@ describe('Testing CommentCard Component [User Portal]', () => {
             </I18nextProvider>
           </Provider>
         </BrowserRouter>
-      </MockedProvider>
+      </MockedProvider>,
     );
 
     const initialLikes = container.textContent?.match(/\d+ Likes/)?.[0];
-    
+
     await wait();
-    
+
     userEvent.click(screen.getByTestId('likeCommentBtn'));
     await wait();
 
     // Verify that the likes count hasn't changed
     const updatedLikes = container.textContent?.match(/\d+ Likes/)?.[0];
     expect(updatedLikes).toBe(initialLikes);
-    
+
     // Verify that the callback wasn't called
     expect(defaultProps.handleLikeComment).not.toHaveBeenCalled();
   });

--- a/src/components/UserPortal/CommentCard/CommentCard.spec.tsx
+++ b/src/components/UserPortal/CommentCard/CommentCard.spec.tsx
@@ -1,6 +1,6 @@
 import React, { act } from 'react';
 import { MockedProvider } from '@apollo/react-testing';
-import { render, screen } from '@testing-library/react';
+import { render, screen} from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
@@ -12,6 +12,7 @@ import userEvent from '@testing-library/user-event';
 import { LIKE_COMMENT, UNLIKE_COMMENT } from 'GraphQl/Mutations/mutations';
 import useLocalStorage from 'utils/useLocalstorage';
 import { vi } from 'vitest';
+import {toast} from 'react-toastify';
 
 /**
  * Unit tests for the CommentCard component.
@@ -25,6 +26,13 @@ import { vi } from 'vitest';
  * to isolate the component and test its behavior independently.
  */
 const { getItem, setItem } = useLocalStorage();
+
+vi.mock('react-toastify', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
 
 async function wait(ms = 100): Promise<void> {
   await act(() => {
@@ -67,11 +75,31 @@ const MOCKS = [
   },
 ];
 
+
+const defaultProps = {
+  id: '1',
+  creator: {
+    id: '1',
+    firstName: 'test',
+    lastName: 'user',
+    email: 'test@user.com',
+  },
+  likeCount: 1,
+  likedBy: [{ id: '1' }],
+  text: 'testComment',
+  handleLikeComment: vi.fn(),
+  handleDislikeComment: vi.fn(),
+};
+
 const handleLikeComment = vi.fn();
 const handleDislikeComment = vi.fn();
 const link = new StaticMockLink(MOCKS, true);
 
 describe('Testing CommentCard Component [User Portal]', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   afterEach(async () => {
     await act(async () => {
       await i18nForTest.changeLanguage('en');
@@ -248,5 +276,320 @@ describe('Testing CommentCard Component [User Portal]', () => {
     if (beforeUserId) {
       setItem('userId', beforeUserId);
     }
+  });
+
+  it('should handle like mutation error correctly', async () => {
+    const errorMock = {
+      request: {
+        query: LIKE_COMMENT,
+        variables: { commentId: '1' },
+      },
+      error: new Error('Failed to like comment'),
+    };
+
+    const link = new StaticMockLink([errorMock], true);
+    setItem('userId', '2'); // Set user as not having liked the comment
+
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <CommentCard {...defaultProps} />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+    
+    userEvent.click(screen.getByTestId('likeCommentBtn'));
+    await wait();
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(defaultProps.handleLikeComment).not.toHaveBeenCalled();
+  });
+
+  it('should handle unlike mutation error correctly', async () => {
+    const errorMock = {
+      request: {
+        query: UNLIKE_COMMENT,
+        variables: { commentId: '1' },
+      },
+      error: new Error('Failed to unlike comment'),
+    };
+
+    const link = new StaticMockLink([errorMock], true);
+    setItem('userId', '1'); // Set user as having liked the comment
+
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <CommentCard {...defaultProps} />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+    
+    userEvent.click(screen.getByTestId('likeCommentBtn'));
+    await wait();
+
+    expect(toast.error).toHaveBeenCalled();
+    expect(defaultProps.handleDislikeComment).not.toHaveBeenCalled();
+  });
+
+  it('should successfully like a comment and update UI', async () => {
+    const successMock = {
+      request: {
+        query: LIKE_COMMENT,
+        variables: { commentId: '1' },
+      },
+      result: {
+        data: {
+          likeComment: {
+            _id: '1',
+          },
+        },
+      },
+    };
+
+    const link = new StaticMockLink([successMock], true);
+    setItem('userId', '2'); // Set user as not having liked the comment
+
+    const { container } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <CommentCard {...defaultProps} />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+    
+    const initialLikes = container.textContent?.match(/\d+ Likes/)?.[0];
+    userEvent.click(screen.getByTestId('likeCommentBtn'));
+    await wait();
+
+    const updatedLikes = container.textContent?.match(/\d+ Likes/)?.[0];
+    expect(updatedLikes).not.toBe(initialLikes);
+    expect(defaultProps.handleLikeComment).toHaveBeenCalledWith('1');
+  });
+
+  it('should successfully unlike a comment and update UI', async () => {
+    const successMock = {
+      request: {
+        query: UNLIKE_COMMENT,
+        variables: { commentId: '1' },
+      },
+      result: {
+        data: {
+          unlikeComment: {
+            _id: '1',
+          },
+        },
+      },
+    };
+
+    const link = new StaticMockLink([successMock], true);
+    setItem('userId', '1'); // Set user as having liked the comment
+
+    const { container } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <CommentCard {...defaultProps} />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+    
+    const initialLikes = container.textContent?.match(/\d+ Likes/)?.[0];
+    userEvent.click(screen.getByTestId('likeCommentBtn'));
+    await wait();
+
+    const updatedLikes = container.textContent?.match(/\d+ Likes/)?.[0];
+    expect(updatedLikes).not.toBe(initialLikes);
+    expect(defaultProps.handleDislikeComment).toHaveBeenCalledWith('1');
+  });
+
+  it('should show loading state while mutation is in progress', async () => {
+    const slowMock = {
+      request: {
+        query: LIKE_COMMENT,
+        variables: { commentId: '1' },
+      },
+      result: {
+        data: {
+          likeComment: {
+            _id: '1',
+          },
+        },
+      },
+      delay: 100,
+    };
+
+    const link = new StaticMockLink([slowMock], true);
+    setItem('userId', '2'); // Set user as not having liked the comment
+
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <CommentCard {...defaultProps} />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+    
+    userEvent.click(screen.getByTestId('likeCommentBtn'));
+    
+    // HourglassBottomIcon should be visible during loading
+    expect(document.querySelector('[data-testid="HourglassBottomIcon"]')).toBeInTheDocument();
+    
+    await wait(150);
+    
+    // After loading, ThumbUpIcon should be visible
+    expect(document.querySelector('[data-testid="ThumbUpIcon"]')).toBeInTheDocument();
+  });
+
+  it('should not update state if mutation returns no data', async () => {
+    const noDataMock = {
+      request: {
+        query: LIKE_COMMENT,
+        variables: { commentId: '1' },
+      },
+      result: {
+        data: null,
+      },
+    };
+
+    const link = new StaticMockLink([noDataMock], true);
+    setItem('userId', '2'); // Set user as not having liked the comment
+
+    const { container } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <CommentCard {...defaultProps} />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    await wait();
+    
+    const initialLikes = container.textContent?.match(/\d+ Likes/)?.[0];
+    userEvent.click(screen.getByTestId('likeCommentBtn'));
+    await wait();
+
+    const updatedLikes = container.textContent?.match(/\d+ Likes/)?.[0];
+    expect(updatedLikes).toBe(initialLikes);
+    expect(defaultProps.handleLikeComment).not.toHaveBeenCalled();
+  });
+
+  it('should handle successful mutation with empty data for unlike', async () => {
+    const emptyDataMock = {
+      request: {
+        query: UNLIKE_COMMENT,
+        variables: { commentId: '1' },
+      },
+      result: {
+        data: {
+          unlikeComment: null
+        },
+      },
+    };
+
+    const link = new StaticMockLink([emptyDataMock], true);
+    setItem('userId', '1'); // Set user as having liked the comment
+
+    const { container } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <CommentCard {...defaultProps} />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    const initialLikes = container.textContent?.match(/\d+ Likes/)?.[0];
+    
+    await wait();
+    
+    userEvent.click(screen.getByTestId('likeCommentBtn'));
+    await wait();
+
+    // Verify that the likes count hasn't changed
+    const updatedLikes = container.textContent?.match(/\d+ Likes/)?.[0];
+    expect(updatedLikes).toBe(initialLikes);
+    
+    // Verify that the callback wasn't called
+    expect(defaultProps.handleDislikeComment).not.toHaveBeenCalled();
+  });
+
+  it('should handle successful mutation with empty data for like', async () => {
+    const emptyDataMock = {
+      request: {
+        query: LIKE_COMMENT,
+        variables: { commentId: '1' },
+      },
+      result: {
+        data: {
+          likeComment: null
+        },
+      },
+    };
+
+    const link = new StaticMockLink([emptyDataMock], true);
+    setItem('userId', '2'); // Set user as not having liked the comment
+
+    const { container } = render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <CommentCard {...defaultProps} />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>
+    );
+
+    const initialLikes = container.textContent?.match(/\d+ Likes/)?.[0];
+    
+    await wait();
+    
+    userEvent.click(screen.getByTestId('likeCommentBtn'));
+    await wait();
+
+    // Verify that the likes count hasn't changed
+    const updatedLikes = container.textContent?.match(/\d+ Likes/)?.[0];
+    expect(updatedLikes).toBe(initialLikes);
+    
+    // Verify that the callback wasn't called
+    expect(defaultProps.handleLikeComment).not.toHaveBeenCalled();
   });
 });

--- a/src/components/UserPortal/CommentCard/CommentCard.tsx
+++ b/src/components/UserPortal/CommentCard/CommentCard.tsx
@@ -84,14 +84,12 @@ function commentCard(props: InterfaceCommentCardProps): JSX.Element {
             commentId: props.id,
           },
         });
-        /* istanbul ignore next */
-        if (data) {
+        if (data && data.unlikeComment && data.unlikeComment._id) {
           setLikes((likes) => likes - 1);
           setIsLikedByUser(false);
           props.handleDislikeComment(props.id);
         }
       } catch (error: unknown) {
-        /* istanbul ignore next */
         toast.error(error as string);
       }
     } else {
@@ -101,14 +99,13 @@ function commentCard(props: InterfaceCommentCardProps): JSX.Element {
             commentId: props.id,
           },
         });
-        /* istanbul ignore next */
-        if (data) {
+
+        if (data && data.likeComment && data.likeComment._id) {
           setLikes((likes) => likes + 1);
           setIsLikedByUser(true);
           props.handleLikeComment(props.id);
         }
       } catch (error: unknown) {
-        /* istanbul ignore next */
         toast.error(error as string);
       }
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Improve Code Coverage in src/components/UserPortal/CommentCard/CommentCard.tsx. #3066 

**Issue Number:**

Fixes #3066 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

![Screenshot from 2024-12-31 16-08-46](https://github.com/user-attachments/assets/19121909-af1d-4517-a7db-1badc9866976)



**If relevant, did you update the documentation?**

No

**Summary**
This PR Improve Code Coverage in src/screens/OrgSettings/OrgSetting.tsx. Key changes include:
- All sections of the file are covered by tests.
- Code coverage for the file reaches 100%.
- Remove any /* istanbul ignore */ or equivalent statements that bypass code coverage reporting, unless absolutely necessary.

**Does this PR introduce a breaking change?**

No

**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for comment liking and unliking functionality
	- Enhanced validation of GraphQL mutation responses

- **Tests**
	- Added comprehensive unit tests for `CommentCard` component
	- Implemented test cases for various comment interaction scenarios
	- Added error notification and loading state tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->