### PR TITLE
Fix Search Functionality for Full Name and Partial Matches in People Section (#3388)

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1006,7 +1006,8 @@
   },
   "people": {
     "title": "People",
-    "searchUsers": "Search users"
+    "searchUsers": "Search users",
+    "nothingToShow": "Nothing to show here."
   },
   "userLogin": {
     "login": "Login",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -966,7 +966,8 @@
   },
   "people": {
     "title": "Personnes",
-    "searchUsers": "Rechercher des utilisateurs"
+    "searchUsers": "Rechercher des utilisateurs",
+    "nothingToShow": "Rien à afficher ici."
   },
   "userLogin": {
     "login": "Se connecter",

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -966,7 +966,8 @@
   },
   "people": {
     "title": "लोग",
-    "searchUsers": "उपयोगकर्ताओं को खोजें"
+    "searchUsers": "उपयोगकर्ताओं को खोजें",
+    "nothingToShow": "यहां दिखाने के लिए कुछ नहीं है।"
   },
   "userLogin": {
     "login": "लॉग इन करें",

--- a/public/locales/sp/translation.json
+++ b/public/locales/sp/translation.json
@@ -981,7 +981,8 @@
   },
   "people": {
     "title": "Gente",
-    "searchUsers": "Buscar usuarios"
+    "searchUsers": "Buscar usuarios",
+    "nothingToShow": "Nada que mostrar aquí."
   },
   "userRegister": {
     "register": "Registro",

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -980,7 +980,8 @@
   },
   "people": {
     "title": "人们",
-    "searchUsers": "搜索用户"
+    "searchUsers": "搜索用户",
+    "nothingToShow": "这里没有可显示的内容。"
   },
   "userRegister": {
     "enterFirstName": "输入您的名字",

--- a/src/screens/UserPortal/People/People.spec.tsx
+++ b/src/screens/UserPortal/People/People.spec.tsx
@@ -75,7 +75,6 @@ const MOCKS = [
       variables: {
         orgId: '',
         firstName_contains: '',
-        lastName_contains: '',
       },
     },
     result: {
@@ -147,7 +146,7 @@ const MOCKS = [
   {
     request: {
       query: ORGANIZATION_ADMINS_LIST,
-      variables: { orgId: '' },
+      variables: { id: '' },
     },
     result: {
       data: {
@@ -337,6 +336,7 @@ describe('Testing People Screen Pagination [User Portal]', () => {
         variables: {
           orgId: '',
           firstName_contains: '',
+          lastName_contains: '',
         },
       },
       result: {
@@ -483,7 +483,11 @@ describe('People Component Mode Switch Coverage', () => {
       {
         request: {
           query: ORGANIZATIONS_MEMBER_CONNECTION_LIST,
-          variables: { orgId: '', firstName_contains: '' },
+          variables: {
+            orgId: '',
+            firstName_contains: '',
+            lastName_contains: '',
+          },
         },
         result: {
           data: {
@@ -596,7 +600,11 @@ describe('People Component Mode Switch Coverage', () => {
       {
         request: {
           query: ORGANIZATIONS_MEMBER_CONNECTION_LIST,
-          variables: { orgId: '', firstName_contains: '' },
+          variables: {
+            orgId: '',
+            firstName_contains: '',
+            lastName_contains: '',
+          },
         },
         result: {
           data: {
@@ -713,7 +721,6 @@ describe('People Additional Flow Tests', () => {
       },
     },
   };
-
   it('handles full name search correctly', async () => {
     const fullNameMock = {
       request: {
@@ -741,17 +748,14 @@ describe('People Additional Flow Tests', () => {
         },
       },
     };
-
     renderComponent([fullNameMock, defaultAdminMock]);
     await wait();
-
     const searchInput = screen.getByTestId('searchInput');
     await act(async () => {
       userEvent.clear(searchInput);
       userEvent.type(searchInput, 'Noble Mittal');
       userEvent.click(screen.getByTestId('searchBtn'));
     });
-
     await waitFor(() => {
       expect(screen.getByText('Noble Mittal')).toBeInTheDocument();
     });
@@ -801,7 +805,11 @@ describe('People Additional Flow Tests', () => {
       {
         request: {
           query: ORGANIZATIONS_MEMBER_CONNECTION_LIST,
-          variables: { orgId: '', firstName_contains: '' },
+          variables: {
+            orgId: '',
+            firstName_contains: '',
+            lastName_contains: '',
+          },
         },
         result: {
           data: {
@@ -1023,7 +1031,7 @@ describe('People Component Additional Coverage Tests', () => {
     const membersMock = {
       request: {
         query: ORGANIZATIONS_MEMBER_CONNECTION_LIST,
-        variables: { orgId: '', firstName_contains: '' },
+        variables: { orgId: '', firstName_contains: '', lastName_contains: '' },
       },
       result: {
         data: {
@@ -1059,7 +1067,7 @@ describe('People Component Pagination Tests', () => {
   const mockData = {
     request: {
       query: ORGANIZATIONS_MEMBER_CONNECTION_LIST,
-      variables: { orgId: '', firstName_contains: '' },
+      variables: { orgId: '', firstName_contains: '', lastName_contains: '' },
     },
     result: {
       data: {

--- a/src/screens/UserPortal/People/People.tsx
+++ b/src/screens/UserPortal/People/People.tsx
@@ -112,9 +112,16 @@ export default function people(): JSX.Element {
     setPage(0);
   };
 
-  const handleSearch = (newFilter: string): void => {
+  const handleSearch = (userName: string): void => {
+    // Split input into firstName and lastName
+    const [firstName = '', lastName = ''] = userName.trim().split(' ');
+
+    const newFilterData = {
+      firstName_contains: firstName,
+      lastName_contains: lastName,
+    };
     refetch({
-      firstName_contains: newFilter,
+      ...newFilterData,
     });
   };
 

--- a/src/screens/UserPortal/People/People.tsx
+++ b/src/screens/UserPortal/People/People.tsx
@@ -88,6 +88,7 @@ export default function people(): JSX.Element {
       variables: {
         orgId: organizationId,
         firstName_contains: '',
+        lastName_contains: '',
       },
     },
   );
@@ -113,15 +114,10 @@ export default function people(): JSX.Element {
   };
 
   const handleSearch = (userName: string): void => {
-    // Split input into firstName and lastName
     const [firstName = '', lastName = ''] = userName.trim().split(' ');
-
-    const newFilterData = {
+    refetch({
       firstName_contains: firstName,
       lastName_contains: lastName,
-    };
-    refetch({
-      ...newFilterData,
     });
   };
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**

Fixes #3388 

**Snapshots/Videos:**


https://github.com/user-attachments/assets/fff531b8-d948-4bca-972d-4d93e80f065c


**If relevant, did you update the documentation?**

No

**Summary**

This PR addresses the issue where the search functionality in the "People" section fails to return results when searching with a full name, partial matches beyond the first name, or queries with extra spaces. The current behavior shows "people.nothingToShow," which is not helpful or accurate. This fix improves the search functionality to support full names, partial matches, and handles spaces correctly, ensuring that users can find a person even with incomplete or extended queries.

**Does this PR introduce a breaking change?**

No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes