### PR TITLE
chore: upgrade inquirer, fix vulnerabilities, and update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "i18next": "^24.2.2",
         "i18next-browser-languagedetector": "^8.0.2",
         "i18next-http-backend": "^3.0.2",
-        "inquirer": "^12.4.1",
+        "inquirer": "^12.9.3",
         "jest-environment-jsdom": "^29.7.0",
         "js-cookie": "^3.0.1",
         "jszip": "^3.10.1",
@@ -92,7 +92,7 @@
         "@testing-library/react": "^16.2.0",
         "@testing-library/user-event": "^14.6.1",
         "@types/apollo-upload-client": "^18.0.0",
-        "@types/inquirer": "^9.0.7",
+        "@types/inquirer": "^9.0.9",
         "@types/jest": "^29.5.14",
         "@types/js-cookie": "^3.0.6",
         "@types/node": "^22.9.0",
@@ -3973,12 +3973,14 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.1.1",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.2.1.tgz",
+      "integrity": "sha512-bevKGO6kX1eM/N+pdh9leS5L7TBF4ICrzi9a+cbWkrxeAeIcwlo/7OfWGCDERdRCI2/Q6tjltX4bt07ALHDwFw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -3995,11 +3997,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.5",
+      "version": "5.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.15.tgz",
+      "integrity": "sha512-SwHMGa8Z47LawQN0rog0sT+6JpiL0B7eW9p1Bb7iCeKDGTI5Ez25TSc2l8kw52VV7hA4sX/C78CGkMrKXfuspA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -4014,11 +4018,13 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.6",
+      "version": "10.1.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.15.tgz",
+      "integrity": "sha512-8xrp836RZvKkpNbVvgWUlxjT4CraKk2q+I3Ksy+seI2zkcE+y6wNs1BVhgcv8VyImFecUhdQrYLdW32pAjwBdA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
@@ -4040,6 +4046,8 @@
     },
     "node_modules/@inquirer/core/node_modules/signal-exit": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -4049,12 +4057,14 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.6",
+      "version": "4.2.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.17.tgz",
+      "integrity": "sha512-r6bQLsyPSzbWrZZ9ufoWL+CztkSatnJ6uSxqd6N+o41EZC51sQeWOzI6s5jLb+xxTWxl7PlUppqm8/sow241gg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/type": "^3.0.4",
-        "external-editor": "^3.1.0"
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/external-editor": "^1.0.1",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -4069,11 +4079,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.8",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.17.tgz",
+      "integrity": "sha512-PSqy9VmJx/VbE3CT453yOfNa+PykpKg/0SYP7odez1/NWBGuDXgPhp4AeGYYKjhLn5lUUavVS/JbeYMPdH50Mw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -4088,19 +4100,56 @@
         }
       }
     },
