### PR TITLE
Fix/4010 admin count

### DIFF
--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ADMIN_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ADMIN_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **ADMIN\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:896](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L896)
+Defined in: [src/GraphQl/Queries/Queries.ts:900](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L900)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ALL_ORGANIZATIONS_PG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ALL_ORGANIZATIONS_PG.md
@@ -6,4 +6,4 @@
 
 > `const` **ALL\_ORGANIZATIONS\_PG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:90](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L90)
+Defined in: [src/GraphQl/Queries/Queries.ts:94](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L94)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/BLOCK_PAGE_MEMBER_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/BLOCK_PAGE_MEMBER_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **BLOCK\_PAGE\_MEMBER\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:651](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L651)
+Defined in: [src/GraphQl/Queries/Queries.ts:655](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L655)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/EVENT_ATTENDEES.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/EVENT_ATTENDEES.md
@@ -6,4 +6,4 @@
 
 > `const` **EVENT\_ATTENDEES**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:330](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L330)
+Defined in: [src/GraphQl/Queries/Queries.ts:334](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L334)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/EVENT_CHECKINS.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/EVENT_CHECKINS.md
@@ -6,4 +6,4 @@
 
 > `const` **EVENT\_CHECKINS**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:358](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L358)
+Defined in: [src/GraphQl/Queries/Queries.ts:362](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L362)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/EVENT_DETAILS.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/EVENT_DETAILS.md
@@ -6,4 +6,4 @@
 
 > `const` **EVENT\_DETAILS**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:284](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L284)
+Defined in: [src/GraphQl/Queries/Queries.ts:288](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L288)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/EVENT_FEEDBACKS.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/EVENT_FEEDBACKS.md
@@ -6,4 +6,4 @@
 
 > `const` **EVENT\_FEEDBACKS**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:378](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L378)
+Defined in: [src/GraphQl/Queries/Queries.ts:382](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L382)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/EVENT_REGISTRANTS.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/EVENT_REGISTRANTS.md
@@ -6,4 +6,4 @@
 
 > `const` **EVENT\_REGISTRANTS**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:348](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L348)
+Defined in: [src/GraphQl/Queries/Queries.ts:352](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L352)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_COMMUNITY_DATA.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_COMMUNITY_DATA.md
@@ -6,4 +6,4 @@
 
 > `const` **GET\_COMMUNITY\_DATA**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:1053](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L1053)
+Defined in: [src/GraphQl/Queries/Queries.ts:1057](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L1057)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_COMMUNITY_DATA_PG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_COMMUNITY_DATA_PG.md
@@ -6,4 +6,4 @@
 
 > `const` **GET\_COMMUNITY\_DATA\_PG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:1029](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L1029)
+Defined in: [src/GraphQl/Queries/Queries.ts:1033](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L1033)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_COMMUNITY_SESSION_TIMEOUT_DATA_PG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_COMMUNITY_SESSION_TIMEOUT_DATA_PG.md
@@ -6,4 +6,4 @@
 
 > `const` **GET\_COMMUNITY\_SESSION\_TIMEOUT\_DATA\_PG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:1090](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L1090)
+Defined in: [src/GraphQl/Queries/Queries.ts:1094](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L1094)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_ORGANIZATION_BLOCKED_USERS_PG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_ORGANIZATION_BLOCKED_USERS_PG.md
@@ -6,4 +6,4 @@
 
 > `const` **GET\_ORGANIZATION\_BLOCKED\_USERS\_PG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:452](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L452)
+Defined in: [src/GraphQl/Queries/Queries.ts:456](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L456)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_ORGANIZATION_DATA_PG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_ORGANIZATION_DATA_PG.md
@@ -6,4 +6,4 @@
 
 > `const` **GET\_ORGANIZATION\_DATA\_PG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:545](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L545)
+Defined in: [src/GraphQl/Queries/Queries.ts:549](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L549)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_ORGANIZATION_EVENTS_PG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_ORGANIZATION_EVENTS_PG.md
@@ -6,4 +6,4 @@
 
 > `const` **GET\_ORGANIZATION\_EVENTS\_PG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:493](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L493)
