### PR TITLE
Feature: Added Talawa-admin to run system daemon service in Linux 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ The process of proposing a change to Talawa Admin can be summarized as:
             ```
             npm install
             npm run test --watchAll=false --coverage
-            genhtml coverage/lcov.info -o coverage
+            genhtml coverage/jest/lcov.info -o coverage
             ```
          3. The output of the `npm run test` command will give you a tablular coverage report per file
          4. The overall coverage rate will be visible on the penultimate line of the `genhtml` command's output.

--- a/examples/linux/Deamon_Service_Setup.md
+++ b/examples/linux/Deamon_Service_Setup.md
@@ -1,0 +1,68 @@
+
+# Talawa-Admin Service Setup Guide
+
+This guide outlines the steps to set up and manage the Talawa-Admin service on a Linux server using `systemd`.
+
+### Prerequisites
+
+- Ensure **Node.js** and **npm** are correctly installed and available for the specified user and group.
+- It’s recommended to use **nvm** (Node Version Manager) for better management of different Node.js versions.
+
+---
+
+### Service Configuration
+
+#### 1. **Copy the `talawa_admin.service` file**
+   - Place the `talawa_admin.service` file in the appropriate systemd directory based on your Linux distribution:
+     - For most distributions: `/etc/systemd/system/`
+     - For systems using `systemd`, this will be the default directory.
+
+#### 2. **Verify the CODEROOT Path**
+   - Ensure that the `CODEROOT` environment variable matches the absolute path to the Talawa-Admin code directory.
+
+#### 3. **Set the Correct Working Directory**
+   - Always use the absolute path for the `WorkingDirectory`. Do **not** use `$CODEROOT` in the `WorkingDirectory` field.
+
+#### 4. **Ensure the `.env` File Exists**
+   - Verify that the path in the `EnvironmentFile` line points to a valid `.env` file located in the root directory of the Talawa-Admin repository.
+
+#### 5. **Adjust User and Group**
+   - Modify the `User` and `Group` settings to match the user account intended to run the service.
+
+---
+
+### Steps to Enable and Manage the Service
+
+1. **Reload the systemd daemon** to apply changes:
+   ```bash
+   sudo systemctl daemon-reload
+   ```
+
+2. **Start the Talawa-Admin Service**:
+   ```bash
+   sudo systemctl start talawa_admin.service
+   ```
+
+3. **Stop the Talawa-Admin Service**:
+   ```bash
+   sudo systemctl stop talawa_admin.service
+   ```
+
+4. **Enable the Service to Start on Boot**:
+   ```bash
+   sudo systemctl enable talawa_admin.service
+   ```
+
+---
+
+### Troubleshooting
+
+- If you encounter any issues, you can check the status and logs of the service:
+  ```bash
+  sudo systemctl status talawa_admin.service
+  sudo journalctl -u talawa_admin.service
+  ```
+
+---
+
+By following these steps, you can set up and manage the Talawa-Admin service efficiently on your Linux server.

--- a/examples/linux/systemd/talawa_admin.service
+++ b/examples/linux/systemd/talawa_admin.service
@@ -1,0 +1,46 @@
+
+################################################################################
+#
+# READ ALL STEPS BEFORE PROCEEDING
+#
+# 0) Ensure that Node.js and npm are correctly installed and available for the 
+#    specified user and group.
+#    Use nvm for better interaction with different node versions.
+# 1) Place this file in the appropriate systemd directory based on your Linux
+#    distribution, e.g., /etc/systemd/system/.
+# 2) Verify the CODEROOT path matches the Talawa-Admin code directory.
+# 3) Always add the absolute path of talawa-admin directory to WorkingDirectory don't use $CODEROOT. 
+# 4) Ensure the EnvironmentFile path points to a valid .env file for the service.
+# 5) Adjust the User and Group to match the user account intended to run the service.
+# 6) Run the command "sudo systemctl daemon-reload" after saving changes.
+# 7) Use "sudo systemctl start talawa_admin.service" to start the service.
+# 8) Use "sudo systemctl stop talawa_admin.service" to stop the service.
+# 9) Use "sudo systemctl enable talawa_admin.service" to start the service on boot.
+#
+################################################################################
+
+[Unit]
+Description=Talawa-Admin Service
+After=network.target
+
+[Service]
+User=talawa
+Group=talawa
+Environment=CODEROOT=path/to/your/talawa-admin
+
+# Absolute path is needed for working directory
+WorkingDirectory=/path/to/your/talawa-admin
+
+################################################################################
+# No need to edit anything below here
+################################################################################
+
+EnvironmentFile=$CODEROOT/.env
+ExecStart=/bin/bash -c "source /path/to/your/.nvm/nvm.sh && nvm use default && npm run serve"
+Restart=on-failure
+RemainAfterExit=yes
+Type=simple
+RuntimeDirectory=talawa-admin
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
**What kind of change does this PR introduce?**
feature

**Issue Number:**

Fixes #2595 

**Did you add tests for your changes?**
No

**Snapshots/Videos:**

 Working proof of talawa_admin.service file
[Screencast from 2025-01-03 13-10-02.webm](https://github.com/user-attachments/assets/8cee7908-e576-4f85-9a34-d81a453414d5)     

**Summary**

- [x] Created examples/linux/systemd folder in the root directory
- [x] Inside examples/linux/systemd added talawa_admin.service file 
- [x] Inside examples/linux folder added Daemon_Service_Setup.md file for proper setup of talawa-admin service
- [x]  Fixed a typo in CONTRIBUTING.md file for smooth testing process from `genhtml coverage/lcov.info -o coverage` to `genhtml coverage/jest/lcov.info -o coverage`

**Does this PR introduce a breaking change?**
No

**Other information**
I have locally tested all the changes that I have made to the codebase

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated `CONTRIBUTING.md` with modified test coverage report generation command
	- Added comprehensive Linux service setup guide for Talawa-Admin in `Deamon_Service_Setup.md`

- **New Features**
	- Introduced systemd service configuration file for Talawa-Admin service deployment on Linux servers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->