### PR TITLE
BugFix: Excludes the file src/utils/useLocalstorage.ts from linting

### DIFF
--- a/docs/docs/auto-docs/components/EventRegistrantsModal/AddOnSpotAttendee/functions/default.md
+++ b/docs/docs/auto-docs/components/EventRegistrantsModal/AddOnSpotAttendee/functions/default.md
@@ -6,7 +6,7 @@
 
 > **default**(`props`, `deprecatedLegacyContext`?): `ReactNode`
 
-Defined in: [src/components/EventRegistrantsModal/AddOnSpotAttendee.tsx:21](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/EventRegistrantsModal/AddOnSpotAttendee.tsx#L21)
+Defined in: [src/components/EventRegistrantsModal/AddOnSpotAttendee.tsx:20](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/EventRegistrantsModal/AddOnSpotAttendee.tsx#L20)
 
 Modal component for adding on-spot attendees to an event
 

--- a/docs/docs/auto-docs/utils/useLocalstorage/functions/getItem.md
+++ b/docs/docs/auto-docs/utils/useLocalstorage/functions/getItem.md
@@ -6,7 +6,7 @@
 
 > **getItem**(`prefix`, `key`): `any`
 
-Defined in: [src/utils/useLocalstorage.ts:29](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/useLocalstorage.ts#L29)
+Defined in: [src/utils/useLocalstorage.ts:36](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/useLocalstorage.ts#L36)
 
 Retrieves the stored value for the given key from local storage.
 

--- a/docs/docs/auto-docs/utils/useLocalstorage/functions/getStorageKey.md
+++ b/docs/docs/auto-docs/utils/useLocalstorage/functions/getStorageKey.md
@@ -6,7 +6,7 @@
 
 > **getStorageKey**(`prefix`, `key`): `string`
 
-Defined in: [src/utils/useLocalstorage.ts:19](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/useLocalstorage.ts#L19)
+Defined in: [src/utils/useLocalstorage.ts:25](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/useLocalstorage.ts#L25)
 
 Generates the prefixed key for storage.
 

--- a/docs/docs/auto-docs/utils/useLocalstorage/functions/removeItem.md
+++ b/docs/docs/auto-docs/utils/useLocalstorage/functions/removeItem.md
@@ -6,7 +6,7 @@
 
 > **removeItem**(`prefix`, `key`): `void`
 
-Defined in: [src/utils/useLocalstorage.ts:51](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/useLocalstorage.ts#L51)
+Defined in: [src/utils/useLocalstorage.ts:59](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/useLocalstorage.ts#L59)
 
 Removes the value associated with the given key from local storage.
 

--- a/docs/docs/auto-docs/utils/useLocalstorage/functions/setItem.md
+++ b/docs/docs/auto-docs/utils/useLocalstorage/functions/setItem.md
@@ -6,7 +6,7 @@
 
 > **setItem**(`prefix`, `key`, `value`): `void`
 
-Defined in: [src/utils/useLocalstorage.ts:41](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/useLocalstorage.ts#L41)
+Defined in: [src/utils/useLocalstorage.ts:49](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/useLocalstorage.ts#L49)
 
 Sets the value for the given key in local storage.
 

--- a/docs/docs/auto-docs/utils/useLocalstorage/functions/useLocalStorage.md
+++ b/docs/docs/auto-docs/utils/useLocalstorage/functions/useLocalStorage.md
@@ -6,7 +6,7 @@
 
 > **useLocalStorage**(`prefix`): `InterfaceStorageHelper`
 
-Defined in: [src/utils/useLocalstorage.ts:61](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/useLocalstorage.ts#L61)
+Defined in: [src/utils/useLocalstorage.ts:70](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/useLocalstorage.ts#L70)
 
 Custom hook for simplified localStorage operations.
 

--- a/src/utils/useLocalstorage.ts
+++ b/src/utils/useLocalstorage.ts
@@ -1,8 +1,14 @@
 /**
  * Helper interface for managing localStorage operations.
+ * The 'any' type is necessary here to handle diverse data types that can be stored
+ * in localStorage. While this violates TypeScript's strict typing principles,
+ * it provides the flexibility needed for a general-purpose storage utility.
+ * This file contains ESLint disable comments to suppress warnings about using 'any' type.
  */
 interface InterfaceStorageHelper {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getItem: (key: string) => any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setItem: (key: string, value: any) => void;
   removeItem: (key: string) => void;
   getStorageKey: (key: string) => string;
@@ -26,6 +32,7 @@ export const getStorageKey = (prefix: string, key: string): string => {
  * @param key - The unique name identifying the value.
  * @returns - The stored value for the given key from local storage.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const getItem = (prefix: string, key: string): any => {
   const prefixedKey = getStorageKey(prefix, key);
   const storedData = localStorage.getItem(prefixedKey);
@@ -38,6 +45,7 @@ export const getItem = (prefix: string, key: string): any => {
  * @param key - The unique name identifying the value.
  * @param value - The value for the key.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
 export const setItem = (prefix: string, key: string, value: any): void => {
   const prefixedKey = getStorageKey(prefix, key);
   localStorage.setItem(prefixedKey, JSON.stringify(value));
@@ -58,11 +66,13 @@ export const removeItem = (prefix: string, key: string): void => {
  * @param prefix - Prefix to be added to the key, common for all keys. Default is 'Talawa-admin'.
  * @returns - Functions to getItem, setItem, removeItem, and getStorageKey.
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const useLocalStorage = (
   prefix: string = PREFIX,
 ): InterfaceStorageHelper => {
   return {
     getItem: (key: string) => getItem(prefix, key),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setItem: (key: string, value: any) => setItem(prefix, key, value),
     removeItem: (key: string) => removeItem(prefix, key),
     getStorageKey: (key: string) => getStorageKey(prefix, key),


### PR DESCRIPTION
**What kind of change does this PR introduce?**

BugFix

**Issue Number:**

Fixes #3490 

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**
This PR adds ignore statements for ESLint to the useLocalstorage.ts file. The file uses any type to handle diverse data types in localStorage, which triggers ESLint warnings. By adding targeted ESLint disable comments, we maintain code functionality while properly documenting intentional linting exceptions.

Changes:

1.Added ESLint disable comments for no-explicit-any warnings
2.Added ESLint disable comment for explicit-module-boundary-types
3.Improved documentation explaining any type usage

**Does this PR introduce a breaking change?**
No


## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->