### PR TITLE
[test]:improve coverage of TagActions.tsx in src/components/TagActions

### DIFF
--- a/docs/docs/auto-docs/components/ChangeLanguageDropdown/ChangeLanguageDropDown/functions/default.md
+++ b/docs/docs/auto-docs/components/ChangeLanguageDropdown/ChangeLanguageDropDown/functions/default.md
@@ -6,7 +6,7 @@
 
 > **default**(`props`): `Element`
 
-Defined in: [src/components/ChangeLanguageDropdown/ChangeLanguageDropDown.tsx:24](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/ChangeLanguageDropdown/ChangeLanguageDropDown.tsx#L24)
+Defined in: [src/components/ChangeLanguageDropdown/ChangeLanguageDropDown.tsx:25](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/ChangeLanguageDropdown/ChangeLanguageDropDown.tsx#L25)
 
 A dropdown component that allows users to change the application's language.
 It updates the user's language preference in the backend and stores the selection in cookies.

--- a/docs/docs/auto-docs/components/OrgSettings/General/GeneralSettings/functions/default.md
+++ b/docs/docs/auto-docs/components/OrgSettings/General/GeneralSettings/functions/default.md
@@ -6,7 +6,7 @@
 
 > **default**(`props`, `deprecatedLegacyContext`?): `ReactNode`
 
-Defined in: [src/components/OrgSettings/General/GeneralSettings.tsx:22](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/OrgSettings/General/GeneralSettings.tsx#L22)
+Defined in: [src/components/OrgSettings/General/GeneralSettings.tsx:23](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/OrgSettings/General/GeneralSettings.tsx#L23)
 
 A component for displaying general settings for an organization.
 


### PR DESCRIPTION
# Improve Code Coverage for TagActions Component

## What kind of change does this PR introduce?
Refactoring and test improvements

## Issue Number:
Fixes #3678 
## Snapshots/Videos:
After:
![Screenshot from 2025-03-15 13-42-14](https://github.com/user-attachments/assets/bbfb3016-9db7-4f7a-88e6-25563f6a309e)
Before:
![Screenshot from 2025-03-15 13-43-55](https://github.com/user-attachments/assets/25ab4eaa-c845-4d2f-9a39-0455eb17cb75)

## If relevant, did you update the documentation?
N/A - This is a testing improvement with no user-facing changes

## Summary
This PR improves the test coverage for the TagActions component to reach 100% Line code coverage. The main challenge was addressing partially covered lines containing conditional statements without explicit `else` branches.

The coverage tool was marking these lines as "partially covered" even though they were functionally covered by the tests:
- Conditional statements like `if (!fetchMoreResult) return prevResult;`
- Error handling conditionals like `if (error instanceof Error)`
- Nullish coalescing operators in expressions like `userTagsList?.length ?? 0`


## Does this PR introduce a breaking change?
No

## Checklist
### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95% (now at 100%)
- [x] I have run the test suite locally and all tests pass

## Other information
This PR shows how to properly test conditional statements that lack explicit `else` branches, which often appear as "partially covered" in coverage reports despite having full functional coverage.

### Have you read the [[contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)]?
Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced test scenarios to ensure robust tag management interactions.
  - Improved coverage for multi-select tag behavior, handling of empty tag lists, and proper modal state management to deliver a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->