### PR TITLE
prevented unnecessary page reload with complementary test

### DIFF
--- a/src/components/OrgPeopleListCard/OrgPeopleListCard.spec.tsx
+++ b/src/components/OrgPeopleListCard/OrgPeopleListCard.spec.tsx
@@ -83,6 +83,45 @@ describe('Testing Organization People List Card', () => {
     });
   });
 
+  const NULL_DATA_MOCKS = [
+    {
+      request: {
+        query: REMOVE_MEMBER_MUTATION,
+        variables: {
+          userid: '1',
+          orgid: '456',
+        },
+      },
+      result: {
+        data: null,
+      },
+    },
+  ];
+
+  test('should handle null data response from mutation', async () => {
+    const link = new StaticMockLink(NULL_DATA_MOCKS, true);
+
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <I18nextProvider i18n={i18nForTest}>
+            <OrgPeopleListCard {...props} />
+          </I18nextProvider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    // Click remove button
+    const removeButton = screen.getByTestId('removeMemberBtn');
+    await userEvent.click(removeButton);
+
+    // Verify that success toast and toggleRemoveModal were not called
+    await waitFor(() => {
+      expect(toast.success).not.toHaveBeenCalled();
+      expect(props.toggleRemoveModal).not.toHaveBeenCalled();
+    });
+  });
+
   test('should render modal and handle successful member removal', async () => {
     const link = new StaticMockLink(MOCKS, true);
 
@@ -123,14 +162,7 @@ describe('Testing Organization People List Card', () => {
     await waitFor(
       () => {
         expect(toast.success).toHaveBeenCalled();
-      },
-      { timeout: 3000 },
-    );
-
-    // Check if page reload is triggered after delay
-    await waitFor(
-      () => {
-        expect(window.location.reload).toHaveBeenCalled();
+        expect(props.toggleRemoveModal).toHaveBeenCalled();
       },
       { timeout: 3000 },
     );

--- a/src/components/OrgPeopleListCard/OrgPeopleListCard.tsx
+++ b/src/components/OrgPeopleListCard/OrgPeopleListCard.tsx
@@ -58,9 +58,7 @@ function orgPeopleListCard(
       // If the mutation is successful, show a success message and reload the page
       if (data) {
         toast.success(t('memberRemoved') as string);
-        setTimeout(() => {
-          window.location.reload();
-        }, 2000);
+        props.toggleRemoveModal();
       }
     } catch (error: unknown) {
       errorHandler(t, error);


### PR DESCRIPTION
# Fix Unnecessary Page Reload After User Deletion

## What kind of change does this PR introduce?
Bugfix - Removes unnecessary page reload after deleting a user from organization people list

## Issue Number:
Fixes #2700

## Did you add tests for your changes?
Yes - Added unit tests to verify the user deletion flow and UI update behavior

## Snapshots/Videos:
[Screencast from 2025-01-08 01-16-28.webm](https://github.com/user-attachments/assets/75d379c0-d49d-4e0d-9fab-94cc21925532)

[Screencast from 2025-01-08 01-08-03.webm](https://github.com/user-attachments/assets/2af973b4-8128-44a0-9412-e49eab96a8f5)

## Summary
This PR addresses the unnecessary page reload that occurs when deleting a user from the organization people list. Currently, the page reloads 2 seconds after successful user deletion, which disrupts the user experience. This PR implements the following changes:

## Does this PR introduce a breaking change?
No - This is a behavioral improvement that maintains all existing functionality

## Testing Performed
- Verified user deletion flow works correctly
- Tested error scenarios
- Confirmed UI updates properly without page reload
- Ran existing test suite to ensure no regressions
- Tested across multiple browsers (Chrome, Firefox, Safari)
-
## Have you read the contributing guide?
Yes

Please review and let me know if any additional changes are needed.