### PR TITLE
Bugfix: Add Visit Button in Joined Organizations Filter

### DIFF
--- a/src/components/OrganizationCard/OrganizationCard.spec.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.spec.tsx
@@ -72,7 +72,7 @@ describe('Testing the Organization Card', () => {
 
     render(
       <TestWrapper>
-        <OrganizationCard {...props} />
+        <OrganizationCard isjoined={false} {...props} />
       </TestWrapper>,
     );
 
@@ -105,7 +105,7 @@ describe('Testing the Organization Card', () => {
 
     render(
       <TestWrapper>
-        <OrganizationCard {...props} />
+        <OrganizationCard isjoined={false} {...props} />
       </TestWrapper>,
     );
 

--- a/src/components/OrganizationCard/OrganizationCard.spec.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.spec.tsx
@@ -1,16 +1,51 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { MockedProvider } from '@apollo/client/testing';
+import { I18nextProvider } from 'react-i18next';
+import i18n from 'i18next';
 import OrganizationCard from './OrganizationCard';
 
-/**
- * This file contains unit tests for the `OrganizationCard` component.
- *
- * The tests cover:
- * - Rendering the component with all provided props and verifying the correct display of text elements.
- * - Ensuring the component handles cases where certain props (like image) are not provided.
- *
- * These tests utilize the React Testing Library for rendering and querying DOM elements.
- */
+// Initialize i18n for testing
+i18n.init({
+  lng: 'en',
+  resources: {
+    en: {
+      translation: {
+        users: {
+          MembershipRequestSent: 'Request sent',
+          orgJoined: 'Joined',
+          AlreadyJoined: 'Already joined',
+          errorOccured: 'Error occurred',
+          MembershipRequestNotFound: 'Request not found',
+          MembershipRequestWithdrawn: 'Request withdrawn',
+          visit: 'Visit',
+          withdraw: 'Withdraw',
+          joinNow: 'Join Now',
+        },
+      },
+      common: {
+        admins: 'Admins',
+        members: 'Members',
+      },
+    },
+  },
+});
+
+// Wrapper component to provide all required contexts
+const TestWrapper = ({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement => {
+  return (
+    <MockedProvider>
+      <I18nextProvider i18n={i18n}>
+        <BrowserRouter>{children}</BrowserRouter>
+      </I18nextProvider>
+    </MockedProvider>
+  );
+};
 
 describe('Testing the Organization Card', () => {
   it('should render props and text elements test for the page component', () => {
@@ -20,14 +55,30 @@ describe('Testing the Organization Card', () => {
       firstName: 'John',
       lastName: 'Doe',
       name: 'Sample',
+      description: '',
+      admins: [],
+      members: [],
+      address: {
+        city: '',
+        countryCode: '',
+        line1: '',
+        postalCode: '',
+        state: '',
+      },
+      membershipRequestStatus: '',
+      userRegistrationRequired: false,
+      membershipRequests: [],
     };
 
-    render(<OrganizationCard {...props} />);
+    render(
+      <TestWrapper>
+        <OrganizationCard {...props} />
+      </TestWrapper>,
+    );
 
     expect(screen.getByText(props.name)).toBeInTheDocument();
-    expect(screen.getByText(/Owner:/i)).toBeInTheDocument();
-    expect(screen.getByText(props.firstName)).toBeInTheDocument();
-    expect(screen.getByText(props.lastName)).toBeInTheDocument();
+    expect(screen.getByText(/Admins/i)).toBeInTheDocument();
+    expect(screen.getByText(/Members/i)).toBeInTheDocument();
   });
 
   it('Should render text elements when props value is not passed', () => {
@@ -37,13 +88,29 @@ describe('Testing the Organization Card', () => {
       firstName: 'John',
       lastName: 'Doe',
       name: 'Sample',
+      description: '',
+      admins: [],
+      members: [],
+      address: {
+        city: '',
+        countryCode: '',
+        line1: '',
+        postalCode: '',
+        state: '',
+      },
+      membershipRequestStatus: '',
+      userRegistrationRequired: false,
+      membershipRequests: [],
     };
 
-    render(<OrganizationCard {...props} />);
+    render(
+      <TestWrapper>
+        <OrganizationCard {...props} />
+      </TestWrapper>,
+    );
 
     expect(screen.getByText(props.name)).toBeInTheDocument();
-    expect(screen.getByText(/Owner:/i)).toBeInTheDocument();
-    expect(screen.getByText(props.firstName)).toBeInTheDocument();
-    expect(screen.getByText(props.lastName)).toBeInTheDocument();
+    expect(screen.getByText(/Admins/i)).toBeInTheDocument();
+    expect(screen.getByText(/Members/i)).toBeInTheDocument();
   });
 });

--- a/src/components/OrganizationCard/OrganizationCard.spec.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.spec.tsx
@@ -325,4 +325,46 @@ describe('OrganizationCard Component', () => {
       });
     });
   });
+
+  it('should handle membership withdrawal successfully', async () => {
+    const props = {
+      ...defaultProps,
+      membershipRequestStatus: 'pending',
+      membershipRequests: [{ _id: 'requestId', user: { _id: 'mockUserId' } }],
+    };
+
+    render(
+      <TestWrapper mocks={successMocks}>
+        <OrganizationCard {...props} isJoined={false} />
+      </TestWrapper>,
+    );
+
+    const withdrawButton = screen.getByTestId('withdrawBtn');
+    await fireEvent.click(withdrawButton);
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('MembershipRequestWithdrawn');
+    });
+  });
+
+  it('should handle membership withdrawal error when request not found', async () => {
+    const props = {
+      ...defaultProps,
+      membershipRequestStatus: 'pending',
+      membershipRequests: [], // Empty requests to trigger error
+    };
+
+    render(
+      <TestWrapper mocks={errorMocks}>
+        <OrganizationCard {...props} isJoined={false} />
+      </TestWrapper>,
+    );
+
+    const withdrawButton = screen.getByTestId('withdrawBtn');
+    await fireEvent.click(withdrawButton);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('MembershipRequestNotFound');
+    });
+  });
 });

