### PR TITLE
BugFix : Display user name instead of "undefined undefined" when making a post in an organization

### DIFF
--- a/src/components/UserPortal/StartPostModal/StartPostModal.spec.tsx
+++ b/src/components/UserPortal/StartPostModal/StartPostModal.spec.tsx
@@ -152,6 +152,14 @@ describe('Testing StartPostModal Component: User Portal', () => {
     );
   });
 
+  it('should display correct username', async () => {
+    renderStartPostModal(true, null);
+    await wait();
+
+    const userFullName = screen.getByText('Glen dsza');
+    expect(userFullName).toBeInTheDocument();
+  });
+
   it('If user image is null then default image should be shown', async () => {
     renderStartPostModal(true, null);
     await wait();

--- a/src/screens/UserPortal/Posts/Posts.tsx
+++ b/src/screens/UserPortal/Posts/Posts.tsx
@@ -23,6 +23,7 @@ import useLocalStorage from 'utils/useLocalstorage';
 import styles from './Posts.module.css';
 import convertToBase64 from 'utils/convertToBase64';
 import Carousel from 'react-multi-carousel';
+import { TAGS_QUERY_DATA_CHUNK_SIZE } from 'utils/organizationTagsUtils';
 import 'react-multi-carousel/lib/styles.css';
 
 const responsive = {
@@ -156,7 +157,10 @@ export default function home(): JSX.Element {
   const userId: string | null = getItem('userId');
 
   const { data: userData } = useQuery(USER_DETAILS, {
-    variables: { id: userId },
+    variables: {
+      id: userId,
+      first: TAGS_QUERY_DATA_CHUNK_SIZE, // This is for tagsAssignedWith pagination
+    },
   });
 
   const user: InterfaceQueryUserListItem | undefined = userData?.user;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

BugFix

**Issue Number:**

Fixes #3222

**Did you add tests for your changes?**

Yes

**Snapshots/Videos:**

Before : 

![Screenshot from 2025-01-09 19-19-44](https://github.com/user-attachments/assets/7c6fc5a0-4674-41d0-9f31-55eacc3cb96e)

After : 

![Screenshot from 2025-01-09 20-35-31](https://github.com/user-attachments/assets/dee3a9fe-c3e7-46c2-b07e-611d11671f79)


**If relevant, did you update the documentation?**
NA

**Summary**
This PR addresses a bug where, while creating a post in an organization, the author's name was displayed as "undefined undefined" instead of the actual user's name. This issue has been resolved to ensure the correct user name is displayed.

**Does this PR introduce a breaking change?**
No

**Other information**
-Refactored the data fetching mechanism to accommodate TAGS_QUERY_DATA_CHUNK_SIZE.
-Tested extensively to ensure consistent behavior across different scenarios.
-Added unit tests to validate the implementation.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Added a test case to verify the correct display of username in the StartPostModal component.

- **Improvements**
	- Updated GraphQL query in Posts screen to include pagination for user tags.
	- Enhanced data fetching capabilities by incorporating a configuration for query data chunk size when fetching user details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->