### PR TITLE
Fix: NoMongo - Postgres Migration Support for Users/Settings page

### DIFF
--- a/src/screens/UserPortal/Settings/UserDetails/UserDetails.spec.tsx
+++ b/src/screens/UserPortal/Settings/UserDetails/UserDetails.spec.tsx
@@ -106,7 +106,7 @@ describe('UserDetailsForm', () => {
   it('shows/hides action buttons based on isUpdated prop', () => {
     const { rerender } = render(
       <MockedProvider mocks={MOCKS} addTypename={false}>
-        <UserDetailsForm {...defaultProps} isUpdated={true} />
+        <UserDetailsForm {...defaultProps} isUpdated={false} />
       </MockedProvider>,
     );
 
@@ -116,7 +116,7 @@ describe('UserDetailsForm', () => {
 
     rerender(
       <MockedProvider mocks={MOCKS} addTypename={false}>
-        <UserDetailsForm {...defaultProps} isUpdated={false} />
+        <UserDetailsForm {...defaultProps} isUpdated={true} />
       </MockedProvider>,
     );
 
@@ -128,7 +128,7 @@ describe('UserDetailsForm', () => {
   it('handles form submission correctly', async () => {
     render(
       <MockedProvider mocks={UPDATE_MOCK} addTypename={false}>
-        <UserDetailsForm {...defaultProps} isUpdated={false} />
+        <UserDetailsForm {...defaultProps} isUpdated={true} />
       </MockedProvider>,
     );
 
@@ -141,7 +141,7 @@ describe('UserDetailsForm', () => {
   it('handles reset changes correctly', async () => {
     render(
       <MockedProvider mocks={MOCKS} addTypename={false}>
-        <UserDetailsForm {...defaultProps} isUpdated={false} />
+        <UserDetailsForm {...defaultProps} isUpdated={true} />
       </MockedProvider>,
     );
 

--- a/src/screens/UserPortal/Settings/UserDetails/UserDetails.tsx
+++ b/src/screens/UserPortal/Settings/UserDetails/UserDetails.tsx
@@ -279,7 +279,7 @@ const UserDetailsForm: React.FC<InterfaceUserDetailsFormProps> = ({
         />
       </Col>
     </Row>
-    {!isUpdated && (
+    {isUpdated && (
       <div className="d-flex justify-content-between mt-4">
         <Button
           onClick={handleResetChanges}


### PR DESCRIPTION
**What kind of change does this PR introduce?**
This PR fix the minor bugs on the `user/Settings` page and ensure code coverage is 100%.
Fixed the conditional rendering of Settings form buttons, they are only visible when form is updated, Earlier this logic was opposite which was wrong.

**Issue Number:**
Fixes #3581

**Snapshots/Videos:**
<img width="1470" alt="Screenshot 2025-03-23 at 11 21 33" src="https://github.com/user-attachments/assets/af443880-93ad-43ab-be18-e8567e26af9d" />

<img width="1470" alt="Screenshot 2025-03-23 at 11 22 03" src="https://github.com/user-attachments/assets/1c098d1f-4729-4e64-9f14-033738bac3ba" />


**If relevant, did you update the documentation?**
N/A

**Summary**
**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Other information**
n/A

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Adjusted the display logic on the settings page so that reset and save buttons now appear only when user details have been updated, resulting in a clearer and more intuitive interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->