### PR TITLE
Upgrade package react-toastify from ^10.0.6 to ^11.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "react-multi-carousel": "^2.8.5",
         "react-redux": "^9.1.2",
         "react-router-dom": "^6.27.0",
-        "react-toastify": "^10.0.6",
+        "react-toastify": "^11.0.3",
         "react-tooltip": "^5.28.0",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0",
@@ -19183,16 +19183,16 @@
       }
     },
     "node_modules/react-toastify": {
-      "version": "10.0.6",
-      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.6.tgz",
-      "integrity": "sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.3.tgz",
+      "integrity": "sha512-cbPtHJPfc0sGqVwozBwaTrTu1ogB9+BLLjd4dDXd863qYLj7DGrQ2sg5RAChjFUB4yc3w8iXOtWcJqPK/6xqRQ==",
       "license": "MIT",
       "dependencies": {
-        "clsx": "^2.1.0"
+        "clsx": "^2.1.1"
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/react-tooltip": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-multi-carousel": "^2.8.5",
     "react-redux": "^9.1.2",
     "react-router-dom": "^6.27.0",
-    "react-toastify": "^10.0.6",
+    "react-toastify": "^11.0.3",
     "react-tooltip": "^5.28.0",
     "redux": "^5.0.1",
     "redux-thunk": "^3.1.0",

--- a/src/components/EventRegistrantsModal/AddOnSpotAttendee.tsx
+++ b/src/components/EventRegistrantsModal/AddOnSpotAttendee.tsx
@@ -94,7 +94,6 @@ const AddOnSpotAttendee: React.FC<InterfaceAddOnSpotAttendeeProps> = ({
         handleClose();
       }
     } catch (error) {
-      /* istanbul ignore next */
       errorHandler(t, error as Error);
     } finally {
       setIsSubmitting(false);

--- a/src/components/EventRegistrantsModal/AddOnSpotAttendee.tsx
+++ b/src/components/EventRegistrantsModal/AddOnSpotAttendee.tsx
@@ -4,7 +4,6 @@ import { Modal, Form, Button, Spinner } from 'react-bootstrap';
 import { useParams } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
 import { toast } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
 import type {
   InterfaceAddOnSpotAttendeeProps,
   InterfaceFormData,

--- a/src/components/OrgListCard/OrgListCard.spec.tsx
+++ b/src/components/OrgListCard/OrgListCard.spec.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-import { act } from 'react-dom/test-utils';
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, test, expect, vi, beforeEach } from 'vitest';
 import { I18nextProvider } from 'react-i18next';

--- a/src/components/OrgListCard/OrgListCard.spec.tsx
+++ b/src/components/OrgListCard/OrgListCard.spec.tsx
@@ -41,8 +41,8 @@ const MOCKS = [
 const link = new StaticMockLink(MOCKS, true);
 
 async function wait(ms = 100): Promise<void> {
-  await act(() => {
-    return new Promise((resolve) => {
+  await act(async () => {
+    await new Promise((resolve) => {
       setTimeout(resolve, ms);
     });
   });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,7 +19,6 @@ import 'react-datepicker/dist/react-datepicker.css'; // React Datepicker Styles
 import 'flag-icons/css/flag-icons.min.css'; // Flag Icons Styles
 import { Provider } from 'react-redux';
 import { ToastContainer, toast } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
 import { LocalizationProvider } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 


### PR DESCRIPTION
What kind of change does this PR introduce?
Upgrades React-Toastify from ^10.0.6 to ^11.0.3.

Issue Number:
Fixes #3514 

Summary of changes
Upgraded React-Toastify from 10.0.6 to 11.0.3.
Removed unnecessary CSS import since v11 now injects styles automatically.
Verified that toast notifications work as expected.
act from react-dom/test-utils is deprecated, use @testing-library/react instead

Does this PR introduce a breaking change?
No

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Upgraded the toast notification library to version 11.0.3 for enhanced performance and features.
	- Removed default styling imports for toast notifications, which may affect their visual presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->