+Defined in: [src/GraphQl/Queries/Queries.ts:497](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L497)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_ORGANIZATION_MEMBERS_PG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_ORGANIZATION_MEMBERS_PG.md
@@ -6,4 +6,4 @@
 
 > `const` **GET\_ORGANIZATION\_MEMBERS\_PG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:430](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L430)
+Defined in: [src/GraphQl/Queries/Queries.ts:434](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L434)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_ORGANIZATION_POSTS_COUNT_PG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_ORGANIZATION_POSTS_COUNT_PG.md
@@ -6,4 +6,4 @@
 
 > `const` **GET\_ORGANIZATION\_POSTS\_COUNT\_PG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:394](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L394)
+Defined in: [src/GraphQl/Queries/Queries.ts:398](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L398)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_ORGANIZATION_POSTS_PG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_ORGANIZATION_POSTS_PG.md
@@ -6,4 +6,4 @@
 
 > `const` **GET\_ORGANIZATION\_POSTS\_PG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:524](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L524)
+Defined in: [src/GraphQl/Queries/Queries.ts:528](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L528)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_POSTS_BY_ORG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_POSTS_BY_ORG.md
@@ -6,4 +6,4 @@
 
 > `const` **GET\_POSTS\_BY\_ORG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:403](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L403)
+Defined in: [src/GraphQl/Queries/Queries.ts:407](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L407)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_USER_BY_ID.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/GET_USER_BY_ID.md
@@ -6,4 +6,4 @@
 
 > `const` **GET\_USER\_BY\_ID**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:421](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L421)
+Defined in: [src/GraphQl/Queries/Queries.ts:425](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L425)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/IS_USER_BLOCKED.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/IS_USER_BLOCKED.md
@@ -6,4 +6,4 @@
 
 > `const` **IS\_USER\_BLOCKED**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:474](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L474)
+Defined in: [src/GraphQl/Queries/Queries.ts:478](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L478)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/MEMBERSHIP_REQUEST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/MEMBERSHIP_REQUEST.md
@@ -6,4 +6,4 @@
 
 > `const` **MEMBERSHIP\_REQUEST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:913](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L913)
+Defined in: [src/GraphQl/Queries/Queries.ts:917](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L917)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/MEMBERS_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/MEMBERS_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **MEMBERS\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:637](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L637)
+Defined in: [src/GraphQl/Queries/Queries.ts:641](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L641)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/MEMBERS_LIST_PG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/MEMBERS_LIST_PG.md
@@ -6,4 +6,4 @@
 
 > `const` **MEMBERS\_LIST\_PG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:618](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L618)
+Defined in: [src/GraphQl/Queries/Queries.ts:622](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L622)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ORGANIZATIONS_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ORGANIZATIONS_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **ORGANIZATIONS\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:589](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L589)
+Defined in: [src/GraphQl/Queries/Queries.ts:593](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L593)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ORGANIZATIONS_MEMBER_CONNECTION_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ORGANIZATIONS_MEMBER_CONNECTION_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **ORGANIZATIONS\_MEMBER\_CONNECTION\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:678](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L678)
+Defined in: [src/GraphQl/Queries/Queries.ts:682](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L682)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ORGANIZATION_DONATION_CONNECTION_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ORGANIZATION_DONATION_CONNECTION_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **ORGANIZATION\_DONATION\_CONNECTION\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:875](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L875)
+Defined in: [src/GraphQl/Queries/Queries.ts:879](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L879)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ORGANIZATION_EVENT_CONNECTION_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/ORGANIZATION_EVENT_CONNECTION_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **ORGANIZATION\_EVENT\_CONNECTION\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:819](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L819)
+Defined in: [src/GraphQl/Queries/Queries.ts:823](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L823)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/RECURRING_EVENTS.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/RECURRING_EVENTS.md
@@ -6,4 +6,4 @@
 
 > `const` **RECURRING\_EVENTS**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:316](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L316)
+Defined in: [src/GraphQl/Queries/Queries.ts:320](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L320)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/SIGNIN_QUERY.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/SIGNIN_QUERY.md
@@ -6,4 +6,4 @@
 
 > `const` **SIGNIN\_QUERY**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:1074](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L1074)
