### PR TITLE
Achieved code coverage upto 100%

### DIFF
--- a/src/components/OrganizationCard/OrganizationCard.spec.tsx
+++ b/src/components/OrganizationCard/OrganizationCard.spec.tsx
@@ -347,12 +347,31 @@ describe('OrganizationCard Component', () => {
     });
   });
 
-  it('should handle membership withdrawal error when request not found', async () => {
+  it('should log development error and show generic error toast', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    // Mock process.env.NODE_ENV to 'development'
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
+
     const props = {
       ...defaultProps,
+      userId: 'mockUserId',
       membershipRequestStatus: 'pending',
-      membershipRequests: [], // Empty requests to trigger error
+      membershipRequests: [{ _id: 'requestId', user: { _id: 'mockUserId' } }],
     };
+
+    const errorMocks: MockedResponse[] = [
+      {
+        request: {
+          query: CANCEL_MEMBERSHIP_REQUEST,
+          variables: { membershipRequestId: 'requestId' },
+        },
+        error: new Error('Withdrawal failed'),
+      },
+    ];
 
     render(
       <TestWrapper mocks={errorMocks}>
@@ -364,7 +383,147 @@ describe('OrganizationCard Component', () => {
     await fireEvent.click(withdrawButton);
 
     await waitFor(() => {
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'Failed to withdraw membership request:',
+        expect.any(Error),
+      );
+      expect(toast.error).toHaveBeenCalledWith('errorOccured');
+    });
+
+    // Restore original environment
+    process.env.NODE_ENV = originalNodeEnv;
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('should handle already joined error when joining organization', async () => {
+    const errorMocksWithAlreadyJoined: MockedResponse[] = [
+      {
+        request: {
+          query: JOIN_PUBLIC_ORGANIZATION,
+          variables: { organizationId: '123' },
+        },
+        result: {
+          errors: [
+            {
+              message: 'Already a member',
+              extensions: { code: 'ALREADY_MEMBER' },
+            },
+          ],
+        },
+      },
+    ];
+
+    render(
+      <TestWrapper mocks={errorMocksWithAlreadyJoined}>
+        <OrganizationCard
+          {...defaultProps}
+          userRegistrationRequired={false}
+          isJoined={false}
+        />
+      </TestWrapper>,
+    );
+
+    const joinButton = screen.getByText('joinNow');
+    await fireEvent.click(joinButton);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('AlreadyJoined');
+    });
+  });
+  it('should handle membership request not found', async () => {
+    // Mock getItem to return a userId that exists
+    mockGetItem.mockReturnValue('testUserId');
+
+    // Create mutation spy
+    const cancelRequestSpy = vi.fn(() => ({
+      data: {
+        cancelMembershipRequest: { success: true },
+      },
+    }));
+
+    const mocksWithSpy = [
+      ...successMocks,
+      {
+        request: {
+          query: CANCEL_MEMBERSHIP_REQUEST,
+          variables: { membershipRequestId: 'requestId' },
+        },
+        result: cancelRequestSpy,
+      },
+    ];
+
+    const props = {
+      ...defaultProps,
+      membershipRequestStatus: 'pending',
+      membershipRequests: [
+        {
+          _id: 'requestId',
+          user: {
+            _id: 'differentUserId', // Different user ID to trigger not found case
+          },
+        },
+      ],
+    };
+
+    render(
+      <TestWrapper mocks={mocksWithSpy}>
+        <OrganizationCard {...props} isJoined={false} />
+      </TestWrapper>,
+    );
+
+    const withdrawButton = screen.getByTestId('withdrawBtn');
+    await fireEvent.click(withdrawButton);
+
+    await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith('MembershipRequestNotFound');
     });
+
+    // Verify the mutation was not called
+    expect(cancelRequestSpy).not.toHaveBeenCalled();
+  });
+
+  it('should handle withdrawal attempt with no userId', async () => {
+    // Mock getItem to return null to simulate no userId
+    mockGetItem.mockReturnValue(null);
+
+    // Create mutation spy
+    const cancelRequestSpy = vi.fn(() => ({
+      data: {
+        cancelMembershipRequest: { success: true },
+      },
+    }));
+
+    const mocksWithSpy = [
+      ...successMocks,
+      {
+        request: {
+          query: CANCEL_MEMBERSHIP_REQUEST,
+          variables: { membershipRequestId: 'requestId' },
+        },
+        result: cancelRequestSpy,
+      },
+    ];
+
+    const props = {
+      ...defaultProps,
+      membershipRequestStatus: 'pending',
+      membershipRequests: [{ _id: 'requestId', user: { _id: 'mockUserId' } }],
+    };
+
+    render(
+      <TestWrapper mocks={mocksWithSpy}>
+        <OrganizationCard {...props} isJoined={false} />
+      </TestWrapper>,
+    );
+
+    const withdrawButton = screen.getByTestId('withdrawBtn');
+    await fireEvent.click(withdrawButton);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('UserIdNotFound');
+    });
+
+    // Verify that the cancelMembershipRequest mutation was not called
+    expect(cancelRequestSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**
Achieved 100% Code Coverage for OrganizationCard Component

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:** #3459 

**Snapshots/Videos:**

![Screenshot 2025-01-27 181520](https://github.com/user-attachments/assets/2eeec125-46d3-421c-9cd1-e91d43eb7022)


<!--Add link to Talawa-Docs.-->

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No, this PR does not introduce a breaking chan

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Tests**
    - Enhanced test coverage for the `OrganizationCard` component.
    - Added tests for handling membership withdrawal errors and displaying appropriate toast messages.
    - Improved handling of edge cases such as duplicate membership, missing user ID, and membership requests not found.
    - Strengthened error message validation for organization-related actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->