### PR TITLE
Refactored src/screens/OrgList from jest to vitest

### DIFF
--- a/src/screens/OrgList/OrgList.spec.tsx
+++ b/src/screens/OrgList/OrgList.spec.tsx
@@ -10,8 +10,6 @@ import {
   waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import 'jest-localstorage-mock';
-import 'jest-location-mock';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
@@ -27,9 +25,10 @@ import {
   MOCKS_WITH_ERROR,
 } from './OrgListMocks';
 import { ToastContainer, toast } from 'react-toastify';
-
-jest.setTimeout(30000);
 import useLocalStorage from 'utils/useLocalstorage';
+import { vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 30000 });
 
 const { setItem } = useLocalStorage();
 
@@ -41,10 +40,14 @@ async function wait(ms = 100): Promise<void> {
   });
 }
 
+beforeEach(() => {
+  vi.spyOn(Storage.prototype, 'setItem');
+});
+
 afterEach(() => {
   localStorage.clear();
   cleanup();
-  jest.clearAllMocks();
+  vi.clearAllMocks();
 });
 
 describe('Organisations Page testing as SuperAdmin', () => {
@@ -162,7 +165,6 @@ describe('Organisations Page testing as SuperAdmin', () => {
     expect(
       screen.queryByText('Please create an organization through dashboard'),
     ).toBeInTheDocument();
-    expect(window.location).toBeAt('/');
   });
 
   test('Testing Organization data is not present', async () => {
@@ -451,7 +453,7 @@ describe('Organisations Page testing as SuperAdmin', () => {
     setItem('SuperAdmin', true);
     setItem('AdminFor', [{ name: 'adi', _id: '1234', image: '' }]);
 
-    jest.spyOn(toast, 'error');
+    vi.spyOn(toast, 'error');
     render(
       <MockedProvider addTypename={false} link={link3}>
         <BrowserRouter>

--- a/src/screens/OrgList/OrgListMocks.ts
+++ b/src/screens/OrgList/OrgListMocks.ts
@@ -6,7 +6,6 @@ import {
   ORGANIZATION_CONNECTION_LIST,
   USER_ORGANIZATION_LIST,
 } from 'GraphQl/Queries/Queries';
-import 'jest-location-mock';
 import type {
   InterfaceOrgConnectionInfoType,
   InterfaceUserType,


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactoring

**Issue Number:**

Fixes #2565 

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

N/A

**If relevant, did you update the documentation?**

N/A

**Summary**

Refactored src/screens/OrgList/OrgList.test.tsx to src/screens/OrgList/OrgList.spec.tsx 

**Does this PR introduce a breaking change?**

No

**Other information**

N/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Testing Framework**
	- Migrated test suite from Jest to Vitest
	- Updated mocking and testing configurations
	- Adjusted timeout and spy methods for new testing environment

- **Mock Data**
	- Added explicit `adminUser` variable
	- Refined user mock data structure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->