+Defined in: [src/GraphQl/Queries/Queries.ts:1078](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L1078)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USERS_CONNECTION_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USERS_CONNECTION_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **USERS\_CONNECTION\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:940](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L940)
+Defined in: [src/GraphQl/Queries/Queries.ts:944](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L944)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USER_DETAILS.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USER_DETAILS.md
@@ -6,4 +6,4 @@
 
 > `const` **USER\_DETAILS**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:732](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L732)
+Defined in: [src/GraphQl/Queries/Queries.ts:736](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L736)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USER_JOINED_ORGANIZATIONS_PG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USER_JOINED_ORGANIZATIONS_PG.md
@@ -6,4 +6,4 @@
 
 > `const` **USER\_JOINED\_ORGANIZATIONS\_PG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:62](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L62)
+Defined in: [src/GraphQl/Queries/Queries.ts:64](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L64)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USER_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USER_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **USER\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:110](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L110)
+Defined in: [src/GraphQl/Queries/Queries.ts:114](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L114)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USER_LIST_FOR_TABLE.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USER_LIST_FOR_TABLE.md
@@ -6,4 +6,4 @@
 
 > `const` **USER\_LIST\_FOR\_TABLE**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:206](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L206)
+Defined in: [src/GraphQl/Queries/Queries.ts:210](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L210)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USER_LIST_REQUEST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USER_LIST_REQUEST.md
@@ -6,4 +6,4 @@
 
 > `const` **USER\_LIST\_REQUEST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:241](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L241)
+Defined in: [src/GraphQl/Queries/Queries.ts:245](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L245)

--- a/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USER_ORGANIZATION_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/Queries/variables/USER_ORGANIZATION_LIST.md
@@ -6,4 +6,4 @@
 
 > `const` **USER\_ORGANIZATION\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/Queries.ts:718](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L718)
+Defined in: [src/GraphQl/Queries/Queries.ts:722](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/Queries.ts#L722)

--- a/docs/docs/auto-docs/screens/UserPortal/Organizations/Organizations/functions/default.md
+++ b/docs/docs/auto-docs/screens/UserPortal/Organizations/Organizations/functions/default.md
@@ -6,7 +6,7 @@
 
 > **default**(): `Element`
 
-Defined in: [src/screens/UserPortal/Organizations/Organizations.tsx:163](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/screens/UserPortal/Organizations/Organizations.tsx#L163)
+Defined in: [src/screens/UserPortal/Organizations/Organizations.tsx:161](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/screens/UserPortal/Organizations/Organizations.tsx#L161)
 
 Component for displaying and managing user organizations.
 

--- a/src/GraphQl/Queries/Queries.ts
+++ b/src/GraphQl/Queries/Queries.ts
@@ -38,13 +38,15 @@ export const CURRENT_USER = gql`
 
 // Query to take the Organization list
 export const ORGANIZATION_LIST = gql`
-  query {
-    organizations {
+  query Organizations($filter: String) {
+    organizations(filter: $filter) {
       id
       name
       addressLine1
       description
       avatarURL
+      membersCount
+      adminsCount
       members(first: 32) {
         edges {
           node {
@@ -60,9 +62,9 @@ export const ORGANIZATION_LIST = gql`
 `;
 
 export const USER_JOINED_ORGANIZATIONS_PG = gql`
-  query UserJoinedOrganizations($id: String!, $first: Int!) {
+  query UserJoinedOrganizations($id: String!, $first: Int!, $filter: String) {
     user(input: { id: $id }) {
-      organizationsWhereMember(first: $first) {
+      organizationsWhereMember(first: $first, filter: $filter) {
         pageInfo {
           hasNextPage
         }
@@ -73,6 +75,8 @@ export const USER_JOINED_ORGANIZATIONS_PG = gql`
             addressLine1
             description
             avatarURL
+            membersCount
+            adminsCount
             members(first: 32) {
               edges {
                 node {


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where the admin count on organization cards was always showing 0, even when admins existed.

### Related Issue

Fixes #4010

### Summary of Fix

- Uses `adminsCount` and `membersCount` from the GraphQL API instead of trying to count locally from empty arrays.
- Cleans up how organization data is passed to the component.

### Testing Steps

1. Go to `/user/organizations`
2. View "All Organizations", "Joined", and "Created"
3. Confirm that admin and member counts are displayed correctly

### Additional Notes

This branch was created because GitHub workflows don't allow PRs from `develop → develop`.

Thanks!
