### PR TITLE
chore: Fixed Node Warning and Deprecation Messages 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -92,8 +92,6 @@
         "@types/react": "^18.3.12",
         "@types/react-beautiful-dnd": "^13.1.8",
         "@types/react-bootstrap": "^0.32.37",
-        "@types/react-chartjs-2": "^2.5.7",
-        "@types/react-datepicker": "^7.0.0",
         "@types/react-dom": "^18.3.1",
         "@types/react-google-recaptcha": "^2.1.9",
         "@types/react-router-dom": "^5.1.8",
@@ -6305,27 +6303,6 @@
         "@types/react": "*"
       }
     },
-    "node_modules/@types/react-chartjs-2": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/@types/react-chartjs-2/-/react-chartjs-2-2.5.7.tgz",
-      "integrity": "sha512-waqYqiNULIVUqaKO7MGUpFmWrVtH7gVPOzqwV4y4zgUyu/JiDwC005PpveO442HKnby9kLgp3t1SB2sld+ACLw==",
-      "deprecated": "This is a stub types definition for react-chartjs-2 (https://github.com/gor181/react-chartjs-2). react-chartjs-2 provides its own type definitions, so you don't need @types/react-chartjs-2 installed!",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "react-chartjs-2": "*"
-      }
-    },
-    "node_modules/@types/react-datepicker": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/react-datepicker/-/react-datepicker-7.0.0.tgz",
-      "integrity": "sha512-4tWwOUq589tozyQPBVEqGNng5DaZkomx5IVNuur868yYdgjH6RaL373/HKiVt1IDoNNXYiTGspm1F7kjrarM8Q==",
-      "deprecated": "This is a stub types definition. react-datepicker provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "react-datepicker": "*"
-      }
-    },
     "node_modules/@types/react-dom": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.1.tgz",
@@ -9031,13 +9008,16 @@
       }
     },
     "node_modules/core-js": {
-      "version": "2.6.12",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
-      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.40.0.tgz",
+      "integrity": "sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
     },
     "node_modules/core-js-compat": {
       "version": "3.38.1",
@@ -11785,13 +11765,14 @@
       }
     },
     "node_modules/gulp-header": {
-      "version": "1.8.12",
-      "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-1.8.12.tgz",
-      "integrity": "sha512-lh9HLdb53sC7XIZOYzTXM4lFuXElv3EVkSDhsd7DoJBj7hm+Ni7D3qYbb+Rr8DuM8nRanBvkVO9d7askreXGnQ==",
-      "deprecated": "Removed event-stream from gulp-header",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-2.0.9.tgz",
+      "integrity": "sha512-LMGiBx+qH8giwrOuuZXSGvswcIUh0OiioNkUpLhNyvaC6/Ga8X6cfAeme2L5PqsbXMhL8o8b/OmVqIQdxprhcQ==",
+      "license": "MIT",
       "dependencies": {
-        "concat-with-sourcemaps": "*",
-        "lodash.template": "^4.4.0",
+        "concat-with-sourcemaps": "^1.1.0",
+        "lodash.template": "^4.5.0",
+        "map-stream": "0.0.7",
         "through2": "^2.0.0"
       }
     },
@@ -15490,6 +15471,12 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
+    },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "license": "MIT"
     },
     "node_modules/markdown-it": {
       "version": "14.1.0",

--- a/package.json
+++ b/package.json
@@ -129,8 +129,6 @@
     "@types/react": "^18.3.12",
     "@types/react-beautiful-dnd": "^13.1.8",
     "@types/react-bootstrap": "^0.32.37",
-    "@types/react-chartjs-2": "^2.5.7",
-    "@types/react-datepicker": "^7.0.0",
     "@types/react-dom": "^18.3.1",
     "@types/react-google-recaptcha": "^2.1.9",
     "@types/react-router-dom": "^5.1.8",
@@ -169,6 +167,14 @@
   },
   "engines": {
     "node": ">=20.x"
+  },
+  "overrides": {
+    "core-js": "^3.40.0",
+    "rc-color-picker": {
+      "react": "^18.3.1",
+      "react-dom": "^18.3.1"
+    },
+    "gulp-header": "^2.0.9"
   },
   "lint-staged": {
     "**/*.{ts, tsx, json, scss, css}": [


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
This pr fixes Node Warning and Deprecation Messages When Installing App Packages.
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

Fixes #3167 

**Snapshots/Videos:**

- Before

<!--Add snapshots or videos wherever possible.-->
![400261071-8ddf10af-8095-4dff-967c-81463c0bcc08](https://github.com/user-attachments/assets/6821d8a0-4136-4075-80da-86276d1697a5)

- After

![Screenshot from 2025-01-12 21-19-14](https://github.com/user-attachments/assets/5098bc9c-3df9-4ae2-ba36-ba43e1daf309)

**Explaination**
![Screenshot from 2025-01-12 21-24-34](https://github.com/user-attachments/assets/77ef6353-11da-47a2-83da-692f2a842dcf)

- ``  "overrides": {
    "rc-color-picker": {
      "react": "^18.3.1",
      "react-dom": "^18.3.1"
    },
    }, ``
- Added rc-color-picker to overrides to resolve peer dependency conflicts. The package normally requires React 16.x, but our project uses React 18.3.1. This override ensures rc-color-picker uses the correct React version, preventing potential compatibility issues and dependency warnings.

- **Many packages in our dependency chain rely on deprecated versions of their sub-dependencies**
Like 
![Screenshot from 2025-01-12 21-30-08](https://github.com/user-attachments/assets/fb7d6047-a7be-4c93-ab70-3a68922f606b)
![Screenshot from 2025-01-12 21-30-29](https://github.com/user-attachments/assets/fd7957c4-2e56-4bfc-ae1a-509cc156113f)

- `` "core-js": "^3.40.0" `` this will enforce all instances of core-js in the dependency tree to use version 3.40.0  and so on.

**Regarding other depreciated msg** 
![Screenshot from 2025-01-12 21-40-58](https://github.com/user-attachments/assets/0b6bd3ca-78d7-4859-8085-8810bb122a53)
- we can solve this by install latest eslint package ie `` 9.10.0 `` 






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Management**
  - Removed development dependencies for type definitions
  - Added package version overrides to ensure compatibility
  - Updated core library and package constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->