### PR TITLE
BugFix : Fixed failing ESLint and Prettier tests in scripts/githooks/check-localstorage-usage.js file

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -153,5 +153,13 @@
     "docs/sidebars.ts",
     "docs/src/**",
     "docs/blog/**"
+  ],
+  "overrides": [
+    {
+      "files": ["*.js"],
+      "rules": {
+        "@typescript-eslint/explicit-function-return-type": "off"
+      }
+    }
   ]
 }

--- a/scripts/githooks/check-localstorage-usage.js
+++ b/scripts/githooks/check-localstorage-usage.js
@@ -86,10 +86,10 @@ if (filesWithLocalStorage.length > 0) {
 
   console.info(
     '\x1b[34m%s\x1b[0m',
-    '\nInfo: Consider using custom hook functions.'
+    '\nInfo: Consider using custom hook functions.',
   );
   console.info(
-    'Please use the getItem, setItem, and removeItem functions provided by the custom hook useLocalStorage.\n'
+    'Please use the getItem, setItem, and removeItem functions provided by the custom hook useLocalStorage.\n',
   );
 
   process.exit(1);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

BugFix

**Issue Number:**

Fixes #3184 

**Did you add tests for your changes?**

No

**Snapshots/Videos:**

Before
![Screenshot from 2025-01-06 19-00-17](https://github.com/user-attachments/assets/be0d587b-3fe5-4741-a561-b5c867930314)


After 
![Screenshot from 2025-01-06 19-13-08](https://github.com/user-attachments/assets/10268640-3280-465b-9726-fbbfe4520e7a)


**If relevant, did you update the documentation?**
Not applicable


**Does this PR introduce a breaking change?**
No

**Other information**
Problem 1: ESLint was configured to check for type declarations in .js files, which caused a conflict since these files are not meant to have type declarations like TypeScript files.

Specifically, the rule @typescript-eslint/explicit-function-return-type was being enforced on JavaScript files. This rule mandates that all functions must have an explicit return type, but this isn’t relevant for regular JavaScript files, leading to unnecessary linting warnings and errors.

To prevent ESLint from applying TypeScript-specific rules (like @typescript-eslint/explicit-function-return-type) to JavaScript files, I added an override to the ESLint configuration file.

Problem 2: Prettier Test was failing since there were some missing commas in console.info 
So i ran the prettier write command to fix that format to a better format.


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated ESLint configuration to allow JavaScript files to bypass explicit function return type requirements.
	- Minor formatting updates to localStorage usage detection script output messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->