+    "node_modules/@inquirer/external-editor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-1.0.1.tgz",
+      "integrity": "sha512-Oau4yL24d2B5IL4ma4UpbQigkVhzPDXLoqy1ggK4gnHg/stmkffJE4oOXHXF3uz0UEpywG68KcyXsyYpA1Re/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^2.1.0",
+        "iconv-lite": "^0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@inquirer/figures": {
-      "version": "1.0.10",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.13.tgz",
+      "integrity": "sha512-lGPVU3yO9ZNqA7vTYz26jny41lE7yoQansmqdMLBEfqaGsmdg7V3W9mK9Pvb5IL4EVZ9GnSDGMO/cJXud5dMaw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.1.5",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.2.1.tgz",
+      "integrity": "sha512-tVC+O1rBl0lJpoUZv4xY+WGWY8V5b0zxU1XDsMsIHYregdh7bN5X5QnIONNBAl0K765FYlAfNHS2Bhn7SSOVow==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -4115,11 +4164,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.8",
+      "version": "3.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.17.tgz",
+      "integrity": "sha512-GcvGHkyIgfZgVnnimURdOueMk0CztycfC8NZTiIY9arIAkeOgt6zG57G+7vC59Jns3UX27LMkPKnKWAOF5xEYg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/type": "^3.0.4"
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8"
       },
       "engines": {
         "node": ">=18"
@@ -4134,11 +4185,13 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.8",
+      "version": "4.0.17",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.17.tgz",
+      "integrity": "sha512-DJolTnNeZ00E1+1TW+8614F7rOJJCM4y4BAGQ3Gq6kQIG+OJ4zr3GLjIjVVJCbKsk2jmkmv6v2kQuN/vriHdZA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -4154,19 +4207,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.3.1",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.8.3.tgz",
+      "integrity": "sha512-iHYp+JCaCRktM/ESZdpHI51yqsDgXu+dMs4semzETftOaF8u5hwlqnbIsuIR/LrWZl8Pm1/gzteK9I7MAq5HTA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.1.1",
-        "@inquirer/confirm": "^5.1.5",
-        "@inquirer/editor": "^4.2.6",
-        "@inquirer/expand": "^4.0.8",
-        "@inquirer/input": "^4.1.5",
-        "@inquirer/number": "^3.0.8",
-        "@inquirer/password": "^4.0.8",
-        "@inquirer/rawlist": "^4.0.8",
-        "@inquirer/search": "^3.0.8",
-        "@inquirer/select": "^4.0.8"
+        "@inquirer/checkbox": "^4.2.1",
+        "@inquirer/confirm": "^5.1.15",
+        "@inquirer/editor": "^4.2.17",
+        "@inquirer/expand": "^4.0.17",
+        "@inquirer/input": "^4.2.1",
+        "@inquirer/number": "^3.0.17",
+        "@inquirer/password": "^4.0.17",
+        "@inquirer/rawlist": "^4.1.5",
+        "@inquirer/search": "^3.1.0",
+        "@inquirer/select": "^4.3.1"
       },
       "engines": {
         "node": ">=18"
@@ -4181,11 +4236,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.0.8",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.1.5.tgz",
+      "integrity": "sha512-R5qMyGJqtDdi4Ht521iAkNqyB6p2UPuZUbMifakg1sWtu24gc2Z8CJuw8rP081OckNDMgtDCuLe42Q2Kr3BolA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/type": "^3.0.8",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -4201,12 +4258,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.0.8",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.1.0.tgz",
+      "integrity": "sha512-PMk1+O/WBcYJDq2H7foV0aAZSmDdkzZB9Mw2v/DmONRJopwA/128cS9M/TXWLKKdEQKZnKwBzqu2G4x/2Nqx8Q==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -4222,12 +4281,14 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.0.8",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.3.1.tgz",
+      "integrity": "sha512-Gfl/5sqOF5vS/LIrSndFgOh7jgoe0UXEizDqahFRkq5aJBLegZ6WjuMh/hVEJwlFQjyLq1z9fRtvUMkb7jM1LA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/figures": "^1.0.10",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/figures": "^1.0.13",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -4244,7 +4305,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.4",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.8.tgz",
+      "integrity": "sha512-lg9Whz8onIHRthWaN1Q9EGLa/0LFJjyM8mEUbL1eTi6yMGvBf8gvyDLtxSXztQsxMvhxxNpJYrwa1YHdq+w4Jw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8450,7 +8513,9 @@
       "license": "MIT"
     },
     "node_modules/@types/inquirer": {
-      "version": "9.0.7",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-9.0.9.tgz",
+      "integrity": "sha512-/mWx5136gts2Z2e5izdoRCo46lPp5TMs9R15GTSsgg/XnZyxDWVqoVU3R9lWnccKpqwsJLvRoxbCjoJtZB7DSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10777,7 +10842,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "0.7.0",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.0.tgz",
+      "integrity": "sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==",
       "license": "MIT"
     },
     "node_modules/chart.js": {
@@ -10904,6 +10971,8 @@
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -13215,28 +13284,6 @@
       "version": "3.0.2",
       "license": "MIT"
     },
