### PR TITLE
Feat: disable remove-member button for non-member users

### DIFF
--- a/src/screens/OrganizationPeople/OrganizationPeople.tsx
+++ b/src/screens/OrganizationPeople/OrganizationPeople.tsx
@@ -468,7 +468,7 @@ function OrganizationPeople(): JSX.Element {
         <Button
           className={`${styles.removeButton}`}
           variant="danger"
-          disabled={state == 2}
+          disabled={state === 2}
           onClick={() => toggleRemoveMemberModal(params.row._id)}
           aria-label="Remove member"
           data-testid="removeMemberModalBtn"


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR introduces a bug fix to prevent errors when using the ```remove-member``` button on ```non-member users``` by disabling remove-member when sort state is ```users```.

**Issue Number:** #4230 

**Screenshots**
Before:
<img width="1358" height="490" alt="Image" src="https://github.com/user-attachments/assets/28545df4-0f44-4709-9b95-0ad25154cdc2" />

After:
<img width="1356" height="530" alt="Image" src="https://github.com/user-attachments/assets/8216b12e-8952-4238-8e41-5af6a0955d3d" />

**Summary**
This PR fixes the issue where the ```remove-member``` button caused errors for ```non-member``` users by disabling the button when the sorting state is set to users.

**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The Remove Member button is now disabled on the Users tab, preventing accidental or invalid removals in that context. This clarifies the button’s behavior and reduces user confusion. No other visible behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->