### PR TITLE
chore: update Husky configuration and remove deprecated prepare script

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
 npm run format:fix
 # npm run lint:fix

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,3 @@
-#!/usr/bin/env sh
 
 npm run format:fix
 # npm run lint:fix

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "format:check": "prettier --check \"**/*.{ts,tsx,json,scss,css}\"",
     "check-tsdoc": "node .github/workflows/check-tsdoc.js",
     "typecheck": "tsc --project tsconfig.json --noEmit",
-    "prepare": "husky install",
+    "prepare": "husky",
     "jest-preview": "jest-preview",
     "update:toc": "node scripts/githooks/update-toc.js",
     "lint-staged": "lint-staged --concurrent false",


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.
-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
- Updates Husky configuration to remove deprecated settings
- updated npm prepare script to use current Husky syntax

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #3168 

1. **Update the prepare script in your package.json:**

Before

```
   "prepare": "husky install"
```
![Screenshot from 2025-01-09 00-53-30](https://github.com/user-attachments/assets/10cd48b8-178f-4a5a-90b3-4a907d618695)


After
```
   "prepare": "husky"
```
![Screenshot from 2025-01-08 22-48-45](https://github.com/user-attachments/assets/b0cd34d0-80a7-4ab3-9511-2852f3f7a002)

Explaination:-

- In Husky versions 8 and above, the husky install command has been deprecated, we don't need to run husky install anymore. Instead, just using husky in the prepare script is enough.
refs
 - https://stackoverflow.com/questions/77897612/problem-when-trying-to-add-prettiers-git-hook-husky-install-error-install-com
 - https://github.com/jenkins-infra/contributor-spotlight/pull/200
 
 2. **Remove deprecated lines from your .husky/pre-commit file**

Before
![Screenshot from 2025-01-09 00-30-31](https://github.com/user-attachments/assets/8202a10f-bd96-405d-b763-8020a41d5f24)

After
![Screenshot from 2025-01-09 00-35-00](https://github.com/user-attachments/assets/8861d40b-1555-470a-93ec-ce3164a840d6)

Explaination:-

```
#!/usr/bin/env sh
. "$(dirname -- "$0")/_/husky.sh"
```
- These are actually deprecated after version 9.1.1 so now we don't require shebang line(#!/usr/bin/env sh) and the sourcing of _/.husky.sh. 

**refs:-**
- https://github.com/typicode/husky/issues/1474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Husky configuration to modify pre-commit hook initialization process.
	- Simplified package preparation script for development environment setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->