### PR TITLE
Refactor: src/screens/UserPortal/Posts from Jest to Vitest #2578

### DIFF
--- a/src/screens/UserPortal/Posts/Posts.spec.tsx
+++ b/src/screens/UserPortal/Posts/Posts.spec.tsx
@@ -16,16 +16,28 @@ import i18nForTest from 'utils/i18nForTest';
 import Home from './Posts';
 import useLocalStorage from 'utils/useLocalstorage';
 import { DELETE_POST_MUTATION } from 'GraphQl/Mutations/mutations';
+import { expect, describe, test, vi } from 'vitest';
 
 const { setItem } = useLocalStorage();
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    error: jest.fn(),
-    info: jest.fn(),
-    success: jest.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
   },
 }));
+
+const mockUseParams = vi.fn().mockReturnValue({ orgId: 'orgId' });
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => mockUseParams(),
+    useNavigate: () => vi.fn(),
+  };
+});
 
 const MOCKS = [
   {
@@ -262,28 +274,24 @@ const renderHomeScreen = (): RenderResult =>
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
-  value: jest.fn().mockImplementation((query) => ({
+  value: vi.fn().mockImplementation((query) => ({
     matches: false,
     media: query,
     onchange: null,
-    addListener: jest.fn(), // Deprecated
-    removeListener: jest.fn(), // Deprecated
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
+    addListener: vi.fn(), // Deprecated
+    removeListener: vi.fn(), // Deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
   })),
 });
 
 describe('Testing Home Screen: User Portal', () => {
-  beforeAll(() => {
-    jest.mock('react-router-dom', () => ({
-      ...jest.requireActual('react-router-dom'),
-      useParams: () => ({ orgId: 'orgId' }),
-    }));
+  beforeEach(() => {
+    mockUseParams.mockReturnValue({ orgId: 'orgId' });
   });
-
   afterAll(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   test('Check if HomeScreen renders properly', async () => {
@@ -325,7 +333,6 @@ describe('Testing Home Screen: User Portal', () => {
 
     userEvent.type(screen.getByTestId('postInput'), 'some content');
 
-    // Check that the content and image have been added
     expect(screen.getByTestId('postInput')).toHaveValue('some content');
     await screen.findByAltText('Post Image Preview');
     expect(screen.getByAltText('Post Image Preview')).toBeInTheDocument();
@@ -371,11 +378,15 @@ describe('Testing Home Screen: User Portal', () => {
 });
 
 describe('HomeScreen with invalid orgId', () => {
+  beforeEach(() => {
+    mockUseParams.mockReturnValue({ orgId: undefined });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   test('Redirect to /user when organizationId is falsy', async () => {
-    jest.mock('react-router-dom', () => ({
-      ...jest.requireActual('react-router-dom'),
-      useParams: () => ({ orgId: undefined }),
-    }));
     render(
       <MockedProvider addTypename={false} link={link}>
         <MemoryRouter initialEntries={['/user/organization/']}>

--- a/src/screens/UserPortal/Posts/Posts.spec.tsx
+++ b/src/screens/UserPortal/Posts/Posts.spec.tsx
@@ -16,7 +16,7 @@ import i18nForTest from 'utils/i18nForTest';
 import Home from './Posts';
 import useLocalStorage from 'utils/useLocalstorage';
 import { DELETE_POST_MUTATION } from 'GraphQl/Mutations/mutations';
-import { expect, describe, test, vi } from 'vitest';
+import { expect, describe, it, vi } from 'vitest';
 
 const { setItem } = useLocalStorage();
 
@@ -294,7 +294,7 @@ describe('Testing Home Screen: User Portal', () => {
     vi.clearAllMocks();
   });
 
-  test('Check if HomeScreen renders properly', async () => {
+  it('Check if HomeScreen renders properly', async () => {
     renderHomeScreen();
 
     await wait();
@@ -302,7 +302,7 @@ describe('Testing Home Screen: User Portal', () => {
     expect(startPostBtn).toBeInTheDocument();
   });
 
-  test('StartPostModal should render on click of StartPost btn', async () => {
+  it('StartPostModal should render on click of StartPost btn', async () => {
     renderHomeScreen();
 
     await wait();
@@ -314,7 +314,7 @@ describe('Testing Home Screen: User Portal', () => {
     expect(startPostModal).toBeInTheDocument();
   });
 
-  test('StartPostModal should close on clicking the close button', async () => {
+  it('StartPostModal should close on clicking the close button', async () => {
     renderHomeScreen();
 
     await wait();
@@ -349,7 +349,7 @@ describe('Testing Home Screen: User Portal', () => {
     expect(screen.getByTestId('postImageInput')).toHaveValue('');
   });
 
-  test('Check whether Posts render in PostCard', async () => {
+  it('Check whether Posts render in PostCard', async () => {
     setItem('userId', '640d98d9eb6a743d75341067');
     renderHomeScreen();
     await wait();
@@ -366,7 +366,7 @@ describe('Testing Home Screen: User Portal', () => {
     expect(screen.queryByText('This is the post two')).toBeInTheDocument();
   });
 
-  test('Checking if refetch works after deleting this post', async () => {
+  it('Checking if refetch works after deleting this post', async () => {
     setItem('userId', '640d98d9eb6a743d75341067');
     renderHomeScreen();
     expect(screen.queryAllByTestId('dropdown')).not.toBeNull();
@@ -386,7 +386,7 @@ describe('HomeScreen with invalid orgId', () => {
     vi.clearAllMocks();
   });
 
-  test('Redirect to /user when organizationId is falsy', async () => {
+  it('Redirect to /user when organizationId is falsy', async () => {
     render(
       <MockedProvider addTypename={false} link={link}>
         <MemoryRouter initialEntries={['/user/organization/']}>


### PR DESCRIPTION
Refactor : src/screens/UserPortal/Posts from Jest to Vitest 
https://github.com/PalisadoesFoundation/talawa-admin/issues/2578

What kind of change does this PR introduce?

Refactor

Issue Number: https://github.com/PalisadoesFoundation/talawa-admin/issues/2578

Fixes https://github.com/PalisadoesFoundation/talawa-admin/issues/2578

Did you add tests for your changes?

Yes

Snapshots/Videos:

![Screenshot 2025-01-07 170056](https://github.com/user-attachments/assets/758b30a1-51ca-4050-a96b-8f57d88a412c)


Summary

Migrated test from jest to vitest.

Does this PR introduce a breaking change?

No

Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Migrated test suite from Jest to Vitest
	- Updated mocking strategies for `react-toastify` and `react-router-dom`
	- Added test coverage for scenarios with undefined organization ID
	- Improved test framework compatibility and reset mechanisms
	- Enhanced mock implementation for `window.matchMedia`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->