### PR TITLE
Bug Fix: admin count issue in /user/organizations

### DIFF
--- a/src/GraphQl/Queries/Queries.ts
+++ b/src/GraphQl/Queries/Queries.ts
@@ -45,6 +45,8 @@ export const ORGANIZATION_LIST = gql`
       addressLine1
       description
       avatarURL
+      adminsCount
+      membersCount
       members(first: 32) {
         edges {
           node {

--- a/src/screens/UserPortal/Organizations/Organizations.tsx
+++ b/src/screens/UserPortal/Organizations/Organizations.tsx
@@ -118,6 +118,8 @@ interface IOrganization {
   avatarURL?: string; // <-- add this
   addressLine1?: string; // <-- add this
   description: string;
+  adminsCount?: number;
+  membersCount?: number;
   admins: [];
   members?: InterfaceMembersConnection; // <-- update this
   address: {
@@ -141,6 +143,8 @@ interface IOrgData {
   addressLine1: string;
   avatarURL: string | null;
   id: string;
+  adminsCount: number;
+  membersCount: number;
   members: {
     edges: [
       {
@@ -287,6 +291,8 @@ export default function organizations(): React.JSX.Element {
               postalCode: '',
               state: '',
             },
+            adminsCount: org.adminsCount || 0,
+            membersCount: org.membersCount || 0,
             admins: [],
             members:
               org.members?.edges?.map(
@@ -488,12 +494,8 @@ export default function organizations(): React.JSX.Element {
                             organization.userRegistrationRequired,
                           membershipRequests: organization.membershipRequests,
                           isJoined: organization.isJoined,
-                          membersCount: Array.isArray(organization.members)
-                            ? organization.members.length
-                            : 0,
-                          adminsCount: Array.isArray(organization.admins)
-                            ? organization.admins.length
-                            : 0,
+                          membersCount: organization.membersCount || 0,
+                          adminsCount: organization.adminsCount || 0,
                         };
                         return (
                           <div


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Admin count in ```/user/organizations``` was wrongly showing 0 because of a query issue.

**Issue Number:** #4010

**Snapshots/Videos:**
Before (Actual) :
<img width="1710" alt="Image" src="https://github.com/user-attachments/assets/a454f07b-e662-4873-aa32-24ca69d8fb80" />

After (Expected) :

https://github.com/user-attachments/assets/854549de-1625-4d15-9446-68d07437a913
<!--Add snapshots or videos wherever possible.-->

**If relevant, did you update the documentation?**

<!--Add link to Talawa-Docs.-->

**Summary**
used ```membersCount``` and ```adminsCount``` in queries to fetch number of members and admins.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->