### PR TITLE
Fix: Improve code coverage in src/screens/forgot password

### DIFF
--- a/src/screens/ForgotPassword/ForgotPassword.spec.tsx
+++ b/src/screens/ForgotPassword/ForgotPassword.spec.tsx
@@ -6,7 +6,10 @@ import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 import { toast } from 'react-toastify';
-import { GENERATE_OTP_MUTATION } from 'GraphQl/Mutations/mutations';
+import {
+  FORGOT_PASSWORD_MUTATION,
+  GENERATE_OTP_MUTATION,
+} from 'GraphQl/Mutations/mutations';
 import { store } from 'state/store';
 import { StaticMockLink } from 'utils/StaticMockLink';
 // import i18nForTest from 'utils/i18nForTest';
@@ -26,6 +29,22 @@ vi.mock('react-toastify', () => ({
 }));
 
 const MOCKS = [
+  {
+    request: {
+      query: FORGOT_PASSWORD_MUTATION,
+      variables: {
+        otpToken: 'lorem ipsum',
+        userOtp: '12345',
+        newPassword: 'johnDoe@12345',
+      },
+    },
+    result: {
+      data: {
+        forgotPassword: true,
+      },
+    },
+  },
+
   {
     request: {
       query: GENERATE_OTP_MUTATION,
@@ -173,8 +192,8 @@ describe('Testing Forgot Password screen', () => {
   it('Testing forgot password functionality', async () => {
     const formData = {
       userOtp: '12345',
-      newPassword: 'johnDoe',
-      confirmNewPassword: 'johnDoe',
+      newPassword: 'johnDoe@12345',
+      confirmNewPassword: 'johnDoe@12345',
       email: 'johndoe@gmail.com',
     };
 

--- a/src/screens/ForgotPassword/ForgotPassword.spec.tsx
+++ b/src/screens/ForgotPassword/ForgotPassword.spec.tsx
@@ -2,13 +2,10 @@ import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import 'jest-localstorage-mock';
-import 'jest-location-mock';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
-import { toast, ToastContainer } from 'react-toastify';
-
+import { toast } from 'react-toastify';
 import { GENERATE_OTP_MUTATION } from 'GraphQl/Mutations/mutations';
 import { store } from 'state/store';
 import { StaticMockLink } from 'utils/StaticMockLink';
@@ -16,14 +13,15 @@ import { StaticMockLink } from 'utils/StaticMockLink';
 import ForgotPassword from './ForgotPassword';
 import i18n from 'utils/i18nForTest';
 import useLocalStorage from 'utils/useLocalstorage';
+import { vi, beforeEach, afterEach, expect, it, describe } from 'vitest';
 
 const { setItem, removeItem } = useLocalStorage();
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    success: jest.fn(),
-    error: jest.fn(),
-    warn: jest.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 
@@ -100,8 +98,8 @@ afterEach(() => {
 });
 
 describe('Testing Forgot Password screen', () => {
-  test('Component should be rendered properly', async () => {
-    window.location.assign('/orglist');
+  it('Component should be rendered properly', async () => {
+    window.history.pushState({}, 'Test page', '/orglist');
 
     render(
       <MockedProvider addTypename={false} link={link}>
@@ -121,10 +119,10 @@ describe('Testing Forgot Password screen', () => {
     expect(screen.getByText(/Registered Email/i)).toBeInTheDocument();
     expect(screen.getByText(/Get Otp/i)).toBeInTheDocument();
     expect(screen.getByText(/Back to Login/i)).toBeInTheDocument();
-    expect(window.location).toBeAt('/orglist');
+    expect(window.location.pathname).toBe('/orglist');
   });
 
-  test('Testing, If user is already loggedIn', async () => {
+  it('Testing, If user is already loggedIn', async () => {
     setItem('IsLoggedIn', 'TRUE');
 
     render(
@@ -142,7 +140,7 @@ describe('Testing Forgot Password screen', () => {
     await wait();
   });
 
-  test('Testing get OTP functionality', async () => {
+  it('Testing get OTP functionality', async () => {
     const formData = {
       email: 'johndoe@gmail.com',
     };
@@ -172,7 +170,7 @@ describe('Testing Forgot Password screen', () => {
     });
   });
 
-  test('Testing forgot password functionality', async () => {
+  it('Testing forgot password functionality', async () => {
     const formData = {
       userOtp: '12345',
       newPassword: 'johnDoe',
@@ -213,7 +211,7 @@ describe('Testing Forgot Password screen', () => {
     await wait();
   });
 
-  test('Testing forgot password functionality, if the otp got deleted from the local storage', async () => {
+  it('Testing forgot password functionality, if the otp got deleted from the local storage', async () => {
     const formData = {
       userOtp: '12345',
       newPassword: 'johnDoe',
@@ -254,7 +252,7 @@ describe('Testing Forgot Password screen', () => {
     await wait();
   });
 
-  test('Testing forgot password functionality, when new password and confirm password is not same', async () => {
+  it('Testing forgot password functionality, when new password and confirm password is not same', async () => {
     const formData = {
       email: 'johndoe@gmail.com',
       userOtp: '12345',
@@ -294,7 +292,7 @@ describe('Testing Forgot Password screen', () => {
     userEvent.click(screen.getByText('Change Password'));
   });
 
-  test('Testing forgot password functionality, when the user is not found', async () => {
+  it('Testing forgot password functionality, when the user is not found', async () => {
     const formData = {
       email: 'notexists@gmail.com',
     };
@@ -324,7 +322,7 @@ describe('Testing Forgot Password screen', () => {
     });
   });
 
-  test('Testing forgot password functionality, when there is an error except unregistered email and api failure', async () => {
+  it('Testing forgot password functionality, when there is an error except unregistered email and api failure', async () => {
     render(
       <MockedProvider addTypename={false} link={notWorkingLink}>
         <BrowserRouter>
@@ -342,7 +340,7 @@ describe('Testing Forgot Password screen', () => {
     });
   });
 
-  test('Testing forgot password functionality, when talawa api failed', async () => {
+  it('Testing forgot password functionality, when talawa api failed', async () => {
     const formData = {
       email: 'johndoe@gmail.com',
     };
@@ -372,7 +370,7 @@ describe('Testing Forgot Password screen', () => {
     });
   });
 
-  test('Testing forgot password functionality, when otp token is not present', async () => {
+  it('Testing forgot password functionality, when otp token is not present', async () => {
     const formData = {
       userOtp: '12345',
       newPassword: 'johnDoe',

--- a/src/screens/ForgotPassword/ForgotPassword.tsx
+++ b/src/screens/ForgotPassword/ForgotPassword.tsx
@@ -135,7 +135,7 @@ const ForgotPassword = (): JSX.Element => {
         },
       });
 
-      /* istanbul ignore next */
+      /* istanbul ignore else -- @preserve */
       if (data) {
         toast.success(t('passwordChanges') as string);
         setShowEnterEmail(true);
@@ -147,7 +147,6 @@ const ForgotPassword = (): JSX.Element => {
       }
     } catch (error: unknown) {
       setShowEnterEmail(true);
-      /* istanbul ignore next */
       errorHandler(t, error);
     }
   };


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR will migrate `src/screens/ForgotPassword/ForgotPassword.tsx` from Jest to Vitest also improve its code coverage to 100%.
Removed `Istanbul ignore next` comments.

**Issue Number:**

Fixes #3025 
Fixes #2551

**Did you add tests for your changes?**
Yes

**Snapshots/Videos:**
<img width="1009" alt="Screenshot 2025-01-01 at 17 12 00" src="https://github.com/user-attachments/assets/d48e153e-9a53-48db-8408-5e29166702ef" />


**If relevant, did you update the documentation?**
N/A

**Summary**
**Does this PR introduce a breaking change?**
No

**Other information**
At one place we are using `istanbul ignore else` statement because there we don't need else statement.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced password recovery test suite with comprehensive test cases
	- Improved error handling in forgot password functionality

- **Tests**
	- Updated testing framework from Jest to Vitest
	- Added more robust test scenarios for password reset process

- **Chores**
	- Standardized test case descriptions
	- Refined code coverage configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->