### PR TITLE
Fix: update Chat section title to 'Chats'

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1262,6 +1262,7 @@
     "endOfResults": "endOfResults"
   },
   "userChat": {
+    "title": "Chats",
     "add": "Add",
     "chat": "Chat",
     "search": "Search",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -1262,6 +1262,7 @@
     "endOfResults": "Fin des résultats"
   },
   "userChat": {
+    "title": "Discussions",
     "add": "Ajouter",
     "chat": "Chat",
     "contacts": "Contacts",

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -1262,6 +1262,7 @@
     "endOfResults": "परिणाम समाप्त"
   },
   "userChat": {
+    "title": "चैट्स",
     "add": "जोड़ें",
     "chat": "बात करना",
     "contacts": "संपर्क",

--- a/public/locales/sp/translation.json
+++ b/public/locales/sp/translation.json
@@ -1265,6 +1265,7 @@
     "createAdvertisement": "Crear publicidad"
   },
   "userChat": {
+    "title": "Chats",
     "add": "Agregar",
     "chat": "Charlar",
     "search": "Buscar",

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -1262,6 +1262,7 @@
     "endOfResults": "结果结束"
   },
   "userChat": {
+    "title": "聊天",
     "add": "添加",
     "chat": "聊天",
     "contacts": "联系方式",

--- a/src/screens/UserPortal/UserScreen/UserScreen.spec.tsx
+++ b/src/screens/UserPortal/UserScreen/UserScreen.spec.tsx
@@ -130,6 +130,25 @@ describe('UserScreen tests with LeftDrawer functionality', () => {
     expect(titleElement).toHaveTextContent('People');
   });
 
+  it('renders the correct title for chat', () => {
+    mockLocation = '/user/chat/123';
+
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <UserScreen />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    const titleElement = screen.getByRole('heading', { level: 1 });
+    expect(titleElement).toHaveTextContent('Chats');
+  });
+
   it('toggles LeftDrawer correctly based on window size and user interaction', () => {
     render(
       <MockedProvider addTypename={false} link={link}>

--- a/src/screens/UserPortal/UserScreen/UserScreen.tsx
+++ b/src/screens/UserPortal/UserScreen/UserScreen.tsx
@@ -17,6 +17,7 @@ const map: InterfaceMapType = {
   people: 'people',
   events: 'userEvents',
   donate: 'donate',
+  chat: 'userChat',
   campaigns: 'userCampaigns',
   pledges: 'userPledges',
   volunteer: 'userVolunteer',


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**

Fixes #3191 

**Did you add tests for your changes?**

yes

**Snapshots/Videos:**

Before fix:
![Screenshot 2025-01-07 175541](https://github.com/user-attachments/assets/aaa81ccf-7bc0-4744-b4c6-8e2485b2181d)


After Fix :
![Screenshot 2025-01-07 175513](https://github.com/user-attachments/assets/43f37f06-9e7c-4b73-baa9-408db393a9e8)


https://github.com/user-attachments/assets/fcf1918f-cc70-43e2-8680-a65bbfde04f9


**If relevant, did you update the documentation?**

No

**Summary**

This PR fixes the issue where the Chat section was incorrectly displaying "Title" instead of "Chats." The title has been corrected, and tests have been added to ensure this behavior remains consistent.

**Does this PR introduce a breaking change?**

No

**Other information**

None

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localized "Chats" titles for multiple languages (English, French, Hindi, Spanish, Chinese)
  - Implemented chat route mapping in the user screen

- **Tests**
  - Added test case to verify chat title rendering in the user screen

<!-- end of auto-generated comment: release notes by coderabbit.ai -->