### PR TITLE
Fix: Prevent Success Message on Failed Data Reception #3391

### DIFF
--- a/src/components/UserPortal/PostCard/PostCard.tsx
+++ b/src/components/UserPortal/PostCard/PostCard.tsx
@@ -276,10 +276,12 @@ export default function postCard(props: InterfacePostCard): JSX.Element {
         },
       });
 
-      if(createEventData){
+      if (createEventData) {
         props.fetchPosts(); // Refresh the posts
         toggleEditPost();
-        toast.success(tCommon('updatedSuccessfully', { item: 'Post' }) as string);
+        toast.success(
+          tCommon('updatedSuccessfully', { item: 'Post' }) as string,
+        );
       }
     } catch (error: unknown) {
       errorHandler(t, error);

--- a/src/components/UserPortal/PostCard/PostCard.tsx
+++ b/src/components/UserPortal/PostCard/PostCard.tsx
@@ -277,9 +277,9 @@ export default function postCard(props: InterfacePostCard): JSX.Element {
       });
 
       if(createEventData){
-      props.fetchPosts(); // Refresh the posts
-      toggleEditPost();
-      toast.success(tCommon('updatedSuccessfully', { item: 'Post' }) as string);
+        props.fetchPosts(); // Refresh the posts
+        toggleEditPost();
+        toast.success(tCommon('updatedSuccessfully', { item: 'Post' }) as string);
       }
     } catch (error: unknown) {
       errorHandler(t, error);

--- a/src/components/UserPortal/PostCard/PostCard.tsx
+++ b/src/components/UserPortal/PostCard/PostCard.tsx
@@ -267,18 +267,20 @@ export default function postCard(props: InterfacePostCard): JSX.Element {
   };
 
   // Edit the post
-  const handleEditPost = (): void => {
+  const handleEditPost = async (): Promise<void> => {
     try {
-      editPost({
+      const { data: createEventData } = await editPost({
         variables: {
           id: props.id,
           text: postContent,
         },
       });
 
+      if(createEventData){
       props.fetchPosts(); // Refresh the posts
       toggleEditPost();
       toast.success(tCommon('updatedSuccessfully', { item: 'Post' }) as string);
+      }
     } catch (error: unknown) {
       errorHandler(t, error);
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

 Prevent Success Message on Failed Data Reception

**Issue Number:**

Fixes #3391 

**Snapshots/Videos:**

https://github.com/user-attachments/assets/d88dea2b-65f6-48f7-9e5f-9ed19b31678e

**Summary**

Currently, the system displays a success message even when the API fails to return the expected response after an edit operation. This can mislead users into thinking their changes were successfully applied when they weren't.

**Does this PR introduce a breaking change?**

NO

## Checklist

### CodeRabbit AI Review
- [ Y ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ Y ] I have implemented or provided justification for each non-critical suggestion
- [ Y ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ Y ] I have written tests for all new changes/features
- [ Y ] I have verified that test coverage meets or exceeds 95%
- [ Y ] I have run the test suite locally and all tests pass

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the post editing experience to offer real-time updates. Now, when you edit a post, the system verifies the update before refreshing content and displaying a confirmation message, ensuring your changes are reliably reflected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->