--- a/src/components/OrganizationCard/OrganizationCard.spec.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.spec.tsx
@@ -72,7 +72,7 @@ describe('Testing the Organization Card', () => {
 
     render(
       <TestWrapper>
-        <OrganizationCard isjoined={false} {...props} />
+        <OrganizationCard isJoined={false} {...props} />
       </TestWrapper>,
     );
 
@@ -105,7 +105,7 @@ describe('Testing the Organization Card', () => {
 
     render(
       <TestWrapper>
-        <OrganizationCard isjoined={false} {...props} />
+        <OrganizationCard isJoined={false} {...props} />
       </TestWrapper>,
     );
 

--- a/src/components/OrganizationCard/OrganizationCard.spec.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.spec.tsx
@@ -1,10 +1,49 @@
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
 import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { BrowserRouter } from 'react-router-dom';
-import { MockedProvider } from '@apollo/client/testing';
-import { I18nextProvider } from 'react-i18next';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { MockedResponse } from '@apollo/client/testing';
+import { toast } from 'react-toastify';
 import i18n from 'i18next';
 import OrganizationCard from './OrganizationCard';
+import { TestWrapper } from '../../components/test-utils/TestWrapper';
+import {
+  SEND_MEMBERSHIP_REQUEST,
+  JOIN_PUBLIC_ORGANIZATION,
+  CANCEL_MEMBERSHIP_REQUEST,
+} from 'GraphQl/Mutations/OrganizationMutations';
+import { USER_JOINED_ORGANIZATIONS } from 'GraphQl/Queries/OrganizationQueries';
+
+// Mock hooks
+const mockGetItem = vi.fn();
+vi.mock('utils/useLocalstorage', () => ({
+  __esModule: true,
+  default: () => ({
+    getItem: () => mockGetItem(),
+    setItem: vi.fn(),
+  }),
+}));
+
+vi.mock('react-toastify', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => {
+  const actual = vi.importActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    BrowserRouter: ({
+      children,
+    }: {
+      children: React.ReactNode;
+    }): JSX.Element => <div>{children}</div>,
+  };
+});
 
 // Initialize i18n for testing
 i18n.init({
@@ -16,7 +55,7 @@ i18n.init({
           MembershipRequestSent: 'Request sent',
           orgJoined: 'Joined',
           AlreadyJoined: 'Already joined',
-          errorOccured: 'Error occurred',
+          errorOccured: 'error occurred',
           MembershipRequestNotFound: 'Request not found',
           MembershipRequestWithdrawn: 'Request withdrawn',
           visit: 'Visit',
@@ -32,85 +71,258 @@ i18n.init({
   },
 });
 
-// Wrapper component to provide all required contexts
-const TestWrapper = ({
-  children,
-}: {
-  children: React.ReactNode;
-}): React.ReactElement => {
-  return (
-    <MockedProvider>
-      <I18nextProvider i18n={i18n}>
-        <BrowserRouter>{children}</BrowserRouter>
-      </I18nextProvider>
-    </MockedProvider>
-  );
-};
-
-describe('Testing the Organization Card', () => {
-  it('should render props and text elements test for the page component', () => {
-    const props = {
-      id: '123',
-      image: 'https://via.placeholder.com/80',
-      firstName: 'John',
-      lastName: 'Doe',
-      name: 'Sample',
-      description: '',
-      admins: [],
-      members: [],
-      address: {
-        city: '',
-        countryCode: '',
-        line1: '',
-        postalCode: '',
-        state: '',
+// Success mocks
+const successMocks: MockedResponse[] = [
+  {
+    request: {
+      query: SEND_MEMBERSHIP_REQUEST,
+      variables: { organizationId: '123' },
+    },
+    result: {
+      data: { sendMembershipRequest: { success: true } },
+    },
+  },
+  {
+    request: {
+      query: JOIN_PUBLIC_ORGANIZATION,
+      variables: { organizationId: '123' },
+    },
+    result: {
+      data: { joinPublicOrganization: { success: true } },
+    },
+  },
+  {
+    request: {
+      query: CANCEL_MEMBERSHIP_REQUEST,
+      variables: { membershipRequestId: 'requestId' },
+    },
+    result: {
+      data: { cancelMembershipRequest: { success: true } },
+    },
+  },
+  {
+    request: {
+      query: USER_JOINED_ORGANIZATIONS,
+      variables: { userId: 'mockUserId' },
+    },
+    result: {
+      data: {
+        organizations: [
+          {
+            _id: '123',
+            name: 'Test Org',
+          },
+        ],
       },
-      membershipRequestStatus: '',
-      userRegistrationRequired: false,
-      membershipRequests: [],
-    };
+    },
+  },
+];
 
-    render(
-      <TestWrapper>
-        <OrganizationCard isJoined={false} {...props} />
-      </TestWrapper>,
-    );
+// Error mocks
+const errorMocks: MockedResponse[] = [
+  {
+    request: {
+      query: SEND_MEMBERSHIP_REQUEST,
+      variables: { organizationId: '123' },
+    },
+    error: new Error('Failed to send request'),
+  },
+  {
+    request: {
+      query: JOIN_PUBLIC_ORGANIZATION,
+      variables: { organizationId: '123' },
+    },
+    error: new Error('Failed to join organization'),
+  },
+  {
+    request: {
+      query: CANCEL_MEMBERSHIP_REQUEST,
+      variables: { membershipRequestId: 'requestId' },
+    },
+    error: new Error('Failed to cancel request'),
+  },
+];
 
-    expect(screen.getByText(props.name)).toBeInTheDocument();
-    expect(screen.getByText(/Admins/i)).toBeInTheDocument();
-    expect(screen.getByText(/Members/i)).toBeInTheDocument();
+describe('OrganizationCard Component', () => {
+  const defaultProps = {
+    id: '123',
+    image: 'https://via.placeholder.com/80',
+    firstName: 'John',
+    lastName: 'Doe',
+    name: 'Sample',
+    description: '',
+    admins: [],
+    members: [],
+    address: {
+      city: '',
+      countryCode: '',
+      line1: '',
+      postalCode: '',
+      state: '',
+    },
+    membershipRequestStatus: '',
+    userRegistrationRequired: false,
+    membershipRequests: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetItem.mockReturnValue('mockUserId');
   });
 
-  it('Should render text elements when props value is not passed', () => {
-    const props = {
-      id: '123',
-      image: '',
-      firstName: 'John',
-      lastName: 'Doe',
-      name: 'Sample',
-      description: '',
-      admins: [],
-      members: [],
-      address: {
-        city: '',
-        countryCode: '',
-        line1: '',
-        postalCode: '',
-        state: '',
-      },
-      membershipRequestStatus: '',
-      userRegistrationRequired: false,
-      membershipRequests: [],
-    };
+  // Basic Rendering Tests
+  describe('Rendering', () => {
+    it('should render props and text elements', () => {
+      render(
+        <TestWrapper mocks={successMocks}>
+          <OrganizationCard isJoined={false} {...defaultProps} />
+        </TestWrapper>,
+      );
 
-    render(
-      <TestWrapper>
-        <OrganizationCard isJoined={false} {...props} />
-      </TestWrapper>,
-    );
+      expect(screen.getByText(defaultProps.name)).toBeInTheDocument();
+      expect(screen.getByText(/Admins/i)).toBeInTheDocument();
+      expect(screen.getByText(/Members/i)).toBeInTheDocument();
+    });
 
-    expect(screen.getByText(props.name)).toBeInTheDocument();
-    expect(screen.getByText(/Admins/i)).toBeInTheDocument();
-    expect(screen.getByText(/Members/i)).toBeInTheDocument();
+    it('should render without image', () => {
+      const props = { ...defaultProps, image: '' };
+      render(
+        <TestWrapper mocks={successMocks}>
+          <OrganizationCard isJoined={false} {...props} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText(props.name)).toBeInTheDocument();
+    });
+
+    it('should render full address when provided', () => {
+      const props = {
+        ...defaultProps,
+        address: {
+          city: 'Test City',
+          countryCode: 'TC',
+          line1: 'Test Line 1',
+          postalCode: '12345',
+          state: 'TS',
+        },
+      };
+
+      render(
+        <TestWrapper mocks={successMocks}>
+          <OrganizationCard isJoined={false} {...props} />
+        </TestWrapper>,
+      );
+
+      expect(screen.getByText(/Test Line 1/)).toBeInTheDocument();
+      expect(screen.getByText(/Test City/)).toBeInTheDocument();
+      expect(screen.getByText(/TC/)).toBeInTheDocument();
+    });
+  });
+
+  // Hook Tests
+  describe('Hooks Behavior', () => {
+    it('should handle localStorage error gracefully', () => {
+      mockGetItem.mockImplementation(() => {
+        throw new Error('localStorage error');
+      });
+
+      render(
+        <TestWrapper mocks={successMocks}>
+          <OrganizationCard isJoined={false} {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const joinButton = screen.getByTestId('joinBtn');
+      expect(joinButton).toBeInTheDocument();
+      expect(joinButton).toHaveTextContent('joinNow');
+    });
+
+    it('should navigate to organization page on visit', () => {
+      render(
+        <TestWrapper mocks={successMocks}>
+          <OrganizationCard isJoined={true} {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const visitButton = screen.getByTestId('manageBtn');
+      fireEvent.click(visitButton);
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `/user/organization/${defaultProps.id}`,
+      );
+    });
+
+    it('should correctly translate all text elements', () => {
+      render(
+        <TestWrapper mocks={successMocks}>
+          <OrganizationCard isJoined={false} {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      const adminText = screen.getByText(/Admins:/);
+      const memberText = screen.getByText(/Members:/);
+
+      expect(adminText).toBeInTheDocument();
+      expect(memberText).toBeInTheDocument();
+    });
+  });
+
+  // Mutation Tests
+  describe('Mutations', () => {
+    it('should handle joining a private organization successfully', async () => {
+      render(
+        <TestWrapper mocks={successMocks}>
+          <OrganizationCard
+            {...defaultProps}
+            userRegistrationRequired={true}
+            isJoined={false}
+          />
+        </TestWrapper>,
+      );
+
+      const joinButton = screen.getByText('joinNow');
+      await fireEvent.click(joinButton);
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('MembershipRequestSent');
+      });
+    });
+
+    it('should handle joining a public organization successfully', async () => {
+      render(
+        <TestWrapper mocks={successMocks}>
+          <OrganizationCard
+            {...defaultProps}
+            userRegistrationRequired={false}
+            isJoined={false}
+          />
+        </TestWrapper>,
+      );
+
+      const joinButton = screen.getByText('joinNow');
+      await fireEvent.click(joinButton);
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('orgJoined');
+      });
+    });
+
+    it('should handle private organization join error', async () => {
+      render(
+        <TestWrapper mocks={errorMocks}>
+          <OrganizationCard
+            {...defaultProps}
+            userRegistrationRequired={true}
+            isJoined={false}
+          />
+        </TestWrapper>,
+      );
+
+      const joinButton = screen.getByTestId('joinBtn');
+      await fireEvent.click(joinButton);
+
+      await waitFor(() => {
+        expect(toast.error).toHaveBeenCalledWith('errorOccured');
+      });
+    });
   });
 });

--- a/src/components/OrganizationCard/OrganizationCard.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.tsx
@@ -1,55 +1,241 @@
 import React from 'react';
 import styles from './OrganizationCard.module.css';
+import { Button } from 'react-bootstrap';
+import { Tooltip } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
+import {
+  CANCEL_MEMBERSHIP_REQUEST,
+  JOIN_PUBLIC_ORGANIZATION,
+  SEND_MEMBERSHIP_REQUEST,
+} from 'GraphQl/Mutations/OrganizationMutations';
+import { useMutation, useQuery } from '@apollo/client';
+import {
+  USER_JOINED_ORGANIZATIONS,
+  USER_ORGANIZATION_CONNECTION,
+} from 'GraphQl/Queries/OrganizationQueries';
+import useLocalStorage from 'utils/useLocalstorage';
+import Avatar from 'components/Avatar/Avatar';
+import { useNavigate } from 'react-router-dom';
+import type { ApolloError } from '@apollo/client';
+
+const { getItem } = useLocalStorage();
 
 interface InterfaceOrganizationCardProps {
-  image: string;
   id: string;
   name: string;
-  lastName: string;
-  firstName: string;
+  image: string;
+  description: string;
+  admins: {
+    id: string;
+  }[];
+  members: {
+    id: string;
+  }[];
+  address: {
+    city: string;
+    countryCode: string;
+    line1: string;
+    postalCode: string;
+    state: string;
+  };
+  membershipRequestStatus: string;
+  userRegistrationRequired: boolean;
+  membershipRequests: {
+    _id: string;
+    user: {
+      _id: string;
+    };
+  }[];
 }
 
 /**
- * Component to display an organization's card with its image and owner details.
+ * Displays an organization card with options to join or manage membership.
  *
- * @param props - Properties for the organization card.
- * @returns JSX element representing the organization card.
+ * Shows the organization's name, image, description, address, number of admins and members,
+ * and provides buttons for joining, withdrawing membership requests, or visiting the organization page.
+ *
+ * @param props - The properties for the organization card.
+ * @param id - The unique identifier of the organization.
+ * @param name - The name of the organization.
+ * @param image - The URL of the organization's image.
+ * @param description - A description of the organization.
+ * @param admins - The list of admins with their IDs.
+ * @param members - The list of members with their IDs.
+ * @param address - The address of the organization including city, country code, line1, postal code, and state.
+ * @param membershipRequestStatus - The status of the membership request (accepted, pending, or empty).
+ * @param userRegistrationRequired - Indicates if user registration is required to join the organization.
+ * @param membershipRequests - The list of membership requests with user IDs.
+ *
+ * @returns The organization card component.
  */
-function OrganizationCard(props: InterfaceOrganizationCardProps): JSX.Element {
-  const uri = '/superorghome/i=' + props.id;
+const userId: string | null = getItem('userId');
+
+function OrganizationCard({
+  id,
+  name,
+  image,
+  description,
+  admins,
+  members,
+  address,
+  membershipRequestStatus,
+  userRegistrationRequired,
+  membershipRequests,
+}: InterfaceOrganizationCardProps): JSX.Element {
+  const { t } = useTranslation('translation', {
+    keyPrefix: 'users',
+  });
+  const { t: tCommon } = useTranslation('common');
+
+  const navigate = useNavigate();
+
+  // Mutations for handling organization memberships
+  const [sendMembershipRequest] = useMutation(SEND_MEMBERSHIP_REQUEST, {
+    refetchQueries: [
+      { query: USER_ORGANIZATION_CONNECTION, variables: { id } },
+    ],
+  });
+  const [joinPublicOrganization] = useMutation(JOIN_PUBLIC_ORGANIZATION, {
+    refetchQueries: [
+      { query: USER_ORGANIZATION_CONNECTION, variables: { id } },
+    ],
+  });
+  const [cancelMembershipRequest] = useMutation(CANCEL_MEMBERSHIP_REQUEST, {
+    refetchQueries: [
+      { query: USER_ORGANIZATION_CONNECTION, variables: { id } },
+    ],
+  });
+  const { refetch } = useQuery(USER_JOINED_ORGANIZATIONS, {
+    variables: { id: userId },
+  });
+
+  async function joinOrganization(): Promise<void> {
+    try {
+      if (userRegistrationRequired) {
+        await sendMembershipRequest({
+          variables: {
+            organizationId: id,
+          },
+        });
+        toast.success(t('MembershipRequestSent') as string);
+      } else {
+        await joinPublicOrganization({
+          variables: {
+            organizationId: id,
+          },
+        });
+        toast.success(t('orgJoined') as string);
+      }
+      refetch();
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        const apolloError = error as ApolloError;
+        const errorCode = apolloError.graphQLErrors[0]?.extensions?.code;
+
+        if (errorCode === 'ALREADY_MEMBER') {
+          toast.error(t('AlreadyJoined') as string);
+        } else {
+          toast.error(t('errorOccured') as string);
+        }
+      }
+    }
+  }
+
+  async function withdrawMembershipRequest(): Promise<void> {
+    const membershipRequest = membershipRequests.find(
+      (request) => request.user._id === userId,
+    );
+    try {
+      if (!membershipRequest) {
+        toast.error(t('MembershipRequestNotFound') as string);
+        return;
+      }
+
+      await cancelMembershipRequest({
+        variables: {
+          membershipRequestId: membershipRequest._id,
+        },
+      });
+
+      toast.success(t('MembershipRequestWithdrawn') as string);
+    } catch (error: unknown) {
+      console.error('Failed to withdraw membership request:', error);
+      toast.error(t('errorOccured') as string);
+    }
+  }
 
   return (
-    <a href={uri}>
-      <div className={styles.box}>
-        <div className={styles.first_box}>
-          {props.image ? (
-            <img
-              src={props.image}
-              className={styles.alignimg}
-              alt="Organization"
-            />
+    <div className={styles.orgCard}>
+      <div className={styles.innerContainer}>
+        <div className={styles.orgImgContainer}>
+          {image ? (
+            <img src={image} alt={`${name} image`} />
           ) : (
-            <img
-              src="https://via.placeholder.com/80"
-              className={styles.alignimg}
-              alt="Placeholder"
+            <Avatar
+              name={name}
+              alt={`${name} image`}
+              dataTestId="emptyContainerForImage"
             />
           )}
-          <div className={styles.second_box}>
-            <h4>{props.name}</h4>
-            <h5>
-              Owner:
-              <span>{props.firstName}</span>
-              <span>
-                &nbsp;
-                {props.lastName}
-              </span>
-            </h5>
-          </div>
         </div>
-        <div className={styles.deco}></div>
+        <div className={styles.content}>
+          <Tooltip title={name} placement="top-end">
+            <h4 className={`${styles.orgName} fw-semibold`}>{name}</h4>
+          </Tooltip>
+          <h6 className={`${styles.orgdesc} fw-semibold`}>
+            <span>{description}</span>
+          </h6>
+          {address && address.city && (
+            <div className={styles.address}>
+              <h6 className="text-secondary">
+                <span className="address-line">{address.line1}, </span>
+                <span className="address-line">{address.city}, </span>
+                <span className="address-line">{address.countryCode}</span>
+              </h6>
+            </div>
+          )}
+          <h6 className={styles.orgadmin}>
+            {tCommon('admins')}: <span>{admins?.length}</span> &nbsp; &nbsp;
+            &nbsp; {tCommon('members')}: <span>{members?.length}</span>
+          </h6>
+        </div>
       </div>
-    </a>
+      {membershipRequestStatus === 'accepted' && (
+        <Button
+          variant="success"
+          data-testid="manageBtn"
+          className={styles.joinedBtn}
+          onClick={() => {
+            navigate(`/user/organization/${id}`);
+          }}
+        >
+          {t('visit')}
+        </Button>
+      )}
+
+      {membershipRequestStatus === 'pending' && (
+        <Button
+          variant="danger"
+          onClick={withdrawMembershipRequest}
+          data-testid="withdrawBtn"
+          className={styles.withdrawBtn}
+        >
+          {t('withdraw')}
+        </Button>
+      )}
+
+      {membershipRequestStatus === '' && (
+        <Button
+          onClick={joinOrganization}
+          data-testid="joinBtn"
+          className={styles.joinBtn}
+          variant="outline-success"
+        >
+          {t('joinNow')}
+        </Button>
+      )}
+    </div>
   );
 }
 

--- a/src/components/OrganizationCard/OrganizationCard.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.tsx
@@ -157,6 +157,10 @@ function OrganizationCard({
   }
 
   async function withdrawMembershipRequest(): Promise<void> {
+    if (!userId) {
+      toast.error(t('UserIdNotFound') as string);
+      return;
+    }
     const membershipRequest = membershipRequests.find(
       (request) => request.user._id === userId,
     );

--- a/src/components/OrganizationCard/OrganizationCard.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.tsx
@@ -160,7 +160,6 @@ function OrganizationCard({
     const membershipRequest = membershipRequests.find(
       (request) => request.user._id === userId,
     );
-    console.log('Membership Request:', membershipRequest); // Add this log
 
     try {
       if (!membershipRequest) {
@@ -174,7 +173,6 @@ function OrganizationCard({
         },
       });
 
-      console.log('Mutation executed successfully'); // Log mutation success
       toast.success(t('MembershipRequestWithdrawn') as string); // Ensure this gets called
     } catch (error: unknown) {
       if (process.env.NODE_ENV === 'development') {

--- a/src/components/OrganizationCard/OrganizationCard.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.tsx
@@ -50,6 +50,30 @@ interface InterfaceOrganizationCardProps {
   isjoined: boolean;
 }
 
+/**
+ * Component to display an organization's card with its image and owner details.
+ * Displays an organization card with options to join or manage membership.
+ *
+ * Shows the organization's name, image, description, address, number of admins and members,
+ * and provides buttons for joining, withdrawing membership requests, or visiting the organization page.
+ *
+ * @param props - The properties for the organization card.
+ * @param id - The unique identifier of the organization.
+ * @param name - The name of the organization.
+ * @param image - The URL of the organization's image.
+ * @param description - A description of the organization.
+ * @param admins - The list of admins with their IDs.
+ * @param members - The list of members with their IDs.
+ * @param address - The address of the organization including city, country code, line1, postal code, and state.
+ * @param membershipRequestStatus - The status of the membership request (accepted, pending, or empty).
+ * @param userRegistrationRequired - Indicates if user registration is required to join the organization.
+ * @param membershipRequests - The list of membership requests with user IDs.
+ *
+ * @param props - Properties for the organization card.
+ * @returns JSX element representing the organization card.
+ * @returns The organization card component.
+ */
+
 function OrganizationCard({
   id,
   name,

--- a/src/components/OrganizationCard/OrganizationCard.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.tsx
@@ -19,8 +19,6 @@ import Avatar from 'components/Avatar/Avatar';
 import { useNavigate } from 'react-router-dom';
 import type { ApolloError } from '@apollo/client';
 
-useLocalStorage();
-
 interface InterfaceOrganizationCardProps {
   id: string;
   name: string;

--- a/src/components/OrganizationCard/OrganizationCard.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.tsx
@@ -19,7 +19,7 @@ import Avatar from 'components/Avatar/Avatar';
 import { useNavigate } from 'react-router-dom';
 import type { ApolloError } from '@apollo/client';
 
-const { getItem } = useLocalStorage();
+useLocalStorage();
 
 interface InterfaceOrganizationCardProps {
   id: string;
@@ -47,29 +47,8 @@ interface InterfaceOrganizationCardProps {
       _id: string;
     };
   }[];
+  isjoined: boolean;
 }
-
-/**
- * Displays an organization card with options to join or manage membership.
- *
- * Shows the organization's name, image, description, address, number of admins and members,
- * and provides buttons for joining, withdrawing membership requests, or visiting the organization page.
- *
- * @param props - The properties for the organization card.
- * @param id - The unique identifier of the organization.
- * @param name - The name of the organization.
- * @param image - The URL of the organization's image.
- * @param description - A description of the organization.
- * @param admins - The list of admins with their IDs.
- * @param members - The list of members with their IDs.
- * @param address - The address of the organization including city, country code, line1, postal code, and state.
- * @param membershipRequestStatus - The status of the membership request (accepted, pending, or empty).
- * @param userRegistrationRequired - Indicates if user registration is required to join the organization.
- * @param membershipRequests - The list of membership requests with user IDs.
- *
- * @returns The organization card component.
- */
-const userId: string | null = getItem('userId');
 
 function OrganizationCard({
   id,
@@ -82,11 +61,13 @@ function OrganizationCard({
   membershipRequestStatus,
   userRegistrationRequired,
   membershipRequests,
+  isjoined,
 }: InterfaceOrganizationCardProps): JSX.Element {
-  const { t } = useTranslation('translation', {
-    keyPrefix: 'users',
-  });
+  const { getItem } = useLocalStorage();
+  const userId: string | null = getItem('userId');
+
   const { t: tCommon } = useTranslation('common');
+  const { t } = useTranslation();
 
   const navigate = useNavigate();
 
@@ -131,8 +112,7 @@ function OrganizationCard({
     } catch (error: unknown) {
       if (error instanceof Error) {
         const apolloError = error as ApolloError;
-        const errorCode = apolloError.graphQLErrors[0]?.extensions?.code;
-
+        const errorCode = apolloError.graphQLErrors?.[0]?.extensions?.code;
         if (errorCode === 'ALREADY_MEMBER') {
           toast.error(t('AlreadyJoined') as string);
         } else {
@@ -201,7 +181,7 @@ function OrganizationCard({
           </h6>
         </div>
       </div>
-      {membershipRequestStatus === 'accepted' && (
+      {isjoined && (
         <Button
           variant="success"
           data-testid="manageBtn"

--- a/src/components/OrganizationCard/OrganizationCard.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.tsx
@@ -47,7 +47,7 @@ interface InterfaceOrganizationCardProps {
       _id: string;
     };
   }[];
-  isjoined: boolean;
+  isJoined: boolean;
 }
 
 /**
@@ -85,7 +85,7 @@ function OrganizationCard({
   membershipRequestStatus,
   userRegistrationRequired,
   membershipRequests,
-  isjoined,
+  isJoined,
 }: InterfaceOrganizationCardProps): JSX.Element {
   const { getItem } = useLocalStorage();
   const userId: string | null = getItem('userId');
@@ -205,7 +205,7 @@ function OrganizationCard({
           </h6>
         </div>
       </div>
-      {isjoined && (
+      {isJoined && (
         <Button
           variant="success"
           data-testid="manageBtn"

--- a/src/components/test-utils/TestWrapper.tsx
+++ b/src/components/test-utils/TestWrapper.tsx
@@ -1,16 +1,44 @@
-import type { ReactNode } from 'react';
 import React from 'react';
-import type { MockedResponse } from '@apollo/client/testing';
-import { MockedProvider } from '@apollo/client/testing';
+import type { MockedResponse } from '@apollo/react-testing';
+import { MockedProvider } from '@apollo/react-testing';
+import type { ReactNode } from 'react';
 import { I18nextProvider } from 'react-i18next';
 import { BrowserRouter } from 'react-router-dom';
-import i18n from 'i18next';
+import i18n from 'utils/i18n';
 
+/**
+ * Props for the TestWrapper component.
+ */
 interface InterfaceTestWrapperProps {
+  /** The React components to be wrapped */
   children: ReactNode;
+  /** Optional Apollo GraphQL mocks for testing queries and mutations */
   mocks?: MockedResponse[];
 }
 
+/**
+ * A wrapper component for testing React components that require Apollo Client, i18n, and Router contexts.
+ * Provides the necessary provider context for testing components that use GraphQL, translations, and routing.
+ *
+ * @example
+ * ```tsx
+ * const mocks = [{
+ *   request: { query: TEST_QUERY },
+ *   result: { data: { test: 'data' } }
+ * }];
+ *
+ * render(
+ *   <TestWrapper mocks={mocks}>
+ *     <ComponentToTest />
+ *   </TestWrapper>
+ * );
+ * ```
+ *
+ * @param props - The component props
+ * @param children - The React components to be wrapped
+ * @param mocks - Optional Apollo GraphQL mocks for testing queries and mutations
+ * @returns A JSX element with all required providers wrapped around the children
+ */
 export const TestWrapper = ({
   children,
   mocks = [],

--- a/src/components/test-utils/TestWrapper.tsx
+++ b/src/components/test-utils/TestWrapper.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import type { MockedResponse } from '@apollo/react-testing';
-import { MockedProvider } from '@apollo/react-testing';
+import type { MockedResponse } from '@apollo/client/testing';
+import { MockedProvider } from '@apollo/client/testing';
 import type { ReactNode } from 'react';
 import { I18nextProvider } from 'react-i18next';
 import { BrowserRouter } from 'react-router-dom';

--- a/src/components/test-utils/TestWrapper.tsx
+++ b/src/components/test-utils/TestWrapper.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from 'react';
+import React from 'react';
+import type { MockedResponse } from '@apollo/client/testing';
+import { MockedProvider } from '@apollo/client/testing';
+import { I18nextProvider } from 'react-i18next';
+import { BrowserRouter } from 'react-router-dom';
+import i18n from 'i18next';
+
+interface InterfaceTestWrapperProps {
+  children: ReactNode;
+  mocks?: MockedResponse[];
+}
+
+export const TestWrapper = ({
+  children,
+  mocks = [],
+}: InterfaceTestWrapperProps): JSX.Element => (
+  <MockedProvider mocks={mocks}>
+    <I18nextProvider i18n={i18n}>
+      <BrowserRouter>{children}</BrowserRouter>
+    </I18nextProvider>
+  </MockedProvider>
+);

--- a/src/screens/UserPortal/Organizations/Organizations.tsx
+++ b/src/screens/UserPortal/Organizations/Organizations.tsx
@@ -40,12 +40,14 @@ interface InterfaceOrganizationCardProps {
       _id: string;
     };
   }[];
+  isJoined: boolean;
 }
 
 /**
  * Interface defining the structure of organization properties.
  */
 interface InterfaceOrganization {
+  isJoined: boolean;
   _id: string;
   name: string;
   image: string;
@@ -405,6 +407,7 @@ export default function organizations(): JSX.Element {
                         userRegistrationRequired:
                           organization.userRegistrationRequired,
                         membershipRequests: organization.membershipRequests,
+                        isJoined: organization.isJoined,
                       };
                       return <OrganizationCard key={index} {...cardProps} />;
                     })

--- a/src/screens/UserPortal/Organizations/Organizations.tsx
+++ b/src/screens/UserPortal/Organizations/Organizations.tsx
@@ -139,7 +139,6 @@ export default function organizations(): JSX.Element {
    * @param _event - The event triggering the page change.
    * @param  newPage - The new page number.
    */
-  /* istanbul ignore next */
   const handleChangePage = (
     _event: React.MouseEvent<HTMLButtonElement> | null,
     newPage: number,
@@ -152,7 +151,6 @@ export default function organizations(): JSX.Element {
    *
    * @param  event - The event triggering the change.
    */
-  /* istanbul ignore next */
   const handleChangeRowsPerPage = (
     event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ): void => {
@@ -202,7 +200,6 @@ export default function organizations(): JSX.Element {
   /**
    * Updates the list of organizations based on query results and selected mode.
    */
-  /* istanbul ignore next */
   useEffect(() => {
     if (data) {
       const organizations = data.organizationsConnection.map(
@@ -231,7 +228,6 @@ export default function organizations(): JSX.Element {
   /**
    * Updates the list of organizations based on the selected mode and query results.
    */
-  /* istanbul ignore next */
   useEffect(() => {
     if (mode === 0) {
       if (data) {
@@ -251,7 +247,11 @@ export default function organizations(): JSX.Element {
               )
             )
               membershipRequestStatus = 'pending';
-            return { ...organization, membershipRequestStatus };
+            return {
+              ...organization,
+              membershipRequestStatus,
+              isJoined: false,
+            };
           },
         );
         setOrganizations(organizations);
@@ -259,7 +259,13 @@ export default function organizations(): JSX.Element {
     } else if (mode === 1) {
       if (joinedOrganizationsData && joinedOrganizationsData.users.length > 0) {
         const organizations =
-          joinedOrganizationsData.users[0]?.user?.joinedOrganizations || [];
+          joinedOrganizationsData.users[0]?.user?.joinedOrganizations.map(
+            (org: InterfaceOrganization) => ({
+              ...org,
+              membershipRequestStatus: 'accepted',
+              isJoined: true,
+            }),
+          ) || [];
         setOrganizations(organizations);
       }
     } else if (mode === 2) {
@@ -268,8 +274,13 @@ export default function organizations(): JSX.Element {
         createdOrganizationsData.users.length > 0
       ) {
         const organizations =
-          createdOrganizationsData.users[0]?.appUserProfile
-            ?.createdOrganizations || [];
+          createdOrganizationsData.users[0]?.appUserProfile?.createdOrganizations.map(
+            (org: InterfaceOrganization) => ({
+              ...org,
+              membershipRequestStatus: 'accepted',
+              isJoined: true,
+            }),
+          ) || [];
         setOrganizations(organizations);
       }
     }
@@ -379,8 +390,7 @@ export default function organizations(): JSX.Element {
                           page * rowsPerPage,
                           page * rowsPerPage + rowsPerPage,
                         )
-                      : /* istanbul ignore next */
-                        organizations
+                      : organizations
                     ).map((organization: InterfaceOrganization, index) => {
                       const cardProps: InterfaceOrganizationCardProps = {
                         name: organization.name,
@@ -408,10 +418,7 @@ export default function organizations(): JSX.Element {
               <tbody>
                 <tr>
                   <PaginationList
-                    count={
-                      /* istanbul ignore next */
-                      organizations ? organizations.length : 0
-                    }
+                    count={organizations ? organizations.length : 0}
                     rowsPerPage={rowsPerPage}
                     page={page}
                     onPageChange={handleChangePage}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix: Ensures the "Visit" button appears for all joined organizations when filtering by "Joined Organizations."

**Issue Number:**

Fixes #3162 

**Snapshots/Videos:**


https://github.com/user-attachments/assets/aaf56942-b6e3-4fb1-b675-d487c9361748



**Summary**

The issue was caused by a restrictive condition for rendering the "Visit" button. The button only appeared when membershipRequestStatus === 'accepted'. This PR modifies the logic to include all joined organizations by checking the props.isJoined property.

**Does this PR introduce a breaking change?**
No

**Other information**
The feature was tested in multiple scenarios to ensure seamless functionality.
Does this PR introduce a breaking change?

No, this PR does not introduce breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Organization Card with additional details, including admins, members, and description.
	- Added organization membership request and join functionality with success notifications.
	- Improved organization display with image, name, description, and address details.
	- Introduced membership status indicators for organizations within the user portal.
	- New `TestWrapper` component for enhanced testing capabilities.

- **Bug Fixes**
	- Updated organization membership status handling to accurately reflect user membership.
	- Refined organization list pagination and display logic for clarity.

- **Documentation**
	- Updated component prop descriptions and documentation to reflect new properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->