### PR TITLE
fix(query): remove pluginCreationAllowed from query

### DIFF
--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ADMIN_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ADMIN_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **ADMIN\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:707](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L707)
+Defined in: [src/GraphQl/Queries/Queries.ts:706](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L706)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_COMMUNITY_DATA.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_COMMUNITY_DATA.md
@@ -6,4 +6,4 @@
 
 > `const` **GET\_COMMUNITY\_DATA**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:839](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L839)
+Defined in: [src/GraphQl/Queries/Queries.ts:838](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L838)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_COMMUNITY_SESSION_TIMEOUT_DATA.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_COMMUNITY_SESSION_TIMEOUT_DATA.md
@@ -6,4 +6,4 @@
 
 > `const` **GET\_COMMUNITY\_SESSION\_TIMEOUT\_DATA**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:860](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L860)
+Defined in: [src/GraphQl/Queries/Queries.ts:859](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L859)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/MEMBERSHIP_REQUEST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/MEMBERSHIP_REQUEST.md
@@ -6,4 +6,4 @@
 
 > `const` **MEMBERSHIP\_REQUEST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:724](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L724)
+Defined in: [src/GraphQl/Queries/Queries.ts:723](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L723)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ORGANIZATION_DONATION_CONNECTION_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ORGANIZATION_DONATION_CONNECTION_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **ORGANIZATION\_DONATION\_CONNECTION\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:686](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L686)
+Defined in: [src/GraphQl/Queries/Queries.ts:685](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L685)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ORGANIZATION_EVENT_CONNECTION_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ORGANIZATION_EVENT_CONNECTION_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **ORGANIZATION\_EVENT\_CONNECTION\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:630](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L630)
+Defined in: [src/GraphQl/Queries/Queries.ts:629](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L629)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ORGANIZATION_EVENT_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ORGANIZATION_EVENT_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **ORGANIZATION\_EVENT\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:611](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L611)
+Defined in: [src/GraphQl/Queries/Queries.ts:610](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L610)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USERS_CONNECTION_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USERS_CONNECTION_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **USERS\_CONNECTION\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:750](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L750)
+Defined in: [src/GraphQl/Queries/Queries.ts:749](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L749)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/VERIFY_ROLE.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/VERIFY_ROLE.md
@@ -6,4 +6,4 @@
 
 > `const` **VERIFY\_ROLE**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:867](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L867)
+Defined in: [src/GraphQl/Queries/Queries.ts:866](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L866)

--- a/src/GraphQl/Queries/Queries.ts
+++ b/src/GraphQl/Queries/Queries.ts
@@ -592,7 +592,6 @@ export const USER_DETAILS = gql`
         }
         isSuperAdmin
         appLanguageCode
-        pluginCreationAllowed
         createdOrganizations {
           _id
         }

--- a/src/screens/MemberDetail/MemberDetail.spec.tsx
+++ b/src/screens/MemberDetail/MemberDetail.spec.tsx
@@ -191,7 +191,6 @@ describe('MemberDetail', () => {
     userEvent.clear(screen.getByPlaceholderText(/Phone/i));
     userEvent.type(screen.getByPlaceholderText(/Phone/i), formData.phoneNumber);
 
-    // userEvent.click(screen.getByPlaceholderText(/pluginCreationAllowed/i));
     // userEvent.selectOptions(screen.getByTestId('applangcode'), 'Français');
     // userEvent.upload(screen.getByLabelText(/Display Image:/i), formData.image);
     await wait();


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Removes `pluginCreationAllowed` from the query as it was missed in[ this pr](https://github.com/PalisadoesFoundation/talawa-admin/pull/3804)

**Issue Number:**

Fixes #3793

**Snapshots/Videos:**

N/A

**If relevant, did you update the documentation?**

N/A

**Summary**

Mentioned above

**Does this PR introduce a breaking change?**

N/A

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to reflect accurate reference details for multiple query variables.
- **Refactor**
  - Streamlined the user profile data response by removing an extraneous attribute from the `USER_DETAILS` query.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->