### PR TITLE
implemented a 'Visit' button for the Joined Organizations filter in the Talawa User Portal

### DIFF
--- a/src/components/OrganizationCard/OrganizationCard.spec.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.spec.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MockedProvider } from '@apollo/client/testing';
+import { BrowserRouter } from 'react-router-dom';
+import { I18nextProvider } from 'react-i18next';
 import OrganizationCard from './OrganizationCard';
+import i18nForTest from 'utils/i18nForTest';
 
 /**
  * This file contains unit tests for the `OrganizationCard` component.
@@ -12,38 +16,196 @@ import OrganizationCard from './OrganizationCard';
  * These tests utilize the React Testing Library for rendering and querying DOM elements.
  */
 
-describe('Testing the Organization Card', () => {
-  it('should render props and text elements test for the page component', () => {
-    const props = {
-      id: '123',
-      image: 'https://via.placeholder.com/80',
-      firstName: 'John',
-      lastName: 'Doe',
-      name: 'Sample',
-    };
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
 
-    render(<OrganizationCard {...props} />);
+const defaultProps = {
+  id: '123',
+  name: 'Test Organization',
+  image: 'test-image.jpg',
+  description: 'Test Description',
+  admins: [{ id: '1' }],
+  members: [{ id: '1' }, { id: '2' }],
+  address: {
+    city: 'Test City',
+    countryCode: 'TC',
+    line1: 'Test Line 1',
+    postalCode: '12345',
+    state: 'Test State',
+  },
+  userRegistrationRequired: false,
+  membershipRequests: [],
+};
 
-    expect(screen.getByText(props.name)).toBeInTheDocument();
-    expect(screen.getByText(/Owner:/i)).toBeInTheDocument();
-    expect(screen.getByText(props.firstName)).toBeInTheDocument();
-    expect(screen.getByText(props.lastName)).toBeInTheDocument();
+describe('OrganizationCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
   });
 
-  it('Should render text elements when props value is not passed', () => {
-    const props = {
-      id: '123',
+  test('renders organization card with image', () => {
+    render(
+      <MockedProvider>
+        <BrowserRouter>
+          <I18nextProvider i18n={i18nForTest}>
+            <OrganizationCard {...defaultProps} membershipRequestStatus="" />
+          </I18nextProvider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    expect(screen.getByText(defaultProps.name)).toBeInTheDocument();
+    expect(screen.getByText(/admins: 1/i)).toBeInTheDocument();
+    expect(screen.getByText(/members: 2/i)).toBeInTheDocument();
+    expect(screen.getByRole('img')).toBeInTheDocument();
+  });
+
+  test('renders organization card without image', () => {
+    const propsWithoutImage = {
+      ...defaultProps,
       image: '',
-      firstName: 'John',
-      lastName: 'Doe',
-      name: 'Sample',
     };
 
-    render(<OrganizationCard {...props} />);
+    render(
+      <MockedProvider>
+        <BrowserRouter>
+          <I18nextProvider i18n={i18nForTest}>
+            <OrganizationCard
+              {...propsWithoutImage}
+              membershipRequestStatus=""
+            />
+          </I18nextProvider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
 
-    expect(screen.getByText(props.name)).toBeInTheDocument();
-    expect(screen.getByText(/Owner:/i)).toBeInTheDocument();
-    expect(screen.getByText(props.firstName)).toBeInTheDocument();
-    expect(screen.getByText(props.lastName)).toBeInTheDocument();
+    expect(screen.getByTestId('emptyContainerForImage')).toBeInTheDocument();
+  });
+
+  test('renders "Join Now" button when membershipRequestStatus is empty', () => {
+    render(
+      <MockedProvider>
+        <BrowserRouter>
+          <I18nextProvider i18n={i18nForTest}>
+            <OrganizationCard {...defaultProps} membershipRequestStatus="" />
+          </I18nextProvider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    expect(screen.getByTestId('joinBtn')).toBeInTheDocument();
+  });
+
+  test('renders "Visit" button when membershipRequestStatus is accepted', () => {
+    render(
+      <MockedProvider>
+        <BrowserRouter>
+          <I18nextProvider i18n={i18nForTest}>
+            <OrganizationCard
+              {...defaultProps}
+              membershipRequestStatus="accepted"
+            />
+          </I18nextProvider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    const visitButton = screen.getByTestId('manageBtn');
+    expect(visitButton).toBeInTheDocument();
+
+    fireEvent.click(visitButton);
+    expect(mockNavigate).toHaveBeenCalledWith('/user/organization/123');
+  });
+
+  test('renders "Withdraw" button when membershipRequestStatus is pending', () => {
+    render(
+      <MockedProvider>
+        <BrowserRouter>
+          <I18nextProvider i18n={i18nForTest}>
+            <OrganizationCard
+              {...defaultProps}
+              membershipRequestStatus="pending"
+            />
+          </I18nextProvider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    expect(screen.getByTestId('withdrawBtn')).toBeInTheDocument();
+  });
+
+  test('displays address when provided', () => {
+    render(
+      <MockedProvider>
+        <BrowserRouter>
+          <I18nextProvider i18n={i18nForTest}>
+            <OrganizationCard {...defaultProps} membershipRequestStatus="" />
+          </I18nextProvider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    expect(screen.getByText(/Test City/i)).toBeInTheDocument();
+    expect(screen.getByText(/TC/i)).toBeInTheDocument();
+  });
+
+  test('displays organization description', () => {
+    render(
+      <MockedProvider>
+        <BrowserRouter>
+          <I18nextProvider i18n={i18nForTest}>
+            <OrganizationCard {...defaultProps} membershipRequestStatus="" />
+          </I18nextProvider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    expect(screen.getByText('Test Description')).toBeInTheDocument();
+  });
+
+  test('displays correct button based on membership status', () => {
+    // Test for empty status (Join Now button)
+    const { rerender } = render(
+      <MockedProvider>
+        <BrowserRouter>
+          <I18nextProvider i18n={i18nForTest}>
+            <OrganizationCard {...defaultProps} membershipRequestStatus="" />
+          </I18nextProvider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+    expect(screen.getByTestId('joinBtn')).toBeInTheDocument();
+
+    // Test for accepted status (Visit button)
+    rerender(
+      <MockedProvider>
+        <BrowserRouter>
+          <I18nextProvider i18n={i18nForTest}>
+            <OrganizationCard
+              {...defaultProps}
+              membershipRequestStatus="accepted"
+            />
+          </I18nextProvider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+    expect(screen.getByTestId('manageBtn')).toBeInTheDocument();
+
+    // Test for pending status (Withdraw button)
+    rerender(
+      <MockedProvider>
+        <BrowserRouter>
+          <I18nextProvider i18n={i18nForTest}>
+            <OrganizationCard
+              {...defaultProps}
+              membershipRequestStatus="pending"
+            />
+          </I18nextProvider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+    expect(screen.getByTestId('withdrawBtn')).toBeInTheDocument();
   });
 });

--- a/src/components/OrganizationCard/OrganizationCard.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.tsx
@@ -1,56 +1,236 @@
 import React from 'react';
 import styles from './OrganizationCard.module.css';
+import { Button } from 'react-bootstrap';
+import { Tooltip } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
+import {
+  CANCEL_MEMBERSHIP_REQUEST,
+  JOIN_PUBLIC_ORGANIZATION,
+  SEND_MEMBERSHIP_REQUEST,
+} from 'GraphQl/Mutations/OrganizationMutations';
+import { useMutation, useQuery } from '@apollo/client';
+import {
+  USER_JOINED_ORGANIZATIONS,
+  USER_ORGANIZATION_CONNECTION,
+} from 'GraphQl/Queries/OrganizationQueries';
+import useLocalStorage from 'utils/useLocalstorage';
+import Avatar from 'components/Avatar/Avatar';
+import { useNavigate } from 'react-router-dom';
+
+const { getItem } = useLocalStorage();
 
 interface InterfaceOrganizationCardProps {
-  image: string;
   id: string;
   name: string;
-  lastName: string;
-  firstName: string;
+  image: string;
+  description: string;
+  admins: {
+    id: string;
+  }[];
+  members: {
+    id: string;
+  }[];
+  address: {
+    city: string;
+    countryCode: string;
+    line1: string;
+    postalCode: string;
+    state: string;
+  };
+  membershipRequestStatus: string;
+  userRegistrationRequired: boolean;
+  membershipRequests: {
+    _id: string;
+    user: {
+      _id: string;
+    };
+  }[];
 }
 
 /**
- * Component to display an organization's card with its image and owner details.
+ * Displays an organization card with options to join or manage membership.
  *
- * @param props - Properties for the organization card.
- * @returns JSX element representing the organization card.
+ * Shows the organization's name, image, description, address, number of admins and members,
+ * and provides buttons for joining, withdrawing membership requests, or visiting the organization page.
+ *
+ * @param props - The properties for the organization card.
+ * @param id - The unique identifier of the organization.
+ * @param name - The name of the organization.
+ * @param image - The URL of the organization's image.
+ * @param description - A description of the organization.
+ * @param admins - The list of admins with their IDs.
+ * @param members - The list of members with their IDs.
+ * @param address - The address of the organization including city, country code, line1, postal code, and state.
+ * @param membershipRequestStatus - The status of the membership request (accepted, pending, or empty).
+ * @param userRegistrationRequired - Indicates if user registration is required to join the organization.
+ * @param membershipRequests - The list of membership requests with user IDs.
+ *
+ * @returns The organization card component.
  */
-function OrganizationCard(props: InterfaceOrganizationCardProps): JSX.Element {
-  const uri = '/superorghome/i=' + props.id;
+const userId: string | null = getItem('userId');
+
+function organizationCard(props: InterfaceOrganizationCardProps): JSX.Element {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'users',
+  });
+  const { t: tCommon } = useTranslation('common');
+
+  const navigate = useNavigate();
+
+  // Mutations for handling organization memberships
+  const [sendMembershipRequest] = useMutation(SEND_MEMBERSHIP_REQUEST, {
+    refetchQueries: [
+      { query: USER_ORGANIZATION_CONNECTION, variables: { id: props.id } },
+    ],
+  });
+  const [joinPublicOrganization] = useMutation(JOIN_PUBLIC_ORGANIZATION, {
+    refetchQueries: [
+      { query: USER_ORGANIZATION_CONNECTION, variables: { id: props.id } },
+    ],
+  });
+  const [cancelMembershipRequest] = useMutation(CANCEL_MEMBERSHIP_REQUEST, {
+    refetchQueries: [
+      { query: USER_ORGANIZATION_CONNECTION, variables: { id: props.id } },
+    ],
+  });
+  const { refetch } = useQuery(USER_JOINED_ORGANIZATIONS, {
+    variables: { id: userId },
+  });
+
+  /**
+   * Handles joining the organization. Sends a membership request if registration is required,
+   * otherwise joins the public organization directly. Displays success or error messages.
+   */
+  async function joinOrganization(): Promise<void> {
+    try {
+      if (props.userRegistrationRequired) {
+        await sendMembershipRequest({
+          variables: {
+            organizationId: props.id,
+          },
+        });
+        toast.success(t('MembershipRequestSent') as string);
+      } else {
+        await joinPublicOrganization({
+          variables: {
+            organizationId: props.id,
+          },
+        });
+        toast.success(t('orgJoined') as string);
+      }
+      refetch();
+    } catch (error: unknown) {
+      /* istanbul ignore next */
+      if (error instanceof Error) {
+        const graphQLError = error as { code?: string };
+
+        if (graphQLError.code === 'ALREADY_MEMBER') {
+          toast.error(t('AlreadyJoined') as string);
+        } else {
+          toast.error(t('errorOccured') as string);
+        }
+      }
+    }
+  }
+
+  /**
+   * Handles withdrawing a membership request. Finds the request for the current user and cancels it.
+   */
+  async function withdrawMembershipRequest(): Promise<void> {
+    const membershipRequest = props.membershipRequests.find(
+      (request) => request.user._id === userId,
+    );
+
+    if (!membershipRequest) {
+      toast.error(t('MembershipRequestNotFound') as string);
+      return;
+    }
+
+    await cancelMembershipRequest({
+      variables: {
+        membershipRequestId: membershipRequest._id,
+      },
+    });
+  }
 
   return (
-    <a href={uri}>
-      <div className={styles.box}>
-        <div className={styles.first_box}>
-          {props.image ? (
-            <img
-              src={props.image}
-              className={styles.alignimg}
-              alt="Organization"
-            />
-          ) : (
-            <img
-              src="https://via.placeholder.com/80"
-              className={styles.alignimg}
-              alt="Placeholder"
-            />
-          )}
-          <div className={styles.second_box}>
-            <h4>{props.name}</h4>
-            <h5>
-              Owner:
-              <span>{props.firstName}</span>
-              <span>
-                &nbsp;
-                {props.lastName}
-              </span>
-            </h5>
+    <>
+      <div className={styles.orgCard}>
+        <div className={styles.innerContainer}>
+          <div className={styles.orgImgContainer}>
+            {props.image ? (
+              <img src={props.image} alt={`${props.name} image`} />
+            ) : (
+              <Avatar
+                name={props.name}
+                alt={`${props.name} image`}
+                dataTestId="emptyContainerForImage"
+              />
+            )}
+          </div>
+          <div className={styles.content}>
+            <Tooltip title={props.name} placement="top-end">
+              <h4 className={`${styles.orgName} fw-semibold`}>{props.name}</h4>
+            </Tooltip>
+            <h6 className={`${styles.orgdesc} fw-semibold`}>
+              <span>{props.description}</span>
+            </h6>
+            {props.address && props.address.city && (
+              <div className={styles.address}>
+                <h6 className="text-secondary">
+                  <span className="address-line">{props.address.line1}, </span>
+                  <span className="address-line">{props.address.city}, </span>
+                  <span className="address-line">
+                    {props.address.countryCode}
+                  </span>
+                </h6>
+              </div>
+            )}
+            <h6 className={styles.orgadmin}>
+              {tCommon('admins')}: <span>{props.admins?.length}</span> &nbsp;
+              &nbsp; &nbsp; {tCommon('members')}:{' '}
+              <span>{props.members?.length}</span>
+            </h6>
           </div>
         </div>
-        <div className={styles.deco}></div>
+        {props.membershipRequestStatus === 'accepted' && (
+          <Button
+            variant="success"
+            data-testid="manageBtn"
+            className={styles.joinedBtn}
+            onClick={() => {
+              navigate(`/user/organization/${props.id}`);
+            }}
+          >
+            {t('visit')}
+          </Button>
+        )}
+
+        {props.membershipRequestStatus === 'pending' && (
+          <Button
+            variant="danger"
+            onClick={withdrawMembershipRequest}
+            data-testid="withdrawBtn"
+            className={styles.withdrawBtn}
+          >
+            {t('withdraw')}
+          </Button>
+        )}
+
+        {props.membershipRequestStatus === '' && (
+          <Button
+            onClick={joinOrganization}
+            data-testid="joinBtn"
+            className={styles.joinBtn}
+            variant="outline-success"
+          >
+            {t('joinNow')}
+          </Button>
+        )}
       </div>
-    </a>
+    </>
   );
 }
 
-export default OrganizationCard;
+export default organizationCard;

--- a/src/components/OrganizationCard/OrganizationCard.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react/destructuring-assignment */
 import React from 'react';
 import styles from './OrganizationCard.module.css';
 import { Button } from 'react-bootstrap';
@@ -9,16 +10,15 @@ import {
   JOIN_PUBLIC_ORGANIZATION,
   SEND_MEMBERSHIP_REQUEST,
 } from 'GraphQl/Mutations/OrganizationMutations';
-import { useMutation, useQuery } from '@apollo/client';
+import { useMutation, useQuery, ApolloError } from '@apollo/client';
 import {
   USER_JOINED_ORGANIZATIONS,
   USER_ORGANIZATION_CONNECTION,
 } from 'GraphQl/Queries/OrganizationQueries';
-import useLocalStorage from 'utils/useLocalstorage';
 import Avatar from 'components/Avatar/Avatar';
 import { useNavigate } from 'react-router-dom';
 
-const { getItem } = useLocalStorage();
+import { useLocalStorage } from 'utils/useLocalstorage';
 
 interface InterfaceOrganizationCardProps {
   id: string;
@@ -48,29 +48,21 @@ interface InterfaceOrganizationCardProps {
   }[];
 }
 
-/**
- * Displays an organization card with options to join or manage membership.
- *
- * Shows the organization's name, image, description, address, number of admins and members,
- * and provides buttons for joining, withdrawing membership requests, or visiting the organization page.
- *
- * @param props - The properties for the organization card.
- * @param id - The unique identifier of the organization.
- * @param name - The name of the organization.
- * @param image - The URL of the organization's image.
- * @param description - A description of the organization.
- * @param admins - The list of admins with their IDs.
- * @param members - The list of members with their IDs.
- * @param address - The address of the organization including city, country code, line1, postal code, and state.
- * @param membershipRequestStatus - The status of the membership request (accepted, pending, or empty).
- * @param userRegistrationRequired - Indicates if user registration is required to join the organization.
- * @param membershipRequests - The list of membership requests with user IDs.
- *
- * @returns The organization card component.
- */
-const userId: string | null = getItem('userId');
+function OrganizationCard({
+  id,
+  name,
+  image,
+  description,
+  admins,
+  members,
+  address,
+  membershipRequestStatus,
+  userRegistrationRequired,
+  membershipRequests,
+}: InterfaceOrganizationCardProps): JSX.Element {
+  const { getItem } = useLocalStorage();
+  const userId = getItem('userId');
 
-function organizationCard(props: InterfaceOrganizationCardProps): JSX.Element {
   const { t } = useTranslation('translation', {
     keyPrefix: 'users',
   });
@@ -78,159 +70,153 @@ function organizationCard(props: InterfaceOrganizationCardProps): JSX.Element {
 
   const navigate = useNavigate();
 
-  // Mutations for handling organization memberships
   const [sendMembershipRequest] = useMutation(SEND_MEMBERSHIP_REQUEST, {
     refetchQueries: [
-      { query: USER_ORGANIZATION_CONNECTION, variables: { id: props.id } },
+      { query: USER_ORGANIZATION_CONNECTION, variables: { id } },
     ],
   });
+
   const [joinPublicOrganization] = useMutation(JOIN_PUBLIC_ORGANIZATION, {
     refetchQueries: [
-      { query: USER_ORGANIZATION_CONNECTION, variables: { id: props.id } },
+      { query: USER_ORGANIZATION_CONNECTION, variables: { id } },
     ],
   });
+
   const [cancelMembershipRequest] = useMutation(CANCEL_MEMBERSHIP_REQUEST, {
     refetchQueries: [
-      { query: USER_ORGANIZATION_CONNECTION, variables: { id: props.id } },
+      { query: USER_ORGANIZATION_CONNECTION, variables: { id } },
     ],
   });
+
   const { refetch } = useQuery(USER_JOINED_ORGANIZATIONS, {
     variables: { id: userId },
   });
 
-  /**
-   * Handles joining the organization. Sends a membership request if registration is required,
-   * otherwise joins the public organization directly. Displays success or error messages.
-   */
   async function joinOrganization(): Promise<void> {
     try {
-      if (props.userRegistrationRequired) {
+      if (userRegistrationRequired) {
         await sendMembershipRequest({
           variables: {
-            organizationId: props.id,
+            organizationId: id,
           },
         });
-        toast.success(t('MembershipRequestSent') as string);
+        toast.success(t('MembershipRequestSent'));
       } else {
         await joinPublicOrganization({
           variables: {
-            organizationId: props.id,
+            organizationId: id,
           },
         });
-        toast.success(t('orgJoined') as string);
+        toast.success(t('orgJoined'));
       }
       refetch();
     } catch (error: unknown) {
-      /* istanbul ignore next */
-      if (error instanceof Error) {
-        const graphQLError = error as { code?: string };
-
-        if (graphQLError.code === 'ALREADY_MEMBER') {
-          toast.error(t('AlreadyJoined') as string);
+      if (error instanceof ApolloError) {
+        const errorCode = error.graphQLErrors[0]?.extensions?.code;
+        if (errorCode === 'ALREADY_MEMBER') {
+          toast.error(t('AlreadyJoined'));
         } else {
-          toast.error(t('errorOccured') as string);
+          toast.error(t('errorOccured'));
         }
       }
     }
   }
 
-  /**
-   * Handles withdrawing a membership request. Finds the request for the current user and cancels it.
-   */
   async function withdrawMembershipRequest(): Promise<void> {
-    const membershipRequest = props.membershipRequests.find(
-      (request) => request.user._id === userId,
-    );
+    try {
+      const membershipRequest = membershipRequests.find(
+        (request) => request.user._id === userId,
+      );
 
-    if (!membershipRequest) {
-      toast.error(t('MembershipRequestNotFound') as string);
-      return;
+      if (!membershipRequest) {
+        toast.error(t('MembershipRequestNotFound'));
+        return;
+      }
+
+      await cancelMembershipRequest({
+        variables: {
+          membershipRequestId: membershipRequest._id,
+        },
+      });
+      toast.success(t('MembershipRequestWithdrawn'));
+    } catch (error: unknown) {
+      console.error(error);
+      toast.error(t('errorOccured'));
     }
-
-    await cancelMembershipRequest({
-      variables: {
-        membershipRequestId: membershipRequest._id,
-      },
-    });
   }
 
   return (
-    <>
-      <div className={styles.orgCard}>
-        <div className={styles.innerContainer}>
-          <div className={styles.orgImgContainer}>
-            {props.image ? (
-              <img src={props.image} alt={`${props.name} image`} />
-            ) : (
-              <Avatar
-                name={props.name}
-                alt={`${props.name} image`}
-                dataTestId="emptyContainerForImage"
-              />
-            )}
-          </div>
-          <div className={styles.content}>
-            <Tooltip title={props.name} placement="top-end">
-              <h4 className={`${styles.orgName} fw-semibold`}>{props.name}</h4>
-            </Tooltip>
-            <h6 className={`${styles.orgdesc} fw-semibold`}>
-              <span>{props.description}</span>
-            </h6>
-            {props.address && props.address.city && (
-              <div className={styles.address}>
-                <h6 className="text-secondary">
-                  <span className="address-line">{props.address.line1}, </span>
-                  <span className="address-line">{props.address.city}, </span>
-                  <span className="address-line">
-                    {props.address.countryCode}
-                  </span>
-                </h6>
-              </div>
-            )}
-            <h6 className={styles.orgadmin}>
-              {tCommon('admins')}: <span>{props.admins?.length}</span> &nbsp;
-              &nbsp; &nbsp; {tCommon('members')}:{' '}
-              <span>{props.members?.length}</span>
-            </h6>
-          </div>
+    <div className={styles.orgCard}>
+      <div className={styles.innerContainer}>
+        <div className={styles.orgImgContainer}>
+          {image ? (
+            <img src={image} alt={`${name} image`} />
+          ) : (
+            <Avatar
+              name={name}
+              alt={`${name} image`}
+              dataTestId="emptyContainerForImage"
+            />
+          )}
         </div>
-        {props.membershipRequestStatus === 'accepted' && (
-          <Button
-            variant="success"
-            data-testid="manageBtn"
-            className={styles.joinedBtn}
-            onClick={() => {
-              navigate(`/user/organization/${props.id}`);
-            }}
-          >
-            {t('visit')}
-          </Button>
-        )}
-
-        {props.membershipRequestStatus === 'pending' && (
-          <Button
-            variant="danger"
-            onClick={withdrawMembershipRequest}
-            data-testid="withdrawBtn"
-            className={styles.withdrawBtn}
-          >
-            {t('withdraw')}
-          </Button>
-        )}
-
-        {props.membershipRequestStatus === '' && (
-          <Button
-            onClick={joinOrganization}
-            data-testid="joinBtn"
-            className={styles.joinBtn}
-            variant="outline-success"
-          >
-            {t('joinNow')}
-          </Button>
-        )}
+        <div className={styles.content}>
+          <Tooltip title={name} placement="top-end">
+            <h4 className={`${styles.orgName} fw-semibold`}>{name}</h4>
+          </Tooltip>
+          <h6 className={`${styles.orgdesc} fw-semibold`}>
+            <span>{description}</span>
+          </h6>
+          {address && address.city && (
+            <div className={styles.address}>
+              <h6 className="text-secondary">
+                <span className="address-line">{address.line1}, </span>
+                <span className="address-line">{address.city}, </span>
+                <span className="address-line">{address.countryCode}</span>
+              </h6>
+            </div>
+          )}
+          <h6 className={styles.orgadmin}>
+            {tCommon('admins')}: <span>{admins?.length}</span> &nbsp; &nbsp;
+            &nbsp; {tCommon('members')}: <span>{members?.length}</span>
+          </h6>
+        </div>
       </div>
-    </>
+      {membershipRequestStatus === 'accepted' && (
+        <Button
+          variant="success"
+          data-testid="manageBtn"
+          className={styles.joinedBtn}
+          onClick={() => {
+            navigate(`/user/organization/${id}`);
+          }}
+        >
+          {t('visit')}
+        </Button>
+      )}
+
+      {membershipRequestStatus === 'pending' && (
+        <Button
+          variant="danger"
+          onClick={withdrawMembershipRequest}
+          data-testid="withdrawBtn"
+          className={styles.withdrawBtn}
+        >
+          {t('withdraw')}
+        </Button>
+      )}
+
+      {membershipRequestStatus === '' && (
+        <Button
+          onClick={joinOrganization}
+          data-testid="joinBtn"
+          className={styles.joinBtn}
+          variant="outline-success"
+        >
+          {t('joinNow')}
+        </Button>
+      )}
+    </div>
   );
 }
 
-export default organizationCard;
+export default OrganizationCard;

--- a/src/screens/UserPortal/Organizations/Organizations.tsx
+++ b/src/screens/UserPortal/Organizations/Organizations.tsx
@@ -251,7 +251,11 @@ export default function organizations(): JSX.Element {
               )
             )
               membershipRequestStatus = 'pending';
-            return { ...organization, membershipRequestStatus };
+            return {
+              ...organization,
+              membershipRequestStatus,
+              isJoined: false,
+            };
           },
         );
         setOrganizations(organizations);
@@ -259,7 +263,13 @@ export default function organizations(): JSX.Element {
     } else if (mode === 1) {
       if (joinedOrganizationsData && joinedOrganizationsData.users.length > 0) {
         const organizations =
-          joinedOrganizationsData.users[0]?.user?.joinedOrganizations || [];
+          joinedOrganizationsData.users[0]?.user?.joinedOrganizations.map(
+            (org: InterfaceOrganization) => ({
+              ...org,
+              membershipRequestStatus: 'accepted',
+              isJoined: true,
+            }),
+          ) || [];
         setOrganizations(organizations);
       }
     } else if (mode === 2) {
@@ -268,8 +278,13 @@ export default function organizations(): JSX.Element {
         createdOrganizationsData.users.length > 0
       ) {
         const organizations =
-          createdOrganizationsData.users[0]?.appUserProfile
-            ?.createdOrganizations || [];
+          createdOrganizationsData.users[0]?.appUserProfile?.createdOrganizations.map(
+            (org: InterfaceOrganization) => ({
+              ...org,
+              membershipRequestStatus: 'accepted',
+              isJoined: true,
+            }),
+          ) || [];
         setOrganizations(organizations);
       }
     }

--- a/src/screens/UserPortal/Organizations/Organizations.tsx
+++ b/src/screens/UserPortal/Organizations/Organizations.tsx
@@ -254,7 +254,7 @@ export default function organizations(): JSX.Element {
             return {
               ...organization,
               membershipRequestStatus,
-              isJoined: false,
+              isJoined: membershipRequestStatus === 'accepted',
             };
           },
         );


### PR DESCRIPTION
# Pull Request for the Talawa User Portal

**What kind of change does this PR introduce?**  
Feature  

**Issue Number:**  
Fixes #3162 

**Did you add tests for your changes?**  
No

**Snapshots/Videos:**  

https://github.com/user-attachments/assets/74973d6f-88c6-4780-9b2e-a6bc0b4fa5fd


**Summary**  
This PR introduces a 'Visit' button in the Joined Organizations filter.  
- Enhances the user experience by providing direct navigation to organizations from the filter.  
- Solves the issue of limited navigation options in the Joined Organizations section.  

**Does this PR introduce a breaking change?**  
No  

**Other information**  
The feature was tested in multiple scenarios to ensure seamless functionality.  

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**  
Yes  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced organization card with detailed membership management options.
	- Added support for displaying organization details such as address and description.
	- Implemented dynamic membership request buttons based on user status.
	- Introduced a user membership status indicator in the organization data.

- **Bug Fixes**
	- Improved handling of user interactions with organization membership requests.
	- Added error handling for various membership request scenarios.

- **Refactor**
	- Updated organization data processing logic to include user membership status.
	- Restructured organization card component for improved readability and maintainability.
	- Enhanced unit tests for the organization card to cover more scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->