### PR TITLE
chore: upgrade inquirer to 12.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "i18next": "^24.2.2",
         "i18next-browser-languagedetector": "^8.0.2",
         "i18next-http-backend": "^3.0.2",
-        "inquirer": "^12.4.1",
+        "inquirer": "^12.9.0",
         "jest-environment-jsdom": "^29.7.0",
         "js-cookie": "^3.0.1",
         "jszip": "^3.10.1",
@@ -4741,14 +4741,14 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.1.tgz",
-      "integrity": "sha512-os5kFd/52gZTl/W6xqMfhaKVJHQM8V/U1P8jcSaQJ/C4Qhdrf2jEXdA/HaxfQs9iiUA/0yzYhk5d3oRHTxGDDQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.1.tgz",
+      "integrity": "sha512-bevKGO6kX1eM/N+pdh9leS5L7TBF4ICrzi9a+cbWkrxeAeIcwlo/7OfWGCDERdRCI2/Q6tjltX4bt07ALHDwFw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -4765,13 +4765,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.5.tgz",
-      "integrity": "sha512-ZB2Cz8KeMINUvoeDi7IrvghaVkYT2RB0Zb31EaLWOE87u276w4wnApv0SH2qWaJ3r0VSUa3BIuz7qAV2ZvsZlg==",
+      "version": "5.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.15.tgz",
+      "integrity": "sha512-SwHMGa8Z47LawQN0rog0sT+6JpiL0B7eW9p1Bb7iCeKDGTI5Ez25TSc2l8kw52VV7hA4sX/C78CGkMrKXfuspA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -4786,13 +4786,13 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.6.tgz",
-      "integrity": "sha512-Bwh/Zk6URrHwZnSSzAZAKH7YgGYi0xICIBDFOqBQoXNNAzBHw/bgXgLmChfp+GyR3PnChcTbiCTZGC6YJNJkMA==",
+      "version": "10.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
+      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
@@ -4813,14 +4813,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.6.tgz",
-      "integrity": "sha512-l0smvr8g/KAVdXx4I92sFxZiaTG4kFc06cFZw+qqwTirwdUHMFLnouXBB9OafWhpO3cfEkEz2CdPoCmor3059A==",
+      "version": "4.2.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.17.tgz",
+      "integrity": "sha512-r6bQLsyPSzbWrZZ9ufoWL+CztkSatnJ6uSxqd6N+o41EZC51sQeWOzI6s5jLb+xxTWxl7PlUppqm8/sow241gg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/type": "^3.0.4",
-        "external-editor": "^3.1.0"
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/external-editor": "^1.0.1",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -4835,13 +4835,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.8.tgz",
-      "integrity": "sha512-k0ouAC6L+0Yoj/j0ys2bat0fYcyFVtItDB7h+pDFKaDDSFJey/C/YY1rmIOqkmFVZ5rZySeAQuS8zLcKkKRLmg==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.17.tgz",
+      "integrity": "sha512-PSqy9VmJx/VbE3CT453yOfNa+PykpKg/0SYP7odez1/NWBGuDXgPhp4AeGYYKjhLn5lUUavVS/JbeYMPdH50Mw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -4856,23 +4856,56 @@
         }
       }
     },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.1.tgz",
