### PR TITLE
fix: deleted posts still visible after removal (#3602)

### DIFF
--- a/src/components/UserPortal/PostCard/PostCard.tsx
+++ b/src/components/UserPortal/PostCard/PostCard.tsx
@@ -289,16 +289,18 @@ export default function postCard(props: InterfacePostCard): JSX.Element {
   };
 
   // Delete the post
-  const handleDeletePost = (): void => {
+  const handleDeletePost = async (): Promise<void> => {
     try {
-      deletePost({
+      const { data: createEventData } = await deletePost({
         variables: {
           id: props.id,
         },
       });
 
-      props.fetchPosts(); // Refresh the posts
-      toast.success('Successfully deleted the Post.');
+      if (createEventData) {
+        props.fetchPosts(); // Refresh the posts
+        toast.success('Successfully deleted the Post.');
+      }
     } catch (error: unknown) {
       errorHandler(t, error);
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Ensures Deleted Posts Are No Longer Visible in posts section of user portal.

**Issue Number:**

#3602 

**Snapshots/Videos:**

https://github.com/user-attachments/assets/c8cad3e4-9afb-40dd-b50b-c2b48e61e6a3


**If relevant, did you update the documentation?**

No

**Summary**

A issue like this can cause confusion for any individual using talawa services as if post is not deleted then they might delete some other post in confusion.

**Does this PR introduce a breaking change?**

There is not any breaking change just a simple awaiting till data is updated.

## Checklist

### CodeRabbit AI Review
- [ Y ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ Y ] I have implemented or provided justification for each non-critical suggestion
- [ Y ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ Y ] I have written tests for all new changes/features
- [ Y ] I have verified that test coverage meets or exceeds 95%
- [ Y ] I have run the test suite locally and all tests pass


**Other information**

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the post deletion process to ensure that posts are removed only after the deletion is fully processed, resulting in more reliable updates and confirmation notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->