### PR TITLE
Fixed LeftDrawerOrg Visibility

### DIFF
--- a/src/components/LeftDrawer/LeftDrawer.spec.tsx
+++ b/src/components/LeftDrawer/LeftDrawer.spec.tsx
@@ -220,4 +220,40 @@ describe('Testing Left Drawer component for ADMIN', () => {
 
     expect(global.window.location.pathname).toContain('/orglist');
   });
+
+  it('Should set hideDrawer to false when initially null', async () => {
+    const mockSetHideDrawer = vi.fn();
+    await act(async () => {
+      render(
+        <MockedProvider addTypename={false} link={link}>
+          <BrowserRouter>
+            <I18nextProvider i18n={i18nForTest}>
+              <LeftDrawer hideDrawer={null} setHideDrawer={mockSetHideDrawer} />
+            </I18nextProvider>
+          </BrowserRouter>
+        </MockedProvider>,
+      );
+    });
+    expect(mockSetHideDrawer).toHaveBeenCalledWith(false);
+    expect(mockSetHideDrawer).toHaveBeenCalledTimes(1);
+  });
+
+  it('Should not call setHideDrawer when hideDrawer has a value', async () => {
+    const mockSetHideDrawer = vi.fn();
+    await act(async () => {
+      render(
+        <MockedProvider addTypename={false} link={link}>
+          <BrowserRouter>
+            <I18nextProvider i18n={i18nForTest}>
+              <LeftDrawer
+                hideDrawer={false}
+                setHideDrawer={mockSetHideDrawer}
+              />
+            </I18nextProvider>
+          </BrowserRouter>
+        </MockedProvider>,
+      );
+    });
+    expect(mockSetHideDrawer).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/LeftDrawerOrg/LeftDrawerOrg.spec.tsx
+++ b/src/components/LeftDrawerOrg/LeftDrawerOrg.spec.tsx
@@ -472,4 +472,47 @@ describe('Testing LeftDrawerOrg component for SUPERADMIN', () => {
       </MockedProvider>,
     );
   });
+
+  test('Should set hideDrawer to false when initially null', async () => {
+    const mockSetHideDrawer = vi.fn();
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <LeftDrawerOrg
+                {...props}
+                hideDrawer={null}
+                setHideDrawer={mockSetHideDrawer}
+              />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+    await wait();
+    expect(mockSetHideDrawer).toHaveBeenCalledWith(false);
+    expect(mockSetHideDrawer).toHaveBeenCalledTimes(1);
+  });
+
+  test('Should not call setHideDrawer when hideDrawer has a value', async () => {
+    const mockSetHideDrawer = vi.fn();
+    render(
+      <MockedProvider addTypename={false} link={link}>
+        <BrowserRouter>
+          <Provider store={store}>
+            <I18nextProvider i18n={i18nForTest}>
+              <LeftDrawerOrg
+                {...props}
+                hideDrawer={false}
+                setHideDrawer={mockSetHideDrawer}
+              />
+            </I18nextProvider>
+          </Provider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+    await wait();
+    expect(mockSetHideDrawer).not.toHaveBeenCalled();
+  });
 });

--- a/src/components/LeftDrawerOrg/LeftDrawerOrg.tsx
+++ b/src/components/LeftDrawerOrg/LeftDrawerOrg.tsx
@@ -74,6 +74,13 @@ const leftDrawerOrg = ({
     () => getIdFromPath(location.pathname),
     [location.pathname],
   );
+
+  useEffect(() => {
+    if (hideDrawer === null) {
+      setHideDrawer(false);
+    }
+  }, []);
+
   // Check if the current page is admin profile page
 
   useEffect(() => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**

Fixes #3237 

**Did you add tests for your changes?**

No, only visible changes

**Snapshots/Videos:**


https://github.com/user-attachments/assets/3ccc5af1-97c7-4101-88dc-9c71b45e64ef


**Does this PR introduce a breaking change?**

No


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced drawer visibility behavior, ensuring it is visible by default when no explicit hide state is set.

- **Tests**
	- Added test cases to verify drawer visibility behavior when the hideDrawer prop is null or has a defined value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->