### PR TITLE
fix: Update regex to detect all variants of /* istanbul ignore */ comments #3217

### DIFF
--- a/.github/workflows/scripts/code_coverage_disable_check.py
+++ b/.github/workflows/scripts/code_coverage_disable_check.py
@@ -38,10 +38,10 @@ def has_code_coverage_disable(file_path):
         otherwise.
     """
     code_coverage_disable_pattern = re.compile(
-        r"""//?\s*istanbul\s+ignore(?:\s+(?:next|-line))?[^\n]*|
-        /\*\s*istanbul\s+ignore\s+(?:next|-line)\s*\*/""",
-        re.IGNORECASE,
-    )
+    r"""//?\s*istanbul\s+ignore(?:\s+(?:next|-line)(?:\s*--\s*\S*)?)?[^\n]*|
+    /\*\s*istanbul\s+ignore\s+(?:next|-line)(?:\s*--\s*\S*)?\s*\*/""",
+    re.IGNORECASE,
+)
     try:
         with open(file_path, "r", encoding="utf-8") as file:
             content = file.read()

--- a/src/screens/UserPortal/Posts/Posts.spec.tsx
+++ b/src/screens/UserPortal/Posts/Posts.spec.tsx
@@ -16,16 +16,28 @@ import i18nForTest from 'utils/i18nForTest';
 import Home from './Posts';
 import useLocalStorage from 'utils/useLocalstorage';
 import { DELETE_POST_MUTATION } from 'GraphQl/Mutations/mutations';
+import { expect, describe, test, vi } from 'vitest';
 
 const { setItem } = useLocalStorage();
 
-jest.mock('react-toastify', () => ({
+vi.mock('react-toastify', () => ({
   toast: {
-    error: jest.fn(),
-    info: jest.fn(),
-    success: jest.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
   },
 }));
+
+const mockUseParams = vi.fn().mockReturnValue({ orgId: 'orgId' });
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useParams: () => mockUseParams(),
+    useNavigate: () => vi.fn(),
+  };
+});
 
 const MOCKS = [
   {
@@ -262,28 +274,24 @@ const renderHomeScreen = (): RenderResult =>
 
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
-  value: jest.fn().mockImplementation((query) => ({
+  value: vi.fn().mockImplementation((query) => ({
     matches: false,
     media: query,
     onchange: null,
-    addListener: jest.fn(), // Deprecated
-    removeListener: jest.fn(), // Deprecated
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
+    addListener: vi.fn(), // Deprecated
+    removeListener: vi.fn(), // Deprecated
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
   })),
 });
 
 describe('Testing Home Screen: User Portal', () => {
-  beforeAll(() => {
-    jest.mock('react-router-dom', () => ({
-      ...jest.requireActual('react-router-dom'),
-      useParams: () => ({ orgId: 'orgId' }),
-    }));
+  beforeEach(() => {
+    mockUseParams.mockReturnValue({ orgId: 'orgId' });
   });
-
   afterAll(() => {
-    jest.clearAllMocks();
+    vi.clearAllMocks();
   });
 
   test('Check if HomeScreen renders properly', async () => {
@@ -325,7 +333,6 @@ describe('Testing Home Screen: User Portal', () => {
 
     userEvent.type(screen.getByTestId('postInput'), 'some content');
 
-    // Check that the content and image have been added
     expect(screen.getByTestId('postInput')).toHaveValue('some content');
     await screen.findByAltText('Post Image Preview');
     expect(screen.getByAltText('Post Image Preview')).toBeInTheDocument();
@@ -371,11 +378,15 @@ describe('Testing Home Screen: User Portal', () => {
 });
 
 describe('HomeScreen with invalid orgId', () => {
+  beforeEach(() => {
+    mockUseParams.mockReturnValue({ orgId: undefined });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   test('Redirect to /user when organizationId is falsy', async () => {
-    jest.mock('react-router-dom', () => ({
-      ...jest.requireActual('react-router-dom'),
-      useParams: () => ({ orgId: undefined }),
-    }));
     render(
       <MockedProvider addTypename={false} link={link}>
         <MemoryRouter initialEntries={['/user/organization/']}>

--- a/src/screens/UserPortal/Posts/Posts.spec.tsx
+++ b/src/screens/UserPortal/Posts/Posts.spec.tsx
@@ -16,7 +16,7 @@ import i18nForTest from 'utils/i18nForTest';
 import Home from './Posts';
 import useLocalStorage from 'utils/useLocalstorage';
 import { DELETE_POST_MUTATION } from 'GraphQl/Mutations/mutations';
-import { expect, describe, test, vi } from 'vitest';
+import { expect, describe, it, vi } from 'vitest';
 
 const { setItem } = useLocalStorage();
 
@@ -294,7 +294,7 @@ describe('Testing Home Screen: User Portal', () => {
     vi.clearAllMocks();
   });
 
-  test('Check if HomeScreen renders properly', async () => {
+  it('Check if HomeScreen renders properly', async () => {
     renderHomeScreen();
 
     await wait();
@@ -302,7 +302,7 @@ describe('Testing Home Screen: User Portal', () => {
     expect(startPostBtn).toBeInTheDocument();
   });
 
-  test('StartPostModal should render on click of StartPost btn', async () => {
+  it('StartPostModal should render on click of StartPost btn', async () => {
     renderHomeScreen();
 
     await wait();
@@ -314,7 +314,7 @@ describe('Testing Home Screen: User Portal', () => {
     expect(startPostModal).toBeInTheDocument();
   });
 
-  test('StartPostModal should close on clicking the close button', async () => {
+  it('StartPostModal should close on clicking the close button', async () => {
     renderHomeScreen();
 
     await wait();
@@ -349,7 +349,7 @@ describe('Testing Home Screen: User Portal', () => {
     expect(screen.getByTestId('postImageInput')).toHaveValue('');
   });
 
-  test('Check whether Posts render in PostCard', async () => {
+  it('Check whether Posts render in PostCard', async () => {
     setItem('userId', '640d98d9eb6a743d75341067');
     renderHomeScreen();
     await wait();
@@ -366,7 +366,7 @@ describe('Testing Home Screen: User Portal', () => {
     expect(screen.queryByText('This is the post two')).toBeInTheDocument();
   });
 
-  test('Checking if refetch works after deleting this post', async () => {
+  it('Checking if refetch works after deleting this post', async () => {
     setItem('userId', '640d98d9eb6a743d75341067');
     renderHomeScreen();
     expect(screen.queryAllByTestId('dropdown')).not.toBeNull();
@@ -386,7 +386,7 @@ describe('HomeScreen with invalid orgId', () => {
     vi.clearAllMocks();
   });
 
-  test('Redirect to /user when organizationId is falsy', async () => {
+  it('Redirect to /user when organizationId is falsy', async () => {
     render(
       <MockedProvider addTypename={false} link={link}>
         <MemoryRouter initialEntries={['/user/organization/']}>


### PR DESCRIPTION
Issue Number:

Fixes https://github.com/PalisadoesFoundation/talawa-admin/issues/3211

Description:
What Changed:
The regular expression in the code_coverage_disable_check.py script has been updated to ensure that all variants of the /* istanbul ignore */ comment are detected. This includes:
/* istanbul ignore */
/* istanbul ignore next */
/* istanbul ignore line */
/* istanbul ignore next -- @preserve */

Snapshots/Videos: dummy test files to check that its working or not 
![Screenshot 2025-01-09 185826](https://github.com/user-attachments/assets/86aea976-76f6-4275-9007-0e3ed23e07e8)

If relevant, did you update the documentation?

N/A

Does this PR introduce a breaking change?

No

Other information

N/A