### PR TITLE
fix: User Details page UI

### DIFF
--- a/src/screens/MemberDetail/MemberDetail.tsx
+++ b/src/screens/MemberDetail/MemberDetail.tsx
@@ -475,25 +475,20 @@ const MemberDetail: React.FC<MemberDetailProps> = ({ id }): JSX.Element => {
               </Row>
             </Card.Body>
           </Card>
-          <Col>
-            <Card className={`${styles.contact} ${styles.allRound} mt-3`}>
-              <Card.Header
-                className={`bg-primary d-flex justify-content-between align-items-center py-3 px-4 ${styles.topRadius}`}
-              >
-                <h3
-                  className="text-white m-0"
-                  data-testid="eventsAttended-title"
-                >
-                  {t('tagsAssigned')}
-                </h3>
-              </Card.Header>
-              <Card.Body
-                id="tagsAssignedScrollableDiv"
-                data-testid="tagsAssignedScrollableDiv"
-                className={`${styles.cardBody} pe-0`}
-              ></Card.Body>
-            </Card>
-          </Col>
+          <Card className={`${styles.contact} ${styles.allRound} mt-3`}>
+            <Card.Header
+              className={`bg-primary d-flex justify-content-between align-items-center py-3 px-4 ${styles.topRadius}`}
+            >
+              <h3 className="text-white m-0" data-testid="tagsAssigned-title">
+                {t('tagsAssigned')}
+              </h3>
+            </Card.Header>
+            <Card.Body
+              id="tagsAssignedScrollableDiv"
+              data-testid="tagsAssignedScrollableDiv"
+              className={`${styles.cardBody} pe-0`}
+            ></Card.Body>
+          </Card>
         </Col>
         <Col md={6}>
           <Card className={`${styles.allRound}`}>
@@ -696,7 +691,6 @@ const MemberDetail: React.FC<MemberDetailProps> = ({ id }): JSX.Element => {
               </Button>
               <Button
                 variant="outline-success"
-                active={true}
                 onClick={handleUserUpdate}
                 data-testid="saveChangesBtn"
               >


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixed Misaligned tags section and inactive save button state.

**Issue Number:** #4155

**Screenshots**
Before:
<img width="1706" height="906" alt="Image" src="https://github.com/user-attachments/assets/7726e7e1-a1da-4f99-a3b8-5e6cf28fdec5" />

After:
<img width="1710" height="912" alt="Image" src="https://github.com/user-attachments/assets/c72ff461-3766-4837-97fe-ad1cd2940f15" />

**Summary**
Corrected the Save Changes button state, which previously stayed inactive (grey) even after form modifications.
Fixed the alignment of the “Tags Assigned” section, ensuring consistent layout with the rest of the form.

**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved the “Tags Assigned” section into its own card within the main left column for a cleaner, unified layout.

* **Style**
  * Added a primary-styled card header and made the tags area scrollable for better usability.
  * Simplified footer appearance for a cleaner look.
  * Changed “Save Changes” to an outline-styled button for clearer visual affordance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->