-    "node_modules/external-editor": {
-      "version": "3.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "chardet": "^0.7.0",
-        "iconv-lite": "^0.4.24",
-        "tmp": "^0.0.33"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/external-editor/node_modules/tmp": {
-      "version": "0.0.33",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/extract-files": {
       "version": "13.0.0",
       "license": "MIT",
@@ -14469,7 +14516,10 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
+      "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -14630,16 +14680,18 @@
       }
     },
     "node_modules/inquirer": {
-      "version": "12.4.1",
+      "version": "12.9.3",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-12.9.3.tgz",
+      "integrity": "sha512-Hpw2JWdrYY8xJSmhU05Idd5FPshQ1CZErH00WO+FK6fKxkBeqj+E+yFXSlERZLKtzWeQYFCMfl8U2TK9SvVbtQ==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.6",
-        "@inquirer/prompts": "^7.3.1",
-        "@inquirer/type": "^3.0.4",
+        "@inquirer/core": "^10.1.15",
+        "@inquirer/prompts": "^7.8.3",
+        "@inquirer/type": "^3.0.8",
         "ansi-escapes": "^4.3.2",
         "mute-stream": "^2.0.0",
-        "run-async": "^3.0.0",
-        "rxjs": "^7.8.1"
+        "run-async": "^4.0.5",
+        "rxjs": "^7.8.2"
       },
       "engines": {
         "node": ">=18"
@@ -21459,6 +21511,8 @@
     },
     "node_modules/mute-stream": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -21986,13 +22040,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/ospath": {
@@ -24198,7 +24245,9 @@
       ]
     },
     "node_modules/run-async": {
-      "version": "3.0.0",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-4.0.6.tgz",
+      "integrity": "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -25505,7 +25554,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -27002,6 +27053,8 @@
     },
     "node_modules/yoctocolors-cjs": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/apollo-upload-client": "^18.0.0",
-    "@types/inquirer": "^9.0.9",
     "@types/jest": "^29.5.14",
     "@types/js-cookie": "^3.0.6",
     "@types/node": "^22.9.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "i18next": "^24.2.2",
     "i18next-browser-languagedetector": "^8.0.2",
     "i18next-http-backend": "^3.0.2",
-    "inquirer": "^12.4.1",
+    "inquirer": "^12.9.3",
     "jest-environment-jsdom": "^29.7.0",
     "js-cookie": "^3.0.1",
     "jszip": "^3.10.1",
@@ -135,7 +135,7 @@
     "@testing-library/react": "^16.2.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/apollo-upload-client": "^18.0.0",
-    "@types/inquirer": "^9.0.7",
+    "@types/inquirer": "^9.0.9",
     "@types/jest": "^29.5.14",
     "@types/js-cookie": "^3.0.6",
     "@types/node": "^22.9.0",
@@ -218,10 +218,10 @@
     "graphql": "^16.5.0"
   },
   "optionalDependencies": {
-    "@rollup/rollup-linux-x64-gnu": "^4.46.2",
-    "@rollup/rollup-win32-x64-msvc": "^4.46.2",
+    "@rollup/rollup-darwin-arm64": "^4.46.2",
     "@rollup/rollup-darwin-x64": "^4.46.2",
-    "@rollup/rollup-darwin-arm64": "^4.46.2"
+    "@rollup/rollup-linux-x64-gnu": "^4.46.2",
+    "@rollup/rollup-win32-x64-msvc": "^4.46.2"
   },
   "engines": {
     "node": ">=20.x"


### PR DESCRIPTION
Upgraded inquirer and @types/inquirer to the latest versions.
Ran npm audit fix and npm audit fix --force to resolve vulnerabilities and update other dependencies.
Addressed all dependency warnings and ensured compatibility with the latest package versions.
All tests pass and the codebase is compatible with the new dependency versions.
Manual edits and fixes were re-applied after syncing with the latest upstream develop branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the interactive prompt library to a newer version for improved compatibility and stability.
  * Removed the separate development type package for that library.
  * Adjusted optional platform-specific bundler packages to align with supported environments; final platform entries remain effectively unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->