### PR TITLE
Fix: user's profile picture rendering

### DIFF
--- a/src/components/ProfileCard/ProfileCard.tsx
+++ b/src/components/ProfileCard/ProfileCard.tsx
@@ -74,6 +74,7 @@ const ProfileCard = (): React.JSX.Element => {
               src={userImage}
               alt={`profile picture`}
               data-testid="display-img"
+              crossOrigin="anonymous"
               onError={(e) => {
                 e.currentTarget.onerror = null;
                 e.currentTarget.style.display = 'none';


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixed profile picture rendering in user's sidebar.

**Issue Number:** #4096

**Screenshots**
Before fix:
<img width="1146"  alt="Image" src="https://github.com/user-attachments/assets/5c350b4a-68de-4566-9d50-28b3a48638d7" />
<img width="1128" height="902" alt="Image" src="https://github.com/user-attachments/assets/5590c554-3135-4891-a4b2-d9e284b8992e" />

After fix:
<img width="1138" height="912" alt="Image" src="https://github.com/user-attachments/assets/a531ee4e-1d39-454f-b06b-6a82351871a2" />


**Summary**
When a user updates their profile image, the new image is correctly displayed in the Profile Settings section, but the sidebar profile image does not update, instead shows blank image. This PR aims to fix this issue

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
<!-- Try to link to an open issue for more information. -->

**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->