### PR TITLE
fix: Update regex to detect all variants of /* istanbul ignore */ comments #3217 

### DIFF
--- a/.github/workflows/scripts/code_coverage_disable_check.py
+++ b/.github/workflows/scripts/code_coverage_disable_check.py
@@ -38,10 +38,9 @@ def has_code_coverage_disable(file_path):
         otherwise.
     """
     code_coverage_disable_pattern = re.compile(
-    r"""//?\s*istanbul\s+ignore(?:\s+(?:next|line)(?:\s*--\s*\S*)?)?[^\n]*|
-    /\*.*istanbul\s+ignore(?:\s+(?:next|line)(?:\s*--\s*\S*)?)?.*\*/""",
-    re.IGNORECASE,
-)
+        r"/\*\s*istanbul\s+ignore.*?\*/|//?\s*istanbul\s+ignore(?:\s+(?:next|-line))?[^\n]*",
+        re.IGNORECASE,
+    )
 
 
     try:

--- a/.github/workflows/scripts/code_coverage_disable_check.py
+++ b/.github/workflows/scripts/code_coverage_disable_check.py
@@ -38,10 +38,10 @@ def has_code_coverage_disable(file_path):
         otherwise.
     """
     code_coverage_disable_pattern = re.compile(
-        r"""//?\s*istanbul\s+ignore(?:\s+(?:next|-line))?[^\n]*|
-        /\*\s*istanbul\s+ignore\s+(?:next|-line)\s*\*/""",
-        re.IGNORECASE,
-    )
+        r"""//?\s*istanbul\s+ignore(?:\s+(?:next|-line)(?:\s*--\s*\S*)?)?[^\n]*|
+    /\*\s*istanbul\s+ignore\s+(?:next|-line)(?:\s*--\s*\S*)?\s*\*/""",
+    re.IGNORECASE,
+)
     try:
         with open(file_path, "r", encoding="utf-8") as file:
             content = file.read()

--- a/.github/workflows/scripts/code_coverage_disable_check.py
+++ b/.github/workflows/scripts/code_coverage_disable_check.py
@@ -39,9 +39,10 @@ def has_code_coverage_disable(file_path):
     """
     code_coverage_disable_pattern = re.compile(
     r"""//?\s*istanbul\s+ignore(?:\s+(?:next|line)(?:\s*--\s*\S*)?)?[^\n]*|
-    /\*\s*istanbul\s+ignore(?:\s+(?:next|line)(?:\s*--\s*\S*)?)?\s*\*/""",
+    /\*.*istanbul\s+ignore(?:\s+(?:next|line)(?:\s*--\s*\S*)?)?.*\*/""",
     re.IGNORECASE,
 )
+
 
     try:
         with open(file_path, "r", encoding="utf-8") as file:

--- a/.github/workflows/scripts/code_coverage_disable_check.py
+++ b/.github/workflows/scripts/code_coverage_disable_check.py
@@ -38,10 +38,11 @@ def has_code_coverage_disable(file_path):
         otherwise.
     """
     code_coverage_disable_pattern = re.compile(
-        r"""//?\s*istanbul\s+ignore(?:\s+(?:next|-line)(?:\s*--\s*\S*)?)?[^\n]*|
-    /\*\s*istanbul\s+ignore\s+(?:next|-line)(?:\s*--\s*\S*)?\s*\*/""",
+    r"""//?\s*istanbul\s+ignore(?:\s+(?:next|line)(?:\s*--\s*\S*)?)?[^\n]*|
+    /\*\s*istanbul\s+ignore(?:\s+(?:next|line)(?:\s*--\s*\S*)?)?\s*\*/""",
     re.IGNORECASE,
 )
+
     try:
         with open(file_path, "r", encoding="utf-8") as file:
             content = file.read()


### PR DESCRIPTION
Issue Number:

Fixes https://github.com/PalisadoesFoundation/talawa-admin/issues/3217

Description:
What Changed:
The regular expression in the code_coverage_disable_check.py script has been updated to ensure that all variants of the /* istanbul ignore / comment are detected. This includes:
/ istanbul ignore /
/ istanbul ignore next /
/ istanbul ignore line /
/ istanbul ignore next -- https://github.com/preserve */

Snapshots/Videos: dummy test files to check that its working or not
![Screenshot 2025-01-09 185826](https://github.com/user-attachments/assets/9d8e6b79-311c-4aed-a829-2e69e7591df1)


If relevant, did you update the documentation?

N/A

Does this PR introduce a breaking change?

No

Other information

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated code coverage disable detection script to improve regex pattern matching for TypeScript files.
	- Enhanced flexibility in identifying code coverage disable statements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->