### PR TITLE
improved code coverage of src/screens/OrganizationVenues/Organization…

### DIFF
--- a/src/screens/OrganizationVenues/OrganizationVenues.spec.tsx
+++ b/src/screens/OrganizationVenues/OrganizationVenues.spec.tsx
@@ -508,9 +508,7 @@ describe('Organisation Venues', () => {
   });
 });
 
-
 vi.mock('utils/errorHandler');
-
 describe('Organisation Venues Error Handling', () => {
   beforeEach(() => {
     vi.resetAllMocks();
@@ -538,72 +536,81 @@ describe('Organisation Venues Error Handling', () => {
     renderOrganizationVenue(errorLink);
 
     await waitFor(() => {
-      expect(errorHandler).toHaveBeenCalledWith(expect.any(Function), mockError);
+      expect(errorHandler).toHaveBeenCalledWith(
+        expect.any(Function),
+        mockError,
+      );
     });
   });
 
   test('handles venue deletion error correctly', async () => {
     const mockError = new Error('Failed to delete venue');
-    const errorLink = new StaticMockLink([
-      {
-        request: {
-          query: VENUE_LIST,
-          variables: {
-            orgId: 'orgId',
-            orderBy: 'capacity_DESC',
-            where: {
-              name_starts_with: '',
-              description_starts_with: undefined,
+    const errorLink = new StaticMockLink(
+      [
+        {
+          request: {
+            query: VENUE_LIST,
+            variables: {
+              orgId: 'orgId',
+              orderBy: 'capacity_DESC',
+              where: {
+                name_starts_with: '',
+                description_starts_with: undefined,
+              },
+            },
+          },
+          result: {
+            data: {
+              getVenueByOrgId: [
+                {
+                  _id: 'venue1',
+                  name: 'Test Venue',
+                  description: 'Test Description',
+                  capacity: 100,
+                  // ... other required fields
+                },
+              ],
             },
           },
         },
-        result: {
-          data: {
-            getVenueByOrgId: [
-              {
-                _id: 'venue1',
-                name: 'Test Venue',
-                description: 'Test Description',
-                capacity: 100,
-                // ... other required fields
-              },
-            ],
+        {
+          request: {
+            query: DELETE_VENUE_MUTATION,
+            variables: { id: 'venue1' },
           },
+          error: mockError,
         },
-      },
-      {
-        request: {
-          query: DELETE_VENUE_MUTATION,
-          variables: { id: 'venue1' },
-        },
-        error: mockError,
-      },
-    ], true);
+      ],
+      true,
+    );
 
     renderOrganizationVenue(errorLink);
-    
+
     await waitFor(() => {
       expect(screen.getByTestId('deleteVenueBtn1')).toBeInTheDocument();
     });
-    
+
     fireEvent.click(screen.getByTestId('deleteVenueBtn1'));
 
     await waitFor(() => {
-      expect(errorHandler).toHaveBeenCalledWith(expect.any(Function), mockError);
+      expect(errorHandler).toHaveBeenCalledWith(
+        expect.any(Function),
+        mockError,
+      );
     });
   });
 
   test('renders venue list correctly after loading', async () => {
     renderOrganizationVenue(link);
-    
+
     // First verify loading state
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
-    
+
     // Then verify venues are rendered
     await waitFor(() => {
       const venueList = screen.getByTestId('orgvenueslist');
       expect(venueList).toBeInTheDocument();
-      
+
       const venues = screen.getAllByTestId(/^venue-item/);
       expect(venues).toHaveLength(3);
     });

--- a/src/screens/OrganizationVenues/OrganizationVenues.tsx
+++ b/src/screens/OrganizationVenues/OrganizationVenues.tsx
@@ -78,7 +78,6 @@ function organizationVenues(): JSX.Element {
       });
       venueRefetch();
     } catch (error) {
-      /* istanbul ignore next */
       errorHandler(t, error);
     }
   };
@@ -128,7 +127,6 @@ function organizationVenues(): JSX.Element {
   };
 
   // Error handling for venue data fetch
-  /* istanbul ignore next */
   if (venueError) {
     errorHandler(t, venueError);
   }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Improved Code Coverage in src/screens/OrganizationVenues/OrganizationVenues.tsx

**Issue Number:**

Fixes #3032

**Did you add tests for your changes?**

Yes. Added comprehensive test coverage for src/screens/OrganizationVenues/OrganizationVenues.tsx

**Snapshots/Videos:**

 



https://github.com/user-attachments/assets/2bce2b47-89e3-40d0-93d0-afc83a3190d0



**If relevant, did you update the documentation?**

N/A

**Summary**

This PR improves code coverage for the OrganizationVenues component by:
- Adding test cases for previously uncovered code paths
- Removing unnecessary istanbul ignore statements
- Ensuring 100% test coverage of the component

**Does this PR introduce a breaking change?**

No

**Other information**

Code coverage increased from previous coverage to 100% for the specified component.

**Have you read the contributing guide?**

Yes
 
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Enhanced test coverage for the Organization Venues component.
	- Added tests for error handling scenarios during venue query and deletion.
	- Verified venue list rendering after loading state.

- **Bug Fixes**
	- Improved error handling mechanisms for venue-related operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->