### PR TITLE
Improve Code Coverage in src/screens/OrganizationPeople/OrganizationPeople.tsx

### DIFF
--- a/src/screens/OrganizationPeople/AddMember.tsx
+++ b/src/screens/OrganizationPeople/AddMember.tsx
@@ -32,6 +32,7 @@ import type {
 } from 'utils/interfaces';
 import styles from '../../style/app.module.css';
 import Avatar from 'components/Avatar/Avatar';
+import { t } from 'i18next';
 
 const StyledTableCell = styled(TableCell)(() => ({
   [`&.${tableCellClasses.head}`]: {
@@ -110,10 +111,7 @@ function AddMember(): JSX.Element {
         orgId: currentUrl,
       });
     } catch (error: unknown) {
-      if (error instanceof Error) {
-        toast.error(error.message);
-        console.log(error.message);
-      }
+      errorHandler(t, error);
     }
   };
 
@@ -388,7 +386,7 @@ function AddMember(): JSX.Element {
                             >
                               {userDetails.user.image ? (
                                 <img
-                                  src={userDetails.user.image ?? undefined}
+                                  src={userDetails.user.image}
                                   alt="avatar"
                                   className={styles.TableImage}
                                 />
@@ -443,7 +441,10 @@ function AddMember(): JSX.Element {
         show={createNewUserModalisOpen}
         onHide={toggleCreateNewUserModal}
       >
-        <Modal.Header className={styles.createUserModalHeader}>
+        <Modal.Header
+          className={styles.createUserModalHeader}
+          data-testid="createUser"
+        >
           <Modal.Title>Create User</Modal.Title>
         </Modal.Header>
         <Modal.Body>

--- a/src/screens/OrganizationPeople/AddMember.tsx
+++ b/src/screens/OrganizationPeople/AddMember.tsx
@@ -32,7 +32,6 @@ import type {
 } from 'utils/interfaces';
 import styles from '../../style/app.module.css';
 import Avatar from 'components/Avatar/Avatar';
-import { t } from 'i18next';
 
 const StyledTableCell = styled(TableCell)(() => ({
   [`&.${tableCellClasses.head}`]: {
@@ -111,7 +110,7 @@ function AddMember(): JSX.Element {
         orgId: currentUrl,
       });
     } catch (error: unknown) {
-      errorHandler(t, error);
+      errorHandler(tCommon, error);
     }
   };
 

--- a/src/screens/OrganizationPeople/OrganizationPeople.spec.tsx
+++ b/src/screens/OrganizationPeople/OrganizationPeople.spec.tsx
@@ -933,10 +933,6 @@ describe('Organization People Page', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('addNewUserModal')).toBeInTheDocument();
-      console.log(
-        'addnewusermodelcount',
-        screen.getAllByTestId('addNewUserModal'),
-      );
       expect(screen.getByTestId('createUser')).toBeInTheDocument();
     });
 
@@ -997,10 +993,6 @@ describe('Organization People Page', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('addNewUserModal')).toBeInTheDocument();
-      console.log(
-        'addnewusermodelcount',
-        screen.getAllByTestId('addNewUserModal'),
-      );
       expect(screen.getByTestId('createUser')).toBeInTheDocument();
     });
 
@@ -1080,10 +1072,6 @@ describe('Organization People Page', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('addNewUserModal')).toBeInTheDocument();
-      console.log(
-        'addnewusermodelcount',
-        screen.getAllByTestId('addNewUserModal'),
-      );
       expect(screen.getByTestId('createUser')).toBeInTheDocument();
     });
 

--- a/src/screens/OrganizationPeople/OrganizationPeople.spec.tsx
+++ b/src/screens/OrganizationPeople/OrganizationPeople.spec.tsx
@@ -898,11 +898,6 @@ describe('Organization People Page', () => {
       result: mockCreateMemberResponse2,
     },
   ];
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   test('successfully creates user and adds them as member', async () => {
     window.location.assign('/orgpeople/orgid');
     render(

--- a/src/screens/OrganizationPeople/OrganizationPeople.tsx
+++ b/src/screens/OrganizationPeople/OrganizationPeople.tsx
@@ -125,7 +125,6 @@ function organizationPeople(): JSX.Element {
     }
   }, [state, adminData]);
 
-  /* istanbul ignore next */
   if (memberError || usersError || adminError) {
     const error = memberError ?? usersError ?? adminError;
     toast.error(error?.message);


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Improved code coverage in src/screens/OrganizationPeople/OrganizationPeople.tsx
Improved code coverage in src/screens/OrganizationPeople/AddMember.tsx
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #3030 

**Did you add tests for your changes?**
yes
<!--Yes or No. Note: Add unit tests or automation tests for your code.-->

**Snapshots/Videos:**
![Screenshot from 2025-01-04 01-47-29](https://github.com/user-attachments/assets/ec0c51b8-e154-47d4-9444-4c4ae692d9ae)

<!--Add snapshots or videos wherever possible.-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for organization member queries with toast notifications.
	- Improved search functionality for organization members.
	- Added test IDs to improve testability of the "New User Modal".

- **Bug Fixes**
	- Refined data fetching and loading state management.
	- Improved handling of user data and search inputs.

- **Tests**
	- Expanded test coverage for the organization people component, including error scenarios for GraphQL queries and modal state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->