### PR TITLE
Bug fix: Organization Image updating error

### DIFF
--- a/src/components/LeftDrawerOrg/LeftDrawerOrg.tsx
+++ b/src/components/LeftDrawerOrg/LeftDrawerOrg.tsx
@@ -273,6 +273,7 @@ const leftDrawerOrg = ({
               <div className={styles.imageContainer}>
                 {data.organization.avatarURL ? (
                   <img
+                    //To tackle cors issue
                     crossOrigin="anonymous"
                     loading="lazy"
                     decoding="async"

--- a/src/components/LeftDrawerOrg/LeftDrawerOrg.tsx
+++ b/src/components/LeftDrawerOrg/LeftDrawerOrg.tsx
@@ -273,6 +273,7 @@ const leftDrawerOrg = ({
               <div className={styles.imageContainer}>
                 {data.organization.avatarURL ? (
                   <img
+                    crossOrigin="anonymous"
                     src={data.organization.avatarURL}
                     alt={`${data.organization.name}`}
                   />

--- a/src/components/LeftDrawerOrg/LeftDrawerOrg.tsx
+++ b/src/components/LeftDrawerOrg/LeftDrawerOrg.tsx
@@ -274,6 +274,8 @@ const leftDrawerOrg = ({
                 {data.organization.avatarURL ? (
                   <img
                     crossOrigin="anonymous"
+                    loading="lazy"
+                    decoding="async"
                     src={data.organization.avatarURL}
                     alt={`${data.organization.name}`}
                   />

--- a/src/components/LeftDrawerOrg/LeftDrawerOrg.tsx
+++ b/src/components/LeftDrawerOrg/LeftDrawerOrg.tsx
@@ -273,8 +273,8 @@ const leftDrawerOrg = ({
               <div className={styles.imageContainer}>
                 {data.organization.avatarURL ? (
                   <img
-                    //To tackle cors issue
                     crossOrigin="anonymous"
+                    referrerPolicy="no-referrer"
                     loading="lazy"
                     decoding="async"
                     src={data.organization.avatarURL}

--- a/src/components/OrgListCard/OrgListCard.tsx
+++ b/src/components/OrgListCard/OrgListCard.tsx
@@ -76,6 +76,8 @@ function OrgListCard({
                 src={avatarURL}
                 alt={`${name} image`}
                 crossOrigin="anonymous"
+                loading="lazy"
+                decoding="async"
               />
             ) : (
               <Avatar

--- a/src/components/OrgListCard/OrgListCard.tsx
+++ b/src/components/OrgListCard/OrgListCard.tsx
@@ -72,7 +72,11 @@ function OrgListCard({
           {/* Container for the organization image */}
           <div className={styles.orgImgContainer}>
             {avatarURL ? (
-              <img src={avatarURL} alt={`${name} image`} />
+              <img
+                src={avatarURL}
+                alt={`${name} image`}
+                crossOrigin="anonymous"
+              />
             ) : (
               <Avatar
                 name={name}

--- a/src/components/OrgListCard/OrgListCard.tsx
+++ b/src/components/OrgListCard/OrgListCard.tsx
@@ -76,6 +76,7 @@ function OrgListCard({
                 src={avatarURL}
                 alt={`${name} image`}
                 crossOrigin="anonymous"
+                referrerPolicy="no-referrer"
                 loading="lazy"
                 decoding="async"
               />

--- a/src/components/OrgSettings/General/OrgUpdate/OrgUpdate.spec.tsx
+++ b/src/components/OrgSettings/General/OrgUpdate/OrgUpdate.spec.tsx
@@ -301,7 +301,6 @@ describe('OrgUpdate Component', () => {
 
     expect(fileInput.files).toHaveLength(1);
     expect(fileInput.files?.[0]).toBe(file);
-    expect(convertToBase64).toHaveBeenCalledWith(file);
 
     await waitFor(() => {
       const saveButton = screen.getByTestId('save-org-changes-btn');

--- a/src/components/OrgSettings/General/OrgUpdate/OrgUpdate.tsx
+++ b/src/components/OrgSettings/General/OrgUpdate/OrgUpdate.tsx
@@ -30,7 +30,7 @@ interface InterfaceMutationUpdateOrganizationInput {
   state?: string;
   postalCode?: string;
   countryCode?: string;
-  avatar?: string | null;
+  avatar?: File;
 }
 
 /**
@@ -51,6 +51,7 @@ function OrgUpdate(props: InterfaceOrgUpdateProps): JSX.Element {
     orgDescrip: string;
     address: InterfaceAddress;
     orgImage: string | null;
+    avatar?: File;
   }>({
     orgName: '',
     orgDescrip: '',
@@ -154,7 +155,6 @@ function OrgUpdate(props: InterfaceOrgUpdateProps): JSX.Element {
       }
 
       setIsSaving(true);
-
       // Function to remove empty string fields from the input object
       const removeEmptyFields = (
         obj: InterfaceMutationUpdateOrganizationInput,
@@ -179,7 +179,7 @@ function OrgUpdate(props: InterfaceOrgUpdateProps): JSX.Element {
         state: formState.address.state,
         postalCode: formState.address.postalCode,
         countryCode: formState.address?.countryCode,
-        ...(formState.orgImage ? { avatar: formState.orgImage } : {}),
+        ...(formState.avatar ? { avatar: formState.avatar } : {}),
       };
 
       // Filter out empty fields
@@ -282,7 +282,7 @@ function OrgUpdate(props: InterfaceOrgUpdateProps): JSX.Element {
               if (file)
                 setFormState({
                   ...formState,
-                  orgImage: await convertToBase64(file),
+                  avatar: file,
                 });
             }}
             data-testid="organisationImage"

--- a/src/components/OrgSettings/General/OrgUpdate/OrgUpdate.tsx
+++ b/src/components/OrgSettings/General/OrgUpdate/OrgUpdate.tsx
@@ -45,6 +45,7 @@ interface InterfaceMutationUpdateOrganizationInput {
  */
 function OrgUpdate(props: InterfaceOrgUpdateProps): JSX.Element {
   const { orgId } = props;
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
 
   const [formState, setFormState] = useState<{
     orgName: string;
@@ -194,6 +195,9 @@ function OrgUpdate(props: InterfaceOrgUpdateProps): JSX.Element {
       if (data) {
         refetch({ id: orgId });
         toast.success(t('successfulUpdated') as string);
+        // Clear avatar from state and file input after successful upload
+        setFormState((prev) => ({ ...prev, avatar: undefined }));
+        if (fileInputRef.current) fileInputRef.current.value = '';
       } else {
         toast.error('Failed to update organization');
       }
@@ -270,6 +274,7 @@ function OrgUpdate(props: InterfaceOrgUpdateProps): JSX.Element {
             {tCommon('displayImage')}:
           </Form.Label>
           <Form.Control
+            ref={fileInputRef}
             className={styles.customFileInput}
             accept="image/*"
             placeholder={tCommon('displayImage')}

--- a/src/screens/FundCampaignPledge/FundCampaignPledge.spec.tsx
+++ b/src/screens/FundCampaignPledge/FundCampaignPledge.spec.tsx
@@ -1,5 +1,5 @@
 import { MockedProvider } from '@apollo/react-testing';
-import { LocalizationProvider } from '@mui/x-date-pickers';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import type { RenderResult } from '@testing-library/react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
@@ -16,6 +16,7 @@ import React from 'react';
 import type { ApolloLink } from '@apollo/client';
 import { vi } from 'vitest';
 import { FUND_CAMPAIGN_PLEDGE } from 'GraphQl/Queries/fundQueries';
+import styles from 'style/app-fixed.module.css';
 
 vi.mock('react-toastify', () => ({
   toast: {
@@ -464,7 +465,7 @@ describe('Testing Campaign Pledge Screen', () => {
       // Check either real image or avatar is rendered
       if (imageContainer.getAttribute('src')?.startsWith('data:image/svg')) {
         // Avatar SVG is rendered
-        expect(imageContainer).toHaveClass('_TableImagePledge_d00707');
+        expect(imageContainer).toHaveClass(styles.TableImagePledge);
       } else {
         // Real image is rendered
         expect(imageContainer).toHaveAttribute('src', 'img-url');


### PR DESCRIPTION
**What kind of change does this PR introduce?**
fixed error occurring when admin updates any org's image.

**Issue Number:**#4081

**Screenshots**
Before: 

<img width="1710" height="912" alt="Image" src="https://github.com/user-attachments/assets/98de96fc-6c78-4ff9-ac70-f4c4ed1ef4b8" />

After:

https://github.com/user-attachments/assets/144aceff-70ad-4d89-99cc-bb4a1d9b26e9


**Summary**
This PR fixed an error occurring when admin tries to update org's profile image.

**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Avatars now load more efficiently (lazy loading, async decoding) and fetch without credentials for improved privacy.

- Bug Fixes
  - Resolved avatar loading issues related to cross-origin requests and referrer policies.

- Refactor
  - Avatar upload flow simplified to use direct file uploads and reliably clear the file input after updates.

- Tests
  - Updated tests to align with the new avatar handling, removed an obsolete assertion, and adapted class checks to CSS modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->