+      "integrity": "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.0",
+        "iconv-lite": "^0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.10.tgz",
-      "integrity": "sha512-Ey6176gZmeqZuY/W/nZiUyvmb1/qInjcpiZjXWi6nON+nxJpD1bxtSoBxNliGISae32n6OwbY+TSXPZ1CfS4bw==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.5.tgz",
-      "integrity": "sha512-bB6wR5wBCz5zbIVBPnhp94BHv/G4eKbUEjlpCw676pI2chcvzTx1MuwZSCZ/fgNOdqDlAxkhQ4wagL8BI1D3Zg==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.1.tgz",
+      "integrity": "sha512-tVC+O1rBl0lJpoUZv4xY+WGWY8V5b0zxU1XDsMsIHYregdh7bN5X5QnIONNBAl0K765FYlAfNHS2Bhn7SSOVow==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -4887,13 +4920,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.8.tgz",
-      "integrity": "sha512-CTKs+dT1gw8dILVWATn8Ugik1OHLkkfY82J+Musb57KpmF6EKyskv8zmMiEJPzOnLTZLo05X/QdMd8VH9oulXw==",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.17.tgz",
+      "integrity": "sha512-GcvGHkyIgfZgVnnimURdOueMk0CztycfC8NZTiIY9arIAkeOgt6zG57G+7vC59Jns3UX27LMkPKnKWAOF5xEYg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -4908,13 +4941,13 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.8.tgz",
-      "integrity": "sha512-MgA+Z7o3K1df2lGY649fyOBowHGfrKRz64dx3+b6c1w+h2W7AwBoOkHhhF/vfhbs5S4vsKNCuDzS3s9r5DpK1g==",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.17.tgz",
+      "integrity": "sha512-DJolTnNeZ00E1+1TW+8614F7rOJJCM4y4BAGQ3Gq6kQIG+OJ4zr3GLjIjVVJCbKsk2jmkmv6v2kQuN/vriHdZA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -4930,21 +4963,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.3.1.tgz",
-      "integrity": "sha512-r1CiKuDV86BDpvj9DRFR+V+nIjsVBOsa2++dqdPqLYAef8kgHYvmQ8ySdP/ZeAIOWa27YGJZRkENdP3dK0H3gg==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.3.tgz",
+      "integrity": "sha512-iHYp+JCaCRktM/ESZdpHI51yqsDgXu+dMs4semzETftOaF8u5hwlqnbIsuIR/LrWZl8Pm1/gzteK9I7MAq5HTA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.1.1",
-        "@inquirer/confirm": "^5.1.5",
-        "@inquirer/editor": "^4.2.6",
-        "@inquirer/expand": "^4.0.8",
-        "@inquirer/input": "^4.1.5",
-        "@inquirer/number": "^3.0.8",
-        "@inquirer/password": "^4.0.8",
-        "@inquirer/rawlist": "^4.0.8",
-        "@inquirer/search": "^3.0.8",
-        "@inquirer/select": "^4.0.8"
+        "@inquirer/checkbox": "^4.2.1",
+        "@inquirer/confirm": "^5.1.15",
+        "@inquirer/editor": "^4.2.17",
+        "@inquirer/expand": "^4.0.17",
+        "@inquirer/input": "^4.2.1",
+        "@inquirer/number": "^3.0.17",
+        "@inquirer/password": "^4.0.17",
+        "@inquirer/rawlist": "^4.1.5",
+        "@inquirer/search": "^3.1.0",
+        "@inquirer/select": "^4.3.1"
       },
       "engines": {
         "node": ">=18"
@@ -4959,13 +4992,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.8.tgz",
-      "integrity": "sha512-hl7rvYW7Xl4un8uohQRUgO6uc2hpn7PKqfcGkCOWC0AA4waBxAv6MpGOFCEDrUaBCP+pXPVqp4LmnpWmn1E1+g==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.5.tgz",
+      "integrity": "sha512-R5qMyGJqtDdi4Ht521iAkNqyB6p2UPuZUbMifakg1sWtu24gc2Z8CJuw8rP081OckNDMgtDCuLe42Q2Kr3BolA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -4981,14 +5014,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.8.tgz",
-      "integrity": "sha512-ihSE9D3xQAupNg/aGDZaukqoUSXG2KfstWosVmFCG7jbMQPaj2ivxWtsB+CnYY/T4D6LX1GHKixwJLunNCffww==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.1.0.tgz",
+      "integrity": "sha512-PMk1+O/WBcYJDq2H7foV0aAZSmDdkzZB9Mw2v/DmONRJopwA/128cS9M/TXWLKKdEQKZnKwBzqu2G4x/2Nqx8Q==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -5004,14 +5037,14 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.0.8.tgz",
-      "integrity": "sha512-Io2prxFyN2jOCcu4qJbVoilo19caiD3kqkD3WR0q3yDA5HUCo83v4LrRtg55ZwniYACW64z36eV7gyVbOfORjA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.1.tgz",
+      "integrity": "sha512-Gfl/5sqOF5vS/LIrSndFgOh7jgoe0UXEizDqahFRkq5aJBLegZ6WjuMh/hVEJwlFQjyLq1z9fRtvUMkb7jM1LA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -5028,9 +5061,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.4.tgz",
-      "integrity": "sha512-2MNFrDY8jkFYc9Il9DgLsHhMzuHnOYM1+CUYVWbzu9oT0hC7V7EcYvdCKeoll/Fcci04A+ERZ9wcc7cQ8lTkIA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -11555,9 +11588,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
       "license": "MIT"
     },
     "node_modules/chart.js": {
@@ -15370,20 +15403,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
-      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/extract-files": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-11.0.0.tgz",
@@ -17060,6 +17079,7 @@
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
@@ -17259,18 +17279,18 @@
       "license": "ISC"
     },
     "node_modules/inquirer": {
-      "version": "12.4.1",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.4.1.tgz",
-      "integrity": "sha512-/V7OyFkeUBFO2jAokUq5emSlcVMHVvzg8bwwZnzmCwErPgbeftsthmPUg71AIi5mR0YmiJOLQ+bTiHVWEjOw7A==",
+      "version": "12.9.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.0.tgz",
+      "integrity": "sha512-LlFVmvWVCun7uEgPB3vups9NzBrjJn48kRNtFGw3xU1H5UXExTEz/oF1JGLaB0fvlkUB+W6JfgLcSEaSdH7RPA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/prompts": "^7.3.1",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/prompts": "^7.8.0",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "mute-stream": "^2.0.0",
-        "run-async": "^3.0.0",
-        "rxjs": "^7.8.1"
+        "run-async": "^4.0.5",
+        "rxjs": "^7.8.2"
       },
       "engines": {
         "node": ">=18"
@@ -22379,15 +22399,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ospath": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/ospath/-/ospath-1.2.2.tgz",
@@ -25074,9 +25085,9 @@
       }
     },
     "node_modules/run-async": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
-      "integrity": "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -26590,18 +26601,6 @@
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "i18next": "^24.2.2",
     "i18next-browser-languagedetector": "^8.0.2",
     "i18next-http-backend": "^3.0.2",
-    "inquirer": "^12.4.1",
+    "inquirer": "^12.9.0",
     "jest-environment-jsdom": "^29.7.0",
     "js-cookie": "^3.0.1",
     "jszip": "^3.10.1",


### PR DESCRIPTION
This pull request upgrades the inquirer dependency from its previous version to 12.9.0 to ensure compatibility, security, and code health.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a CLI interaction dependency to a newer minor version to improve stability and compatibility.
  * Incorporates upstream fixes and enhancements from the dependency’s latest release line.
  * No functional changes expected for end-users.
  * Routine maintenance to keep dependencies current and reduce potential security or compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->