### PR TITLE
Fix: leave organization issue

### DIFF
--- a/src/GraphQl/Mutations/mutations.ts
+++ b/src/GraphQl/Mutations/mutations.ts
@@ -367,8 +367,10 @@ export const REMOVE_ADMIN_MUTATION = gql`
 // to Remove member from an organization
 export const REMOVE_MEMBER_MUTATION = gql`
   mutation RemoveMember($orgid: ID!, $userid: ID!) {
-    removeMember(data: { organizationId: $orgid, userId: $userid }) {
-      _id
+    deleteOrganizationMembership(
+      input: { organizationId: $orgid, memberId: $userid }
+    ) {
+      id
     }
   }
 `;

--- a/src/GraphQl/Queries/Queries.ts
+++ b/src/GraphQl/Queries/Queries.ts
@@ -585,20 +585,28 @@ export const GET_ORGANIZATION_DATA_PG = gql`
     }
   }
 `;
-// list of a organizations
+
+// Shared fragment with common organization fields
+export const ORGANIZATION_FIELDS = gql`
+  fragment OrganizationFields on Organization {
+    id
+    name
+    description
+    addressLine1
+    addressLine2
+    city
+    state
+    postalCode
+    countryCode
+    avatarURL
+  }
+`;
+
+// Full query with all fields (metadata, creator, updater, etc.)
 export const ORGANIZATIONS_LIST = gql`
   query Organizations {
     organizations {
-      id
-      name
-      description
-      addressLine1
-      addressLine2
-      city
-      state
-      postalCode
-      countryCode
-      avatarURL
+      ...OrganizationFields
       createdAt
       updatedAt
       creator {
@@ -613,6 +621,17 @@ export const ORGANIZATIONS_LIST = gql`
       }
     }
   }
+  ${ORGANIZATION_FIELDS}
+`;
+
+// Basic query using only the shared fragment (no metadata)
+export const ORGANIZATIONS_LIST_BASIC = gql`
+  query Organizations {
+    organizations {
+      ...OrganizationFields
+    }
+  }
+  ${ORGANIZATION_FIELDS}
 `;
 
 export const MEMBERS_LIST_PG = gql`

--- a/src/components/OrganizationScreen/OrganizationScreen.spec.tsx
+++ b/src/components/OrganizationScreen/OrganizationScreen.spec.tsx
@@ -159,4 +159,17 @@ describe('Testing OrganizationScreen', () => {
     // Clean up the spy
     warnSpy.mockRestore();
   });
+
+  test('displays event name when on event path with valid event', async () => {
+    mockUseParams.mockReturnValue({ orgId: '123' });
+    mockUseMatch.mockReturnValue({
+      params: { eventId: 'event123', orgId: '123' },
+    });
+    renderComponent();
+    await waitFor(() => {
+      const eventNameElement = screen.getByText('Test Event Title');
+      expect(eventNameElement).toBeInTheDocument();
+      expect(eventNameElement.tagName).toBe('H4');
+    });
+  });
 });

--- a/src/screens/UserPortal/LeaveOrganization/LeaveOrganization.spec.tsx
+++ b/src/screens/UserPortal/LeaveOrganization/LeaveOrganization.spec.tsx
@@ -10,7 +10,10 @@ import {
   useParams,
 } from 'react-router';
 import LeaveOrganization from './LeaveOrganization';
-import { ORGANIZATIONS_LIST, ORGANIZATION_LIST } from 'GraphQl/Queries/Queries';
+import {
+  ORGANIZATIONS_LIST_BASIC,
+  ORGANIZATION_LIST,
+} from 'GraphQl/Queries/Queries';
 import { REMOVE_MEMBER_MUTATION } from 'GraphQl/Mutations/mutations';
 import { getItem } from 'utils/useLocalstorage';
 import { toast } from 'react-toastify';
@@ -59,82 +62,24 @@ vi.mock('utils/useLocalstorage', () => {
 const mocks = [
   {
     request: {
-      query: ORGANIZATIONS_LIST,
+      query: ORGANIZATIONS_LIST_BASIC,
       variables: { id: 'test-org-id' },
     },
     result: {
       data: {
         organizations: [
           {
-            _id: 'test-org-id',
-            image: 'https://example.com/organization-image.png',
-            creator: {
-              firstName: 'John',
-              lastName: 'Doe',
-              email: 'john.doe@example.com',
-            },
+            id: 'test-org-id',
             name: 'Test Organization',
             description: 'This is a test organization.',
-            address: {
-              city: 'New York',
-              countryCode: 'US',
-              dependentLocality: null,
-              line1: '123 Main Street',
-              line2: 'Suite 456',
-              postalCode: '10001',
-              sortingCode: null,
-              state: 'NY',
-            },
-            userRegistrationRequired: true,
-            visibleInSearch: true,
-            members: [
-              {
-                _id: 'member-001',
-                firstName: 'Alice',
-                lastName: 'Smith',
-                email: 'alice.smith@example.com',
-              },
-              {
-                _id: 'member-002',
-                firstName: 'Bob',
-                lastName: 'Johnson',
-                email: 'bob.johnson@example.com',
-              },
-            ],
-            admins: [
-              {
-                _id: 'admin-001',
-                firstName: 'Jane',
-                lastName: 'Doe',
-                email: 'jane.doe@example.com',
-                createdAt: '2023-01-15T10:00:00Z',
-              },
-              {
-                _id: 'admin-002',
-                firstName: 'Tom',
-                lastName: 'Wilson',
-                email: 'tom.wilson@example.com',
-                createdAt: '2023-02-10T12:30:00Z',
-              },
-            ],
-            membershipRequests: [
-              {
-                _id: 'req-001',
-                user: {
-                  firstName: 'Emily',
-                  lastName: 'Brown',
-                  email: 'emily.brown@example.com',
-                },
-              },
-            ],
-            blockedUsers: [
-              {
-                _id: 'blocked-001',
-                firstName: 'Henry',
-                lastName: 'Clark',
-                email: 'henry.clark@example.com',
-              },
-            ],
+            addressLine1: '123 Test St',
+            addressLine2: 'Suite 100',
+            city: 'Test City',
+            state: 'Test State',
+            postalCode: '12345',
+            countryCode: 'US',
+            avatarURL: null,
+            __typename: 'Organization',
           },
         ],
       },
@@ -214,7 +159,7 @@ const mocks = [
 const errorMocks = [
   {
     request: {
-      query: ORGANIZATIONS_LIST,
+      query: ORGANIZATIONS_LIST_BASIC,
       variables: { id: 'test-org-id' },
     },
     error: new Error('Failed to load organization details'),
@@ -264,15 +209,10 @@ describe('LeaveOrganization Component', () => {
 
   test('renders organization details and displays content correctly', async () => {
     render(
-      <MockedProvider mocks={mocks} addTypename={false}>
-        <MemoryRouter initialEntries={['/user/leaveOrg/test-org-id']}>
-          <Routes>
-            <Route
-              path="/user/leaveOrg/:orgId"
-              element={<LeaveOrganization />}
-            />
-          </Routes>
-        </MemoryRouter>
+      <MockedProvider mocks={mocks.slice(0, 1)} addTypename={false}>
+        <BrowserRouter>
+          <LeaveOrganization />
+        </BrowserRouter>
       </MockedProvider>,
     );
     await waitFor(() => {
@@ -649,7 +589,7 @@ describe('LeaveOrganization Component', () => {
         mocks={[
           {
             request: {
-              query: ORGANIZATIONS_LIST,
+              query: ORGANIZATIONS_LIST_BASIC,
               variables: { id: undefined },
             },
             result: {
@@ -708,7 +648,7 @@ describe('LeaveOrganization Component', () => {
     // Create a mock that returns empty organizations array
     const emptyOrgMock = {
       request: {
-        query: ORGANIZATIONS_LIST,
+        query: ORGANIZATIONS_LIST_BASIC,
         variables: { id: 'test-org-id' },
       },
       result: {

--- a/src/screens/UserPortal/LeaveOrganization/LeaveOrganization.tsx
+++ b/src/screens/UserPortal/LeaveOrganization/LeaveOrganization.tsx
@@ -42,7 +42,10 @@
  */
 import React, { useState } from 'react';
 import { useQuery, useMutation } from '@apollo/client';
-import { ORGANIZATIONS_LIST, ORGANIZATION_LIST } from 'GraphQl/Queries/Queries';
+import {
+  ORGANIZATIONS_LIST_BASIC,
+  ORGANIZATION_LIST,
+} from 'GraphQl/Queries/Queries';
 import { REMOVE_MEMBER_MUTATION } from 'GraphQl/Mutations/mutations';
 import { Button, Modal, Form, Spinner, Alert } from 'react-bootstrap';
 import { useParams, useNavigate } from 'react-router';
@@ -84,7 +87,7 @@ const LeaveOrganization = (): JSX.Element => {
     data: orgData,
     loading: orgLoading,
     error: orgError,
-  } = useQuery(ORGANIZATIONS_LIST, { variables: { id: organizationId } });
+  } = useQuery(ORGANIZATIONS_LIST_BASIC, { variables: { id: organizationId } });
 
   /**
    * Mutation to remove the member from the organization.


### PR DESCRIPTION
**What kind of change does this PR introduce?**
user was not able to leave the organization, it showed ```You are not authorized to perform this action.``` due to a query issue.

<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:** #4019

**Snapshots/Videos:**

<img width="1710" height="912" alt="Image" src="https://github.com/user-attachments/assets/ac3b08c4-a5cd-4a8e-9178-50d3427b6165" />

After (Expected behavior):

https://github.com/user-attachments/assets/a7d51257-2a3f-4bc7-a9ce-c2c70f1f51c8

**Summary**

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a streamlined organizations list query that returns only basic organization details, offering a lighter data option alongside the existing detailed query.

* **Refactor**
  * Centralized common organization fields into a shared fragment for improved consistency and maintainability across queries.
  * Updated the organization member removal process to use a revised mutation and input structure for clarity and alignment with naming conventions.

* **Chores**
  * Updated internal usage to reference the new basic organizations list query where detailed metadata is not required.
  * Simplified test data and setup to align with the new basic organizations list query and updated mutation structure.
  * Added a new test verifying event name display in the organization screen when accessed via an event-specific path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->