### PR TITLE
[GSOC] feat: added pre-commit check for cypress tests

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,5 +5,6 @@ npm run format:fix
 npm run lint-staged
 npm run typecheck
 npm run update:toc
+npm run check:pom
 
 git add .

--- a/cypress/e2e/admin_spec/event.cy.ts
+++ b/cypress/e2e/admin_spec/event.cy.ts
@@ -8,8 +8,7 @@ describe('Admin Event Tab', () => {
   beforeEach(() => {
     cy.loginByApi('admin');
     dashboard.visit().verifyOnDashboard().openFirstOrganization();
-    cy.get('[data-cy="leftDrawerButton-Events"]').should('be.visible').click();
-    cy.url().should('match', /\/orgevents\/[a-f0-9-]+/);
+    eventPage.visitEventPage();
   });
 
   it('create an event with all fields', () => {

--- a/cypress/e2e/admin_spec/leftDrawer.cy.ts
+++ b/cypress/e2e/admin_spec/leftDrawer.cy.ts
@@ -1,41 +1,22 @@
 /// <reference types="cypress" />
 
+import { LeftDrawer } from '../../pageObjects/AdminPortal/LeftDrawer';
+
 describe('LeftDrawer CSS Tests', () => {
+  const drawer = new LeftDrawer();
+
   beforeEach(() => {
     // Setup any necessary authentication or navigation
     cy.loginByApi('admin');
-    // Ensure we're inside the <1280px breakpoint where the fix applies
-    cy.viewport(1200, 900);
-    // Stabilize assertions by waiting on org data
-    cy.intercept('POST', '**/graphql').as('graphql');
-    cy.visit('/orglist');
-    // Visit any organization to check OrgBtn test id
-    cy.get('[data-testid="manageBtn"]').first().click();
-    cy.url().should('include', '/orgdash');
-    cy.wait('@graphql', { timeout: 15000 });
+    drawer.checkBreakpoint();
   });
 
   it('profile container uses row under <1280px viewport', () => {
-    // Wait for the profile container to be visible
-    cy.get('[data-testid="OrgBtn"]').should('be.visible');
-
-    // Check that the profileContainer has flex-direction: row
-    cy.get('[data-testid="OrgBtn"]').should(
-      'have.css',
-      'flex-direction',
-      'row',
-    );
+    drawer.checkRowViewport();
   });
 
   it('should check profileContainer styling when organization data is loaded', () => {
-    // Wait for organization data to load (not shimmer state)
-    cy.get('[data-testid="OrgBtn"]').should('be.visible');
-    cy.get('[class*="shimmer"]').should('not.exist');
-
-    // Verify the CSS property using CSS modules pattern
-    cy.get('[data-testid="OrgBtn"]')
-      .should('be.visible')
-      .and('have.css', 'flex-direction', 'row');
+    drawer.checkProfileContainerStyling();
   });
 
   afterEach(() => {

--- a/cypress/e2e/admin_spec/people.cy.ts
+++ b/cypress/e2e/admin_spec/people.cy.ts
@@ -8,8 +8,7 @@ describe('Admin People Tab', () => {
   beforeEach(() => {
     cy.loginByApi('admin');
     dashboard.visit().verifyOnDashboard().openFirstOrganization();
-    cy.get('[data-cy="leftDrawerButton-People"]').should('be.visible').click();
-    cy.url().should('match', /\/orgpeople\/[a-f0-9-]+/);
+    peoplePage.visitPeoplePage();
   });
 
   it('should search a particular member and then reset to all members', () => {

--- a/cypress/pageObjects/AdminPortal/AdminEventPage.ts
+++ b/cypress/pageObjects/AdminPortal/AdminEventPage.ts
@@ -13,6 +13,13 @@ export class AdminEventPage {
   private readonly _deleteEventModalBtn = '[data-cy="deleteEventModalBtn"]';
   private readonly _deleteEventBtn = '[data-testid="deleteEventBtn"]';
 
+  visitEventPage(): void {
+    cy.get(this._eventsTabButton).should('be.visible').click();
+    // cy.url().should('match', /\/orgevents\/[a-f0-9-]+/);
+    // cy.get('[data-cy="leftDrawerButton-Events"]').should('be.visible').click();
+    cy.url().should('match', /\/orgevents\/[a-f0-9-]+/);
+  }
+
   createEvent(title: string, description: string, location: string): void {
     cy.get(this._createEventModalButton).should('be.visible').click();
     cy.get(this._eventTitleInput).should('be.visible').type(title);

--- a/cypress/pageObjects/AdminPortal/LeftDrawer.ts
+++ b/cypress/pageObjects/AdminPortal/LeftDrawer.ts
@@ -1,0 +1,36 @@
+export class LeftDrawer {
+  checkBreakpoint(): void {
+    // Ensure we're inside the <1280px breakpoint where the fix applies
+    cy.viewport(1200, 900);
+    // Stabilize assertions by waiting on org data
+    cy.intercept('POST', '**/graphql').as('graphql');
+    cy.visit('/orglist');
+    // Visit any organization to check OrgBtn test id
+    cy.get('[data-testid="manageBtn"]').first().click();
+    cy.url().should('include', '/orgdash');
+    cy.wait('@graphql', { timeout: 15000 });
+  }
+
+  checkRowViewport(): void {
+    // Wait for the profile container to be visible
+    cy.get('[data-testid="OrgBtn"]').should('be.visible');
+
+    // Check that the profileContainer has flex-direction: row
+    cy.get('[data-testid="OrgBtn"]').should(
+      'have.css',
+      'flex-direction',
+      'row',
+    );
+  }
+
+  checkProfileContainerStyling(): void {
+    // Wait for organization data to load (not shimmer state)
+    cy.get('[data-testid="OrgBtn"]').should('be.visible');
+    cy.get('[class*="shimmer"]').should('not.exist');
+
+    // Verify the CSS property using CSS modules pattern
+    cy.get('[data-testid="OrgBtn"]')
+      .should('be.visible')
+      .and('have.css', 'flex-direction', 'row');
+  }
+}

--- a/cypress/pageObjects/AdminPortal/PeoplePage.ts
+++ b/cypress/pageObjects/AdminPortal/PeoplePage.ts
@@ -1,4 +1,5 @@
 export class PeoplePage {
+  private readonly _peopleTabButton = '[data-cy="leftDrawerButton-People"]';
   private readonly _searchInput = '[placeholder="Enter Full Name"]';
   private readonly _searchButton = '[data-testid="searchbtn"]';
   private readonly _searchResult = '[data-field="name"]';
@@ -10,6 +11,11 @@ export class PeoplePage {
   private readonly _removeModalBtn = '[data-testid="removeMemberModalBtn"]';
   private readonly _confirmRemoveBtn = '[data-testid="removeMemberBtn"]';
   private readonly _alert = '[role=alert]';
+
+  visitPeoplePage(): void {
+    cy.get(this._peopleTabButton).should('be.visible').click();
+    cy.url().should('match', /\/orgpeople\/[a-f0-9-]+/);
+  }
 
   searchMemberByName(name: string, timeout = 40000) {
     cy.get(this._searchInput, { timeout })

--- a/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/FILTERED_ORGANIZATION_POSTS.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/FILTERED_ORGANIZATION_POSTS.md
@@ -6,4 +6,4 @@
 
 > `const` **FILTERED\_ORGANIZATION\_POSTS**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:104](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L104)
+Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:164](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L164)

--- a/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/GET_POSTS_BY_ORG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/GET_POSTS_BY_ORG.md
@@ -6,4 +6,4 @@
 
 > `const` **GET\_POSTS\_BY\_ORG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:87](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L87)
+Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:147](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L147)

--- a/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/ORGANIZATION_ADMINS_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/ORGANIZATION_ADMINS_LIST.md
@@ -6,7 +6,7 @@
 
 > `const` **ORGANIZATION\_ADMINS\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:318](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L318)
+Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:378](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L378)
 
 GraphQL query to retrieve the list of admins for a specific organization.
 

--- a/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/ORGANIZATION_FUNDS.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/ORGANIZATION_FUNDS.md
@@ -6,7 +6,7 @@
 
 > `const` **ORGANIZATION\_FUNDS**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:339](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L339)
+Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:399](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L399)
 
 GraphQL query to retrieve the list of members for a specific organization.
 

--- a/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/ORGANIZATION_POST_LIST_WITH_VOTES.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/ORGANIZATION_POST_LIST_WITH_VOTES.md
@@ -1,0 +1,9 @@
+[Admin Docs](/)
+
+***
+
+# Variable: ORGANIZATION\_POST\_LIST\_WITH\_VOTES
+
+> `const` **ORGANIZATION\_POST\_LIST\_WITH\_VOTES**: `DocumentNode`
+
+Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:77](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L77)

--- a/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/ORGANIZATION_USER_TAGS_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/ORGANIZATION_USER_TAGS_LIST.md
@@ -6,7 +6,7 @@
 
 > `const` **ORGANIZATION\_USER\_TAGS\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:196](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L196)
+Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:256](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L256)
 
 GraphQL query to retrieve the list of user tags belonging to an organization.
 

--- a/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/ORGANIZATION_USER_TAGS_LIST_PG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/ORGANIZATION_USER_TAGS_LIST_PG.md
@@ -6,4 +6,4 @@
 
 > `const` **ORGANIZATION\_USER\_TAGS\_LIST\_PG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:247](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L247)
+Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:307](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L307)

--- a/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/USER_CREATED_ORGANIZATIONS.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/USER_CREATED_ORGANIZATIONS.md
@@ -6,7 +6,7 @@
 
 > `const` **USER\_CREATED\_ORGANIZATIONS**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:293](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L293)
+Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:353](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L353)
 
 GraphQL query to retrieve organizations created by a user.
 

--- a/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/USER_JOINED_ORGANIZATIONS_PG.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/USER_JOINED_ORGANIZATIONS_PG.md
@@ -6,4 +6,4 @@
 
 > `const` **USER\_JOINED\_ORGANIZATIONS\_PG**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:153](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L153)
+Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:213](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L213)

--- a/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/VENUE_LIST.md
+++ b/docs/docs/auto-docs/GraphQl/Queries/OrganizationQueries/variables/VENUE_LIST.md
@@ -6,7 +6,7 @@
 
 > `const` **VENUE\_LIST**: `DocumentNode`
 
-Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:361](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L361)
+Defined in: [src/GraphQl/Queries/OrganizationQueries.ts:421](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/GraphQl/Queries/OrganizationQueries.ts#L421)
 
 GraphQL query to retrieve the list of venues for a specific organization.
 

--- a/docs/docs/auto-docs/components/UserPortal/CommentCard/CommentCard/functions/default.md
+++ b/docs/docs/auto-docs/components/UserPortal/CommentCard/CommentCard/functions/default.md
@@ -6,7 +6,7 @@
 
 > **default**(`props`): `Element`
 
-Defined in: [src/components/UserPortal/CommentCard/CommentCard.tsx:80](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/UserPortal/CommentCard/CommentCard.tsx#L80)
+Defined in: [src/components/UserPortal/CommentCard/CommentCard.tsx:71](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/UserPortal/CommentCard/CommentCard.tsx#L71)
 
 ## Parameters
 

--- a/docs/docs/auto-docs/screens/MemberDetail/MemberDetailMocks/variables/MOCKS2.md
+++ b/docs/docs/auto-docs/screens/MemberDetail/MemberDetailMocks/variables/MOCKS2.md
@@ -72,7 +72,7 @@ Defined in: [src/screens/MemberDetail/MemberDetailMocks.ts:64](https://github.co
 
 #### result.data.currentUser.createdAt
 
-> **createdAt**: `string` = `'2025-02-06T03:10:50.254'`
+> **createdAt**: `string` = `'2025-02-06T03:10:50.254Z'`
 
 #### result.data.currentUser.description
 
@@ -136,7 +136,7 @@ Defined in: [src/screens/MemberDetail/MemberDetailMocks.ts:64](https://github.co
 
 #### result.data.currentUser.updatedAt
 
-> **updatedAt**: `string` = `'2025-02-06T03:22:17.808'`
+> **updatedAt**: `string` = `'2025-02-06T03:22:17.808Z'`
 
 #### result.data.currentUser.workPhoneNumber
 

--- a/docs/docs/auto-docs/screens/MemberDetail/MemberDetailMocks/variables/MOCKS3.md
+++ b/docs/docs/auto-docs/screens/MemberDetail/MemberDetailMocks/variables/MOCKS3.md
@@ -72,7 +72,7 @@ Defined in: [src/screens/MemberDetail/MemberDetailMocks.ts:106](https://github.c
 
 #### result.data.currentUser.createdAt
 
-> **createdAt**: `string` = `'2025-02-06T03:10:50.254'`
+> **createdAt**: `string` = `'2025-02-06T03:10:50.254Z'`
 
 #### result.data.currentUser.description
 
@@ -136,7 +136,7 @@ Defined in: [src/screens/MemberDetail/MemberDetailMocks.ts:106](https://github.c
 
 #### result.data.currentUser.updatedAt
 
-> **updatedAt**: `string` = `'2025-02-06T03:22:17.808'`
+> **updatedAt**: `string` = `'2025-02-06T03:22:17.808Z'`
 
 #### result.data.currentUser.workPhoneNumber
 

--- a/docs/docs/auto-docs/screens/UserPortal/Posts/Posts/functions/default.md
+++ b/docs/docs/auto-docs/screens/UserPortal/Posts/Posts/functions/default.md
@@ -6,7 +6,7 @@
 
 > **default**(): `Element`
 
-Defined in: [src/screens/UserPortal/Posts/Posts.tsx:108](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/screens/UserPortal/Posts/Posts.tsx#L108)
+Defined in: [src/screens/UserPortal/Posts/Posts.tsx:96](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/screens/UserPortal/Posts/Posts.tsx#L96)
 
 ## Returns
 

--- a/docs/docs/auto-docs/screens/UserPortal/Posts/Posts/variables/POSTS_PER_PAGE.md
+++ b/docs/docs/auto-docs/screens/UserPortal/Posts/Posts/variables/POSTS_PER_PAGE.md
@@ -6,4 +6,4 @@
 
 > `const` **POSTS\_PER\_PAGE**: `5` = `5`
 
-Defined in: [src/screens/UserPortal/Posts/Posts.tsx:97](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/screens/UserPortal/Posts/Posts.tsx#L97)
+Defined in: [src/screens/UserPortal/Posts/Posts.tsx:85](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/screens/UserPortal/Posts/Posts.tsx#L85)

--- a/docs/docs/auto-docs/screens/UserPortal/Settings/SettingsMocks/variables/MOCKS1.md
+++ b/docs/docs/auto-docs/screens/UserPortal/Settings/SettingsMocks/variables/MOCKS1.md
@@ -64,7 +64,7 @@ Defined in: [src/screens/UserPortal/Settings/SettingsMocks.ts:44](https://github
 
 #### result.data.currentUser.createdAt
 
-> **createdAt**: `string` = `'2025-02-06T03:10:50.254'`
+> **createdAt**: `string` = `'2025-02-06T03:10:50.254Z'`
 
 #### result.data.currentUser.description
 
@@ -128,7 +128,7 @@ Defined in: [src/screens/UserPortal/Settings/SettingsMocks.ts:44](https://github
 
 #### result.data.currentUser.updatedAt
 
-> **updatedAt**: `string` = `'2025-02-06T03:22:17.808'`
+> **updatedAt**: `string` = `'2025-02-06T03:22:17.808Z'`
 
 #### result.data.currentUser.workPhoneNumber
 

--- a/docs/docs/auto-docs/types/Comment/interface/interfaces/InterfaceCommentCardProps.md
+++ b/docs/docs/auto-docs/types/Comment/interface/interfaces/InterfaceCommentCardProps.md
@@ -20,7 +20,7 @@ Defined in: [src/types/Comment/interface.ts:5](https://github.com/PalisadoesFoun
 
 > **handleDislikeComment**: (`commentId`) => `void`
 
-Defined in: [src/types/Comment/interface.ts:10](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/interface.ts#L10)
+Defined in: [src/types/Comment/interface.ts:9](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/interface.ts#L9)
 
 #### Parameters
 
@@ -38,7 +38,7 @@ Defined in: [src/types/Comment/interface.ts:10](https://github.com/PalisadoesFou
 
 > **handleLikeComment**: (`commentId`) => `void`
 
-Defined in: [src/types/Comment/interface.ts:9](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/interface.ts#L9)
+Defined in: [src/types/Comment/interface.ts:8](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/interface.ts#L8)
 
 #### Parameters
 
@@ -71,13 +71,5 @@ Defined in: [src/types/Comment/interface.ts:6](https://github.com/PalisadoesFoun
 ### text
 
 > **text**: `string`
-
-Defined in: [src/types/Comment/interface.ts:8](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/interface.ts#L8)
-
-***
-
-### upVoters
-
-> **upVoters**: `Partial`\<[`User`](../../../User/type/type-aliases/User.md)\>[]
 
 Defined in: [src/types/Comment/interface.ts:7](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/interface.ts#L7)

--- a/docs/docs/auto-docs/types/Comment/type/type-aliases/Comment.md
+++ b/docs/docs/auto-docs/types/Comment/type/type-aliases/Comment.md
@@ -46,7 +46,7 @@ Defined in: [src/types/Comment/type.ts:8](https://github.com/PalisadoesFoundatio
 
 > **post**: [`Post`](../../../Post/type/type-aliases/Post.md)
 
-Defined in: [src/types/Comment/type.ts:10](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/type.ts#L10)
+Defined in: [src/types/Comment/type.ts:9](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/type.ts#L9)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/types/Comment/type.ts:10](https://github.com/PalisadoesFoundati
 
 > **text**: `string`
 
-Defined in: [src/types/Comment/type.ts:11](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/type.ts#L11)
+Defined in: [src/types/Comment/type.ts:10](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/type.ts#L10)
 
 ***
 
@@ -62,12 +62,4 @@ Defined in: [src/types/Comment/type.ts:11](https://github.com/PalisadoesFoundati
 
 > **updatedAt**: `Date`
 
-Defined in: [src/types/Comment/type.ts:12](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/type.ts#L12)
-
-***
-
-### upVoters?
-
-> `optional` **upVoters**: [`User`](../../../User/type/type-aliases/User.md)[]
-
-Defined in: [src/types/Comment/type.ts:9](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/type.ts#L9)
+Defined in: [src/types/Comment/type.ts:11](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/type.ts#L11)

--- a/docs/docs/auto-docs/types/Comment/type/type-aliases/CommentInput.md
+++ b/docs/docs/auto-docs/types/Comment/type/type-aliases/CommentInput.md
@@ -6,7 +6,7 @@
 
 > **CommentInput** = `object`
 
-Defined in: [src/types/Comment/type.ts:15](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/type.ts#L15)
+Defined in: [src/types/Comment/type.ts:14](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/type.ts#L14)
 
 ## Properties
 
@@ -14,4 +14,4 @@ Defined in: [src/types/Comment/type.ts:15](https://github.com/PalisadoesFoundati
 
 > **text**: `string`
 
-Defined in: [src/types/Comment/type.ts:16](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/type.ts#L16)
+Defined in: [src/types/Comment/type.ts:15](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Comment/type.ts#L15)

--- a/docs/docs/auto-docs/types/Post/interface/interfaces/InterfaceAttachment.md
+++ b/docs/docs/auto-docs/types/Post/interface/interfaces/InterfaceAttachment.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceAttachment
 
-Defined in: [src/types/Post/interface.ts:72](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L72)
+Defined in: [src/types/Post/interface.ts:71](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L71)
 
 ## Properties
 
@@ -12,4 +12,4 @@ Defined in: [src/types/Post/interface.ts:72](https://github.com/PalisadoesFounda
 
 > **url**: `string`
 
-Defined in: [src/types/Post/interface.ts:73](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L73)
+Defined in: [src/types/Post/interface.ts:72](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L72)

--- a/docs/docs/auto-docs/types/Post/interface/interfaces/InterfaceCreator.md
+++ b/docs/docs/auto-docs/types/Post/interface/interfaces/InterfaceCreator.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceCreator
 
-Defined in: [src/types/Post/interface.ts:76](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L76)
+Defined in: [src/types/Post/interface.ts:75](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L75)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [src/types/Post/interface.ts:76](https://github.com/PalisadoesFounda
 
 > `optional` **avatarURL**: `string`
 
-Defined in: [src/types/Post/interface.ts:80](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L80)
+Defined in: [src/types/Post/interface.ts:79](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L79)
 
 ***
 
@@ -20,7 +20,7 @@ Defined in: [src/types/Post/interface.ts:80](https://github.com/PalisadoesFounda
 
 > **email**: `string`
 
-Defined in: [src/types/Post/interface.ts:79](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L79)
+Defined in: [src/types/Post/interface.ts:78](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L78)
 
 ***
 
@@ -28,7 +28,7 @@ Defined in: [src/types/Post/interface.ts:79](https://github.com/PalisadoesFounda
 
 > **id**: `string`
 
-Defined in: [src/types/Post/interface.ts:77](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L77)
+Defined in: [src/types/Post/interface.ts:76](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L76)
 
 ***
 
@@ -36,4 +36,4 @@ Defined in: [src/types/Post/interface.ts:77](https://github.com/PalisadoesFounda
 
 > **name**: `string`
 
-Defined in: [src/types/Post/interface.ts:78](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L78)
+Defined in: [src/types/Post/interface.ts:77](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L77)

--- a/docs/docs/auto-docs/types/Post/interface/interfaces/InterfaceMutationCreatePostInput.md
+++ b/docs/docs/auto-docs/types/Post/interface/interfaces/InterfaceMutationCreatePostInput.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceMutationCreatePostInput
 
-Defined in: [src/types/Post/interface.ts:65](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L65)
+Defined in: [src/types/Post/interface.ts:64](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L64)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [src/types/Post/interface.ts:65](https://github.com/PalisadoesFounda
 
 > `optional` **attachments**: `File`[]
 
-Defined in: [src/types/Post/interface.ts:69](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L69)
+Defined in: [src/types/Post/interface.ts:68](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L68)
 
 ***
 
@@ -20,7 +20,7 @@ Defined in: [src/types/Post/interface.ts:69](https://github.com/PalisadoesFounda
 
 > **caption**: `string`
 
-Defined in: [src/types/Post/interface.ts:66](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L66)
+Defined in: [src/types/Post/interface.ts:65](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L65)
 
 ***
 
@@ -28,7 +28,7 @@ Defined in: [src/types/Post/interface.ts:66](https://github.com/PalisadoesFounda
 
 > **isPinned**: `boolean`
 
-Defined in: [src/types/Post/interface.ts:68](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L68)
+Defined in: [src/types/Post/interface.ts:67](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L67)
 
 ***
 
@@ -36,4 +36,4 @@ Defined in: [src/types/Post/interface.ts:68](https://github.com/PalisadoesFounda
 
 > **organizationId**: `string`
 
-Defined in: [src/types/Post/interface.ts:67](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L67)
+Defined in: [src/types/Post/interface.ts:66](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L66)

--- a/docs/docs/auto-docs/types/Post/interface/interfaces/InterfaceOrganization.md
+++ b/docs/docs/auto-docs/types/Post/interface/interfaces/InterfaceOrganization.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceOrganization
 
-Defined in: [src/types/Post/interface.ts:51](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L51)
+Defined in: [src/types/Post/interface.ts:50](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L50)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [src/types/Post/interface.ts:51](https://github.com/PalisadoesFounda
 
 > **id**: `string`
 
-Defined in: [src/types/Post/interface.ts:52](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L52)
+Defined in: [src/types/Post/interface.ts:51](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L51)
 
 ***
 
@@ -20,7 +20,7 @@ Defined in: [src/types/Post/interface.ts:52](https://github.com/PalisadoesFounda
 
 > **posts**: `object`
 
-Defined in: [src/types/Post/interface.ts:53](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L53)
+Defined in: [src/types/Post/interface.ts:52](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L52)
 
 #### edges
 

--- a/docs/docs/auto-docs/types/Post/interface/interfaces/InterfaceOrganizationPostListData.md
+++ b/docs/docs/auto-docs/types/Post/interface/interfaces/InterfaceOrganizationPostListData.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceOrganizationPostListData
 
-Defined in: [src/types/Post/interface.ts:60](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L60)
+Defined in: [src/types/Post/interface.ts:59](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L59)
 
 ## Properties
 
@@ -12,4 +12,4 @@ Defined in: [src/types/Post/interface.ts:60](https://github.com/PalisadoesFounda
 
 > **organization**: [`InterfaceOrganization`](InterfaceOrganization.md)
 
-Defined in: [src/types/Post/interface.ts:61](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L61)
+Defined in: [src/types/Post/interface.ts:60](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L60)

--- a/docs/docs/auto-docs/types/Post/interface/interfaces/InterfacePageInfo.md
+++ b/docs/docs/auto-docs/types/Post/interface/interfaces/InterfacePageInfo.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfacePageInfo
 
-Defined in: [src/types/Post/interface.ts:39](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L39)
+Defined in: [src/types/Post/interface.ts:38](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L38)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [src/types/Post/interface.ts:39](https://github.com/PalisadoesFounda
 
 > **endCursor**: `string`
 
-Defined in: [src/types/Post/interface.ts:41](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L41)
+Defined in: [src/types/Post/interface.ts:40](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L40)
 
 ***
 
@@ -20,7 +20,7 @@ Defined in: [src/types/Post/interface.ts:41](https://github.com/PalisadoesFounda
 
 > **hasNextPage**: `boolean`
 
-Defined in: [src/types/Post/interface.ts:42](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L42)
+Defined in: [src/types/Post/interface.ts:41](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L41)
 
 ***
 
@@ -28,7 +28,7 @@ Defined in: [src/types/Post/interface.ts:42](https://github.com/PalisadoesFounda
 
 > **hasPreviousPage**: `boolean`
 
-Defined in: [src/types/Post/interface.ts:43](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L43)
+Defined in: [src/types/Post/interface.ts:42](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L42)
 
 ***
 
@@ -36,4 +36,4 @@ Defined in: [src/types/Post/interface.ts:43](https://github.com/PalisadoesFounda
 
 > **startCursor**: `string`
 
-Defined in: [src/types/Post/interface.ts:40](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L40)
+Defined in: [src/types/Post/interface.ts:39](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L39)

--- a/docs/docs/auto-docs/types/Post/interface/interfaces/InterfacePost.md
+++ b/docs/docs/auto-docs/types/Post/interface/interfaces/InterfacePost.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfacePost
 
-Defined in: [src/types/Post/interface.ts:83](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L83)
+Defined in: [src/types/Post/interface.ts:82](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L82)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [src/types/Post/interface.ts:83](https://github.com/PalisadoesFounda
 
 > `optional` **attachments**: [`InterfaceAttachment`](InterfaceAttachment.md)[]
 
-Defined in: [src/types/Post/interface.ts:90](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L90)
+Defined in: [src/types/Post/interface.ts:89](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L89)
 
 ***
 
@@ -20,7 +20,7 @@ Defined in: [src/types/Post/interface.ts:90](https://github.com/PalisadoesFounda
 
 > **caption**: `string`
 
-Defined in: [src/types/Post/interface.ts:85](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L85)
+Defined in: [src/types/Post/interface.ts:84](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L84)
 
 ***
 
@@ -28,7 +28,7 @@ Defined in: [src/types/Post/interface.ts:85](https://github.com/PalisadoesFounda
 
 > **createdAt**: `string`
 
-Defined in: [src/types/Post/interface.ts:86](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L86)
+Defined in: [src/types/Post/interface.ts:85](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L85)
 
 ***
 
@@ -36,7 +36,7 @@ Defined in: [src/types/Post/interface.ts:86](https://github.com/PalisadoesFounda
 
 > `optional` **creator**: [`InterfaceCreator`](InterfaceCreator.md)
 
-Defined in: [src/types/Post/interface.ts:89](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L89)
+Defined in: [src/types/Post/interface.ts:88](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L88)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [src/types/Post/interface.ts:89](https://github.com/PalisadoesFounda
 
 > **id**: `string`
 
-Defined in: [src/types/Post/interface.ts:84](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L84)
+Defined in: [src/types/Post/interface.ts:83](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L83)
 
 ***
 
@@ -52,7 +52,7 @@ Defined in: [src/types/Post/interface.ts:84](https://github.com/PalisadoesFounda
 
 > `optional` **imageUrl**: `string`
 
-Defined in: [src/types/Post/interface.ts:91](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L91)
+Defined in: [src/types/Post/interface.ts:90](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L90)
 
 ***
 
@@ -60,7 +60,7 @@ Defined in: [src/types/Post/interface.ts:91](https://github.com/PalisadoesFounda
 
 > `optional` **pinned**: `boolean`
 
-Defined in: [src/types/Post/interface.ts:88](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L88)
+Defined in: [src/types/Post/interface.ts:87](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L87)
 
 ***
 
@@ -68,7 +68,7 @@ Defined in: [src/types/Post/interface.ts:88](https://github.com/PalisadoesFounda
 
 > `optional` **pinnedAt**: `string`
 
-Defined in: [src/types/Post/interface.ts:87](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L87)
+Defined in: [src/types/Post/interface.ts:86](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L86)
 
 ***
 
@@ -76,4 +76,4 @@ Defined in: [src/types/Post/interface.ts:87](https://github.com/PalisadoesFounda
 
 > `optional` **videoUrl**: `string`
 
-Defined in: [src/types/Post/interface.ts:92](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L92)
+Defined in: [src/types/Post/interface.ts:91](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L91)

--- a/docs/docs/auto-docs/types/Post/interface/interfaces/InterfacePostCard.md
+++ b/docs/docs/auto-docs/types/Post/interface/interfaces/InterfacePostCard.md
@@ -44,7 +44,7 @@ Defined in: [src/types/Post/interface.ts:5](https://github.com/PalisadoesFoundat
 
 > **fetchPosts**: () => `void`
 
-Defined in: [src/types/Post/interface.ts:15](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L15)
+Defined in: [src/types/Post/interface.ts:14](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L14)
 
 #### Returns
 
@@ -89,14 +89,6 @@ Defined in: [src/types/Post/interface.ts:9](https://github.com/PalisadoesFoundat
 > **title**: `string`
 
 Defined in: [src/types/Post/interface.ts:10](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L10)
-
-***
-
-### upVoters
-
-> **upVoters**: `Partial`\<[`User`](../../../User/type/type-aliases/User.md)\>[]
-
-Defined in: [src/types/Post/interface.ts:14](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L14)
 
 ***
 

--- a/docs/docs/auto-docs/types/Post/interface/interfaces/InterfacePostConnection.md
+++ b/docs/docs/auto-docs/types/Post/interface/interfaces/InterfacePostConnection.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfacePostConnection
 
-Defined in: [src/types/Post/interface.ts:46](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L46)
+Defined in: [src/types/Post/interface.ts:45](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L45)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [src/types/Post/interface.ts:46](https://github.com/PalisadoesFounda
 
 > **edges**: [`InterfacePostEdge`](InterfacePostEdge.md)[]
 
-Defined in: [src/types/Post/interface.ts:47](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L47)
+Defined in: [src/types/Post/interface.ts:46](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L46)
 
 ***
 
@@ -20,4 +20,4 @@ Defined in: [src/types/Post/interface.ts:47](https://github.com/PalisadoesFounda
 
 > **pageInfo**: [`InterfacePageInfo`](InterfacePageInfo.md)
 
-Defined in: [src/types/Post/interface.ts:48](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L48)
+Defined in: [src/types/Post/interface.ts:47](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L47)

--- a/docs/docs/auto-docs/types/Post/interface/interfaces/InterfacePostCreator.md
+++ b/docs/docs/auto-docs/types/Post/interface/interfaces/InterfacePostCreator.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfacePostCreator
 
-Defined in: [src/types/Post/interface.ts:18](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L18)
+Defined in: [src/types/Post/interface.ts:17](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L17)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [src/types/Post/interface.ts:18](https://github.com/PalisadoesFounda
 
 > `optional` **firstName**: `string`
 
-Defined in: [src/types/Post/interface.ts:20](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L20)
+Defined in: [src/types/Post/interface.ts:19](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L19)
 
 ***
 
@@ -20,7 +20,7 @@ Defined in: [src/types/Post/interface.ts:20](https://github.com/PalisadoesFounda
 
 > **id**: `string`
 
-Defined in: [src/types/Post/interface.ts:19](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L19)
+Defined in: [src/types/Post/interface.ts:18](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L18)
 
 ***
 
@@ -28,4 +28,4 @@ Defined in: [src/types/Post/interface.ts:19](https://github.com/PalisadoesFounda
 
 > `optional` **lastName**: `string`
 
-Defined in: [src/types/Post/interface.ts:21](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L21)
+Defined in: [src/types/Post/interface.ts:20](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L20)

--- a/docs/docs/auto-docs/types/Post/interface/interfaces/InterfacePostEdge.md
+++ b/docs/docs/auto-docs/types/Post/interface/interfaces/InterfacePostEdge.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfacePostEdge
 
-Defined in: [src/types/Post/interface.ts:35](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L35)
+Defined in: [src/types/Post/interface.ts:34](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L34)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [src/types/Post/interface.ts:35](https://github.com/PalisadoesFounda
 
 > **cursor**: `string`
 
-Defined in: [src/types/Post/interface.ts:37](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L37)
+Defined in: [src/types/Post/interface.ts:36](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L36)
 
 ***
 
@@ -20,4 +20,4 @@ Defined in: [src/types/Post/interface.ts:37](https://github.com/PalisadoesFounda
 
 > **node**: [`InterfacePost`](InterfacePost.md)
 
-Defined in: [src/types/Post/interface.ts:36](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L36)
+Defined in: [src/types/Post/interface.ts:35](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L35)

--- a/docs/docs/auto-docs/types/Post/interface/interfaces/InterfacePostNode.md
+++ b/docs/docs/auto-docs/types/Post/interface/interfaces/InterfacePostNode.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfacePostNode
 
-Defined in: [src/types/Post/interface.ts:24](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L24)
+Defined in: [src/types/Post/interface.ts:23](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L23)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [src/types/Post/interface.ts:24](https://github.com/PalisadoesFounda
 
 > **caption**: `string`
 
-Defined in: [src/types/Post/interface.ts:26](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L26)
+Defined in: [src/types/Post/interface.ts:25](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L25)
 
 ***
 
@@ -20,7 +20,7 @@ Defined in: [src/types/Post/interface.ts:26](https://github.com/PalisadoesFounda
 
 > **createdAt**: `string`
 
-Defined in: [src/types/Post/interface.ts:32](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L32)
+Defined in: [src/types/Post/interface.ts:31](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L31)
 
 ***
 
@@ -28,7 +28,7 @@ Defined in: [src/types/Post/interface.ts:32](https://github.com/PalisadoesFounda
 
 > `optional` **creator**: [`InterfacePostCreator`](InterfacePostCreator.md)
 
-Defined in: [src/types/Post/interface.ts:30](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L30)
+Defined in: [src/types/Post/interface.ts:29](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L29)
 
 ***
 
@@ -36,7 +36,7 @@ Defined in: [src/types/Post/interface.ts:30](https://github.com/PalisadoesFounda
 
 > **id**: `string`
 
-Defined in: [src/types/Post/interface.ts:25](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L25)
+Defined in: [src/types/Post/interface.ts:24](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L24)
 
 ***
 
@@ -44,7 +44,7 @@ Defined in: [src/types/Post/interface.ts:25](https://github.com/PalisadoesFounda
 
 > `optional` **imageUrl**: `string`
 
-Defined in: [src/types/Post/interface.ts:28](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L28)
+Defined in: [src/types/Post/interface.ts:27](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L27)
 
 ***
 
@@ -52,7 +52,7 @@ Defined in: [src/types/Post/interface.ts:28](https://github.com/PalisadoesFounda
 
 > `optional` **pinned**: `boolean`
 
-Defined in: [src/types/Post/interface.ts:31](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L31)
+Defined in: [src/types/Post/interface.ts:30](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L30)
 
 ***
 
@@ -60,7 +60,7 @@ Defined in: [src/types/Post/interface.ts:31](https://github.com/PalisadoesFounda
 
 > `optional` **text**: `string`
 
-Defined in: [src/types/Post/interface.ts:27](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L27)
+Defined in: [src/types/Post/interface.ts:26](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L26)
 
 ***
 
@@ -68,4 +68,4 @@ Defined in: [src/types/Post/interface.ts:27](https://github.com/PalisadoesFounda
 
 > `optional` **videoUrl**: `string`
 
-Defined in: [src/types/Post/interface.ts:29](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L29)
+Defined in: [src/types/Post/interface.ts:28](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/interface.ts#L28)

--- a/docs/docs/auto-docs/types/Post/type/type-aliases/Post.md
+++ b/docs/docs/auto-docs/types/Post/type/type-aliases/Post.md
@@ -6,7 +6,7 @@
 
 > **Post** = `object`
 
-Defined in: [src/types/Post/type.ts:5](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L5)
+Defined in: [src/types/Post/type.ts:6](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L6)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/types/Post/type.ts:5](https://github.com/PalisadoesFoundation/t
 
 > `optional` **\_id**: `string`
 
-Defined in: [src/types/Post/type.ts:6](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L6)
+Defined in: [src/types/Post/type.ts:7](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L7)
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: [src/types/Post/type.ts:6](https://github.com/PalisadoesFoundation/t
 
 > `optional` **commentCount**: `number`
 
-Defined in: [src/types/Post/type.ts:7](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L7)
+Defined in: [src/types/Post/type.ts:8](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L8)
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: [src/types/Post/type.ts:7](https://github.com/PalisadoesFoundation/t
 
 > `optional` **comments**: [`Comment`](../../../Comment/type/type-aliases/Comment.md)[]
 
-Defined in: [src/types/Post/type.ts:8](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L8)
+Defined in: [src/types/Post/type.ts:9](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L9)
 
 ***
 
@@ -38,7 +38,7 @@ Defined in: [src/types/Post/type.ts:8](https://github.com/PalisadoesFoundation/t
 
 > **createdAt**: `Date`
 
-Defined in: [src/types/Post/type.ts:9](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L9)
+Defined in: [src/types/Post/type.ts:10](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L10)
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: [src/types/Post/type.ts:9](https://github.com/PalisadoesFoundation/t
 
 > `optional` **creator**: [`User`](../../../User/type/type-aliases/User.md)
 
-Defined in: [src/types/Post/type.ts:10](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L10)
+Defined in: [src/types/Post/type.ts:11](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L11)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/types/Post/type.ts:10](https://github.com/PalisadoesFoundation/
 
 > `optional` **imageUrl**: `string`
 
-Defined in: [src/types/Post/type.ts:11](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L11)
+Defined in: [src/types/Post/type.ts:12](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L12)
 
 ***
 
@@ -62,7 +62,7 @@ Defined in: [src/types/Post/type.ts:11](https://github.com/PalisadoesFoundation/
 
 > `optional` **likeCount**: `number`
 
-Defined in: [src/types/Post/type.ts:12](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L12)
+Defined in: [src/types/Post/type.ts:13](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L13)
 
 ***
 
@@ -103,14 +103,6 @@ Defined in: [src/types/Post/type.ts:17](https://github.com/PalisadoesFoundation/
 > **updatedAt**: `Date`
 
 Defined in: [src/types/Post/type.ts:18](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L18)
-
-***
-
-### upVoters?
-
-> `optional` **upVoters**: [`User`](../../../User/type/type-aliases/User.md)[]
-
-Defined in: [src/types/Post/type.ts:13](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L13)
 
 ***
 

--- a/docs/docs/auto-docs/types/Post/type/type-aliases/PostComments.md
+++ b/docs/docs/auto-docs/types/Post/type/type-aliases/PostComments.md
@@ -41,7 +41,3 @@ Defined in: [src/types/Post/type.ts:83](https://github.com/PalisadoesFoundation/
 ### text
 
 > **text**: `string`
-
-### upVoters
-
-> **upVoters**: `object`[]

--- a/docs/docs/auto-docs/types/Post/type/type-aliases/PostLikes.md
+++ b/docs/docs/auto-docs/types/Post/type/type-aliases/PostLikes.md
@@ -6,7 +6,7 @@
 
 > **PostLikes** = `object`[]
 
-Defined in: [src/types/Post/type.ts:99](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L99)
+Defined in: [src/types/Post/type.ts:96](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L96)
 
 ## Type declaration
 

--- a/docs/docs/auto-docs/types/Post/type/type-aliases/PostNode.md
+++ b/docs/docs/auto-docs/types/Post/type/type-aliases/PostNode.md
@@ -6,7 +6,7 @@
 
 > **PostNode** = `object`
 
-Defined in: [src/types/Post/type.ts:104](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L104)
+Defined in: [src/types/Post/type.ts:101](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L101)
 
 ## Properties
 
@@ -14,7 +14,7 @@ Defined in: [src/types/Post/type.ts:104](https://github.com/PalisadoesFoundation
 
 > **attachments**: `object`[]
 
-Defined in: [src/types/Post/type.ts:141](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L141)
+Defined in: [src/types/Post/type.ts:127](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L127)
 
 #### fileHash
 
@@ -38,7 +38,7 @@ Defined in: [src/types/Post/type.ts:141](https://github.com/PalisadoesFoundation
 
 > **caption**: `string` \| `null`
 
-Defined in: [src/types/Post/type.ts:106](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L106)
+Defined in: [src/types/Post/type.ts:103](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L103)
 
 ***
 
@@ -46,7 +46,7 @@ Defined in: [src/types/Post/type.ts:106](https://github.com/PalisadoesFoundation
 
 > **commentCount**: `number`
 
-Defined in: [src/types/Post/type.ts:108](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L108)
+Defined in: [src/types/Post/type.ts:105](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L105)
 
 ***
 
@@ -54,7 +54,7 @@ Defined in: [src/types/Post/type.ts:108](https://github.com/PalisadoesFoundation
 
 > `optional` **comments**: `object`
 
-Defined in: [src/types/Post/type.ts:150](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L150)
+Defined in: [src/types/Post/type.ts:136](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L136)
 
 #### edges
 
@@ -66,7 +66,7 @@ Defined in: [src/types/Post/type.ts:150](https://github.com/PalisadoesFoundation
 
 > **commentsCount**: `number`
 
-Defined in: [src/types/Post/type.ts:148](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L148)
+Defined in: [src/types/Post/type.ts:134](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L134)
 
 ***
 
@@ -74,7 +74,7 @@ Defined in: [src/types/Post/type.ts:148](https://github.com/PalisadoesFoundation
 
 > **createdAt**: `string`
 
-Defined in: [src/types/Post/type.ts:107](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L107)
+Defined in: [src/types/Post/type.ts:104](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L104)
 
 ***
 
@@ -82,7 +82,7 @@ Defined in: [src/types/Post/type.ts:107](https://github.com/PalisadoesFoundation
 
 > **creator**: `object`
 
-Defined in: [src/types/Post/type.ts:109](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L109)
+Defined in: [src/types/Post/type.ts:106](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L106)
 
 #### avatarURL?
 
@@ -106,7 +106,7 @@ Defined in: [src/types/Post/type.ts:109](https://github.com/PalisadoesFoundation
 
 > **downVoters**: `object`
 
-Defined in: [src/types/Post/type.ts:130](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L130)
+Defined in: [src/types/Post/type.ts:116](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L116)
 
 #### edges
 
@@ -118,7 +118,15 @@ Defined in: [src/types/Post/type.ts:130](https://github.com/PalisadoesFoundation
 
 > **downVotesCount**: `number`
 
-Defined in: [src/types/Post/type.ts:116](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L116)
+Defined in: [src/types/Post/type.ts:114](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L114)
+
+***
+
+### hasUserVoted
+
+> **hasUserVoted**: [`VoteState`](../../../../utils/interfaces/type-aliases/VoteState.md)
+
+Defined in: [src/types/Post/type.ts:112](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L112)
 
 ***
 
@@ -126,7 +134,7 @@ Defined in: [src/types/Post/type.ts:116](https://github.com/PalisadoesFoundation
 
 > **id**: `string`
 
-Defined in: [src/types/Post/type.ts:105](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L105)
+Defined in: [src/types/Post/type.ts:102](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L102)
 
 ***
 
@@ -134,19 +142,7 @@ Defined in: [src/types/Post/type.ts:105](https://github.com/PalisadoesFoundation
 
 > **pinnedAt**: `string` \| `null`
 
-Defined in: [src/types/Post/type.ts:117](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L117)
-
-***
-
-### upVoters
-
-> **upVoters**: `object`
-
-Defined in: [src/types/Post/type.ts:119](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L119)
-
-#### edges
-
-> **edges**: `object`[]
+Defined in: [src/types/Post/type.ts:115](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L115)
 
 ***
 
@@ -154,4 +150,4 @@ Defined in: [src/types/Post/type.ts:119](https://github.com/PalisadoesFoundation
 
 > **upVotesCount**: `number`
 
-Defined in: [src/types/Post/type.ts:115](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L115)
+Defined in: [src/types/Post/type.ts:113](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/Post/type.ts#L113)

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceAddOnSpotAttendeeProps.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceAddOnSpotAttendeeProps.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceAddOnSpotAttendeeProps
 
-Defined in: [src/utils/interfaces.ts:2246](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2246)
+Defined in: [src/utils/interfaces.ts:2239](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2239)
 
 InterfaceAddOnSpotAttendeeProps
 
@@ -18,7 +18,7 @@ Defines the props for the AddOnSpotAttendee component.
 
 > **handleClose**: () => `void`
 
-Defined in: [src/utils/interfaces.ts:2248](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2248)
+Defined in: [src/utils/interfaces.ts:2241](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2241)
 
 Callback function to close the modal.
 
@@ -32,7 +32,7 @@ Callback function to close the modal.
 
 > **reloadMembers**: () => `void`
 
-Defined in: [src/utils/interfaces.ts:2249](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2249)
+Defined in: [src/utils/interfaces.ts:2242](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2242)
 
 Callback function to reload members.
 
@@ -46,6 +46,6 @@ Callback function to reload members.
 
 > **show**: `boolean`
 
-Defined in: [src/utils/interfaces.ts:2247](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2247)
+Defined in: [src/utils/interfaces.ts:2240](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2240)
 
 Indicates if the modal should be shown.

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceAgendaItemCategoryInfo.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceAgendaItemCategoryInfo.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceAgendaItemCategoryInfo
 
-Defined in: [src/utils/interfaces.ts:2219](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2219)
+Defined in: [src/utils/interfaces.ts:2212](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2212)
 
 InterfaceAgendaItemCategoryInfo
 
@@ -18,7 +18,7 @@ Defines the structure for agenda item category information.
 
 > **\_id**: `string`
 
-Defined in: [src/utils/interfaces.ts:2220](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2220)
+Defined in: [src/utils/interfaces.ts:2213](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2213)
 
 The unique identifier of the agenda item category.
 
@@ -28,7 +28,7 @@ The unique identifier of the agenda item category.
 
 > **createdBy**: `object`
 
-Defined in: [src/utils/interfaces.ts:2223](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2223)
+Defined in: [src/utils/interfaces.ts:2216](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2216)
 
 The user who created this agenda item category.
 
@@ -50,7 +50,7 @@ The user who created this agenda item category.
 
 > **description**: `string`
 
-Defined in: [src/utils/interfaces.ts:2222](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2222)
+Defined in: [src/utils/interfaces.ts:2215](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2215)
 
 The description of the agenda item category.
 
@@ -60,6 +60,6 @@ The description of the agenda item category.
 
 > **name**: `string`
 
-Defined in: [src/utils/interfaces.ts:2221](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2221)
+Defined in: [src/utils/interfaces.ts:2214](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2214)
 
 The name of the agenda item category.

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceAgendaItemCategoryList.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceAgendaItemCategoryList.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceAgendaItemCategoryList
 
-Defined in: [src/utils/interfaces.ts:2235](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2235)
+Defined in: [src/utils/interfaces.ts:2228](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2228)
 
 InterfaceAgendaItemCategoryList
 
@@ -18,6 +18,6 @@ Defines the structure for a list of agenda item categories by organization.
 
 > **agendaItemCategoriesByOrganization**: [`InterfaceAgendaItemCategoryInfo`](InterfaceAgendaItemCategoryInfo.md)[]
 
-Defined in: [src/utils/interfaces.ts:2236](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2236)
+Defined in: [src/utils/interfaces.ts:2229](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2229)
 
 An array of agenda item category information.

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceAgendaItemInfo.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceAgendaItemInfo.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceAgendaItemInfo
 
-Defined in: [src/utils/interfaces.ts:2297](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2297)
+Defined in: [src/utils/interfaces.ts:2290](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2290)
 
 InterfaceAgendaItemInfo
 
@@ -18,7 +18,7 @@ Defines the structure for agenda item information.
 
 > **\_id**: `string`
 
-Defined in: [src/utils/interfaces.ts:2298](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2298)
+Defined in: [src/utils/interfaces.ts:2291](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2291)
 
 The unique identifier of the agenda item.
 
@@ -28,7 +28,7 @@ The unique identifier of the agenda item.
 
 > **attachments**: `string`[]
 
-Defined in: [src/utils/interfaces.ts:2302](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2302)
+Defined in: [src/utils/interfaces.ts:2295](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2295)
 
 An array of attachment URLs.
 
@@ -38,7 +38,7 @@ An array of attachment URLs.
 
 > **categories**: `object`[]
 
-Defined in: [src/utils/interfaces.ts:2315](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2315)
+Defined in: [src/utils/interfaces.ts:2308](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2308)
 
 An array of categories for the agenda item.
 
@@ -56,7 +56,7 @@ An array of categories for the agenda item.
 
 > **createdBy**: `object`
 
-Defined in: [src/utils/interfaces.ts:2303](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2303)
+Defined in: [src/utils/interfaces.ts:2296](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2296)
 
 The user who created this agenda item.
 
@@ -78,7 +78,7 @@ The user who created this agenda item.
 
 > **description**: `string`
 
-Defined in: [src/utils/interfaces.ts:2300](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2300)
+Defined in: [src/utils/interfaces.ts:2293](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2293)
 
 The description of the agenda item.
 
@@ -88,7 +88,7 @@ The description of the agenda item.
 
 > **duration**: `string`
 
-Defined in: [src/utils/interfaces.ts:2301](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2301)
+Defined in: [src/utils/interfaces.ts:2294](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2294)
 
 The duration of the agenda item.
 
@@ -98,7 +98,7 @@ The duration of the agenda item.
 
 > **organization**: `object`
 
-Defined in: [src/utils/interfaces.ts:2319](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2319)
+Defined in: [src/utils/interfaces.ts:2312](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2312)
 
 The organization associated with the agenda item.
 
@@ -116,7 +116,7 @@ The organization associated with the agenda item.
 
 > **relatedEvent**: `object`
 
-Defined in: [src/utils/interfaces.ts:2323](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2323)
+Defined in: [src/utils/interfaces.ts:2316](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2316)
 
 The related event.
 
@@ -134,7 +134,7 @@ The related event.
 
 > **sequence**: `number`
 
-Defined in: [src/utils/interfaces.ts:2314](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2314)
+Defined in: [src/utils/interfaces.ts:2307](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2307)
 
 The sequence number of the agenda item.
 
@@ -144,7 +144,7 @@ The sequence number of the agenda item.
 
 > **title**: `string`
 
-Defined in: [src/utils/interfaces.ts:2299](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2299)
+Defined in: [src/utils/interfaces.ts:2292](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2292)
 
 The title of the agenda item.
 
@@ -154,7 +154,7 @@ The title of the agenda item.
 
 > **urls**: `string`[]
 
-Defined in: [src/utils/interfaces.ts:2308](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2308)
+Defined in: [src/utils/interfaces.ts:2301](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2301)
 
 An array of URLs related to the agenda item.
 
@@ -164,7 +164,7 @@ An array of URLs related to the agenda item.
 
 > **users**: `object`[]
 
-Defined in: [src/utils/interfaces.ts:2309](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2309)
+Defined in: [src/utils/interfaces.ts:2302](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2302)
 
 An array of users associated with the agenda item.
 

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceAgendaItemList.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceAgendaItemList.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceAgendaItemList
 
-Defined in: [src/utils/interfaces.ts:2334](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2334)
+Defined in: [src/utils/interfaces.ts:2327](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2327)
 
 InterfaceAgendaItemList
 
@@ -18,6 +18,6 @@ Defines the structure for a list of agenda items by event.
 
 > **agendaItemByEvent**: [`InterfaceAgendaItemInfo`](InterfaceAgendaItemInfo.md)[]
 
-Defined in: [src/utils/interfaces.ts:2335](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2335)
+Defined in: [src/utils/interfaces.ts:2328](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2328)
 
 An array of agenda item information.

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceCreatePledge.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceCreatePledge.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceCreatePledge
 
-Defined in: [src/utils/interfaces.ts:2172](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2172)
+Defined in: [src/utils/interfaces.ts:2165](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2165)
 
 InterfaceCreatePledge
 
@@ -18,7 +18,7 @@ Defines the structure for creating a pledge.
 
 > **pledgeAmount**: `number`
 
-Defined in: [src/utils/interfaces.ts:2174](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2174)
+Defined in: [src/utils/interfaces.ts:2167](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2167)
 
 The amount of the pledge.
 
@@ -28,7 +28,7 @@ The amount of the pledge.
 
 > **pledgeCurrency**: `string`
 
-Defined in: [src/utils/interfaces.ts:2175](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2175)
+Defined in: [src/utils/interfaces.ts:2168](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2168)
 
 The currency of the pledge.
 
@@ -38,7 +38,7 @@ The currency of the pledge.
 
 > **pledgeEndDate**: `Date`
 
-Defined in: [src/utils/interfaces.ts:2177](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2177)
+Defined in: [src/utils/interfaces.ts:2170](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2170)
 
 The end date of the pledge.
 
@@ -48,7 +48,7 @@ The end date of the pledge.
 
 > **pledgeStartDate**: `Date`
 
-Defined in: [src/utils/interfaces.ts:2176](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2176)
+Defined in: [src/utils/interfaces.ts:2169](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2169)
 
 The start date of the pledge.
 
@@ -58,6 +58,6 @@ The start date of the pledge.
 
 > **pledgeUsers**: [`InterfaceUserInfoPG`](InterfaceUserInfoPG.md)[]
 
-Defined in: [src/utils/interfaces.ts:2173](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2173)
+Defined in: [src/utils/interfaces.ts:2166](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2166)
 
 An array of user information for the pledgers.

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceCreateVolunteerGroup.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceCreateVolunteerGroup.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceCreateVolunteerGroup
 
-Defined in: [src/utils/interfaces.ts:2452](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2452)
+Defined in: [src/utils/interfaces.ts:2445](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2445)
 
 InterfaceCreateVolunteerGroup
 
@@ -18,7 +18,7 @@ Defines the structure for creating a volunteer group.
 
 > **description**: `string`
 
-Defined in: [src/utils/interfaces.ts:2454](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2454)
+Defined in: [src/utils/interfaces.ts:2447](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2447)
 
 The description of the volunteer group, or null.
 
@@ -28,7 +28,7 @@ The description of the volunteer group, or null.
 
 > **leader**: [`InterfaceUserInfo`](InterfaceUserInfo.md)
 
-Defined in: [src/utils/interfaces.ts:2455](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2455)
+Defined in: [src/utils/interfaces.ts:2448](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2448)
 
 The leader of the volunteer group, or null.
 
@@ -38,7 +38,7 @@ The leader of the volunteer group, or null.
 
 > **name**: `string`
 
-Defined in: [src/utils/interfaces.ts:2453](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2453)
+Defined in: [src/utils/interfaces.ts:2446](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2446)
 
 The name of the volunteer group.
 
@@ -48,7 +48,7 @@ The name of the volunteer group.
 
 > **volunteersRequired**: `number`
 
-Defined in: [src/utils/interfaces.ts:2456](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2456)
+Defined in: [src/utils/interfaces.ts:2449](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2449)
 
 The number of volunteers required for the group, or null.
 
@@ -58,6 +58,6 @@ The number of volunteers required for the group, or null.
 
 > **volunteerUsers**: [`InterfaceUserInfo`](InterfaceUserInfo.md)[]
 
-Defined in: [src/utils/interfaces.ts:2457](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2457)
+Defined in: [src/utils/interfaces.ts:2450](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2450)
 
 An array of user information for the volunteers in the group.

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceCustomFieldData.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceCustomFieldData.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceCustomFieldData
 
-Defined in: [src/utils/interfaces.ts:2355](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2355)
+Defined in: [src/utils/interfaces.ts:2348](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2348)
 
 InterfaceCustomFieldData
 
@@ -18,7 +18,7 @@ Defines the structure for custom field data.
 
 > `optional` **id**: `string`
 
-Defined in: [src/utils/interfaces.ts:2356](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2356)
+Defined in: [src/utils/interfaces.ts:2349](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2349)
 
 The unique identifier of the custom field (optional).
 
@@ -28,7 +28,7 @@ The unique identifier of the custom field (optional).
 
 > **name**: `string`
 
-Defined in: [src/utils/interfaces.ts:2357](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2357)
+Defined in: [src/utils/interfaces.ts:2350](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2350)
 
 The name of the custom field.
 
@@ -38,7 +38,7 @@ The name of the custom field.
 
 > `optional` **organizationId**: `string`
 
-Defined in: [src/utils/interfaces.ts:2359](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2359)
+Defined in: [src/utils/interfaces.ts:2352](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2352)
 
 The unique identifier of the associated organization (optional).
 
@@ -48,6 +48,6 @@ The unique identifier of the associated organization (optional).
 
 > **type**: `string`
 
-Defined in: [src/utils/interfaces.ts:2358](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2358)
+Defined in: [src/utils/interfaces.ts:2351](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2351)
 
 The type of the custom field.

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceEventVolunteerInfo.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceEventVolunteerInfo.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceEventVolunteerInfo
 
-Defined in: [src/utils/interfaces.ts:2377](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2377)
+Defined in: [src/utils/interfaces.ts:2370](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2370)
 
 InterfaceEventVolunteerInfo
 
@@ -18,7 +18,7 @@ Defines the structure for event volunteer information.
 
 > **\_id**: `string`
 
-Defined in: [src/utils/interfaces.ts:2378](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2378)
+Defined in: [src/utils/interfaces.ts:2371](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2371)
 
 The unique identifier of the event volunteer.
 
@@ -28,7 +28,7 @@ The unique identifier of the event volunteer.
 
 > **assignments**: `object`[]
 
-Defined in: [src/utils/interfaces.ts:2382](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2382)
+Defined in: [src/utils/interfaces.ts:2375](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2375)
 
 An array of assignments for the volunteer.
 
@@ -42,7 +42,7 @@ An array of assignments for the volunteer.
 
 > **groups**: `object`[]
 
-Defined in: [src/utils/interfaces.ts:2385](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2385)
+Defined in: [src/utils/interfaces.ts:2378](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2378)
 
 An array of groups the volunteer belongs to.
 
@@ -64,7 +64,7 @@ An array of groups the volunteer belongs to.
 
 > **hasAccepted**: `boolean`
 
-Defined in: [src/utils/interfaces.ts:2379](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2379)
+Defined in: [src/utils/interfaces.ts:2372](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2372)
 
 Indicates if the volunteer has accepted.
 
@@ -74,7 +74,7 @@ Indicates if the volunteer has accepted.
 
 > **hoursVolunteered**: `number`
 
-Defined in: [src/utils/interfaces.ts:2380](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2380)
+Defined in: [src/utils/interfaces.ts:2373](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2373)
 
 The number of hours volunteered, or null.
 
@@ -84,6 +84,6 @@ The number of hours volunteered, or null.
 
 > **user**: [`InterfaceUserInfo`](InterfaceUserInfo.md)
 
-Defined in: [src/utils/interfaces.ts:2381](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2381)
+Defined in: [src/utils/interfaces.ts:2374](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2374)
 
 The user information of the volunteer.

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceFormData.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceFormData.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceFormData
 
-Defined in: [src/utils/interfaces.ts:2261](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2261)
+Defined in: [src/utils/interfaces.ts:2254](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2254)
 
 InterfaceFormData
 
@@ -18,7 +18,7 @@ Defines the structure for form data.
 
 > **email**: `string`
 
-Defined in: [src/utils/interfaces.ts:2264](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2264)
+Defined in: [src/utils/interfaces.ts:2257](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2257)
 
 The email address.
 
@@ -28,7 +28,7 @@ The email address.
 
 > **firstName**: `string`
 
-Defined in: [src/utils/interfaces.ts:2262](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2262)
+Defined in: [src/utils/interfaces.ts:2255](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2255)
 
 The first name.
 
@@ -38,7 +38,7 @@ The first name.
 
 > **gender**: `string`
 
-Defined in: [src/utils/interfaces.ts:2266](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2266)
+Defined in: [src/utils/interfaces.ts:2259](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2259)
 
 The gender.
 
@@ -48,7 +48,7 @@ The gender.
 
 > **lastName**: `string`
 
-Defined in: [src/utils/interfaces.ts:2263](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2263)
+Defined in: [src/utils/interfaces.ts:2256](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2256)
 
 The last name.
 
@@ -58,6 +58,6 @@ The last name.
 
 > **phoneNo**: `string`
 
-Defined in: [src/utils/interfaces.ts:2265](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2265)
+Defined in: [src/utils/interfaces.ts:2258](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2258)
 
 The phone number.

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceMapType.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceMapType.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceMapType
 
-Defined in: [src/utils/interfaces.ts:2343](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2343)
+Defined in: [src/utils/interfaces.ts:2336](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2336)
 
 InterfaceMapType
 

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfacePostCard.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfacePostCard.md
@@ -4,13 +4,7 @@
 
 # Interface: InterfacePostCard
 
-Defined in: [src/utils/interfaces.ts:2118](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2118)
-
-InterfacePostCard
-
-## Description
-
-Defines the structure for a post card.
+Defined in: [src/utils/interfaces.ts:2122](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2122)
 
 ## Properties
 
@@ -18,9 +12,7 @@ Defines the structure for a post card.
 
 > **commentCount**: `number`
 
-Defined in: [src/utils/interfaces.ts:2133](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2133)
-
-The number of comments on the post.
+Defined in: [src/utils/interfaces.ts:2137](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2137)
 
 ***
 
@@ -28,9 +20,7 @@ The number of comments on the post.
 
 > **comments**: `object`[]
 
-Defined in: [src/utils/interfaces.ts:2147](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2147)
-
-An array of comments on the post.
+Defined in: [src/utils/interfaces.ts:2140](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2140)
 
 #### body
 
@@ -40,9 +30,9 @@ An array of comments on the post.
 
 > **creator**: `object`
 
-##### creator.email
+##### creator.avatarURL?
 
-> **email**: `string`
+> `optional` **avatarURL**: `string`
 
 ##### creator.id
 
@@ -56,6 +46,10 @@ An array of comments on the post.
 
 > **downVoteCount**: `number`
 
+#### hasUserVoted
+
+> **hasUserVoted**: [`VoteState`](../type-aliases/VoteState.md)
+
 #### id
 
 > **id**: `string`
@@ -68,27 +62,17 @@ An array of comments on the post.
 
 > **upVoteCount**: `number`
 
-#### upVoters
-
-> **upVoters**: `object`[]
-
 ***
 
 ### creator
 
 > **creator**: `object`
 
-Defined in: [src/utils/interfaces.ts:2121](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2121)
-
-The creator of the post.
+Defined in: [src/utils/interfaces.ts:2125](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2125)
 
 #### avatarURL?
 
 > `optional` **avatarURL**: `string`
-
-#### email
-
-> **email**: `string`
 
 #### id
 
@@ -104,7 +88,7 @@ The creator of the post.
 
 > **downVoteCount**: `number`
 
-Defined in: [src/utils/interfaces.ts:2146](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2146)
+Defined in: [src/utils/interfaces.ts:2139](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2139)
 
 ***
 
@@ -112,9 +96,7 @@ Defined in: [src/utils/interfaces.ts:2146](https://github.com/PalisadoesFoundati
 
 > **fetchPosts**: () => `void`
 
-Defined in: [src/utils/interfaces.ts:2160](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2160)
-
-A function to fetch posts.
+Defined in: [src/utils/interfaces.ts:2153](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2153)
 
 #### Returns
 
@@ -122,13 +104,19 @@ A function to fetch posts.
 
 ***
 
+### hasUserVoted
+
+> **hasUserVoted**: [`VoteState`](../type-aliases/VoteState.md)
+
+Defined in: [src/utils/interfaces.ts:2130](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2130)
+
+***
+
 ### id
 
 > **id**: `string`
 
-Defined in: [src/utils/interfaces.ts:2119](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2119)
-
-The unique identifier of the post.
+Defined in: [src/utils/interfaces.ts:2123](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2123)
 
 ***
 
@@ -136,9 +124,7 @@ The unique identifier of the post.
 
 > **image**: `string`
 
-Defined in: [src/utils/interfaces.ts:2129](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2129)
-
-The URL of the post's image, or null.
+Defined in: [src/utils/interfaces.ts:2133](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2133)
 
 ***
 
@@ -146,7 +132,7 @@ The URL of the post's image, or null.
 
 > `optional` **isModalView**: `boolean`
 
-Defined in: [src/utils/interfaces.ts:2120](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2120)
+Defined in: [src/utils/interfaces.ts:2124](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2124)
 
 ***
 
@@ -154,7 +140,7 @@ Defined in: [src/utils/interfaces.ts:2120](https://github.com/PalisadoesFoundati
 
 > `optional` **pinnedAt**: `string`
 
-Defined in: [src/utils/interfaces.ts:2128](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2128)
+Defined in: [src/utils/interfaces.ts:2132](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2132)
 
 ***
 
@@ -162,9 +148,7 @@ Defined in: [src/utils/interfaces.ts:2128](https://github.com/PalisadoesFoundati
 
 > **postedAt**: `string`
 
-Defined in: [src/utils/interfaces.ts:2127](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2127)
-
-The date and time the post was created.
+Defined in: [src/utils/interfaces.ts:2131](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2131)
 
 ***
 
@@ -172,9 +156,7 @@ The date and time the post was created.
 
 > **text**: `string`
 
-Defined in: [src/utils/interfaces.ts:2132](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2132)
-
-The text content of the post.
+Defined in: [src/utils/interfaces.ts:2136](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2136)
 
 ***
 
@@ -182,9 +164,7 @@ The text content of the post.
 
 > **title**: `string`
 
-Defined in: [src/utils/interfaces.ts:2131](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2131)
-
-The title of the post.
+Defined in: [src/utils/interfaces.ts:2135](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2135)
 
 ***
 
@@ -192,21 +172,7 @@ The title of the post.
 
 > **upVoteCount**: `number`
 
-Defined in: [src/utils/interfaces.ts:2145](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2145)
-
-***
-
-### upVoters
-
-> **upVoters**: `object`
-
-Defined in: [src/utils/interfaces.ts:2134](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2134)
-
-An array of users who liked the post.
-
-#### edges
-
-> **edges**: `object`[]
+Defined in: [src/utils/interfaces.ts:2138](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2138)
 
 ***
 
@@ -214,6 +180,4 @@ An array of users who liked the post.
 
 > **video**: `string`
 
-Defined in: [src/utils/interfaces.ts:2130](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2130)
-
-The URL of the post's video, or null.
+Defined in: [src/utils/interfaces.ts:2134](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2134)

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceQueryMembershipRequestsListItem.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceQueryMembershipRequestsListItem.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceQueryMembershipRequestsListItem
 
-Defined in: [src/utils/interfaces.ts:2193](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2193)
+Defined in: [src/utils/interfaces.ts:2186](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2186)
 
 InterfaceQueryMembershipRequestsListItem
 
@@ -18,7 +18,7 @@ Defines the structure for a membership requests list item returned from a query.
 
 > **organizations**: `object`[]
 
-Defined in: [src/utils/interfaces.ts:2194](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2194)
+Defined in: [src/utils/interfaces.ts:2187](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2187)
 
 An array of organization objects.
 

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceUserEvents.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceUserEvents.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceUserEvents
 
-Defined in: [src/utils/interfaces.ts:2476](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2476)
+Defined in: [src/utils/interfaces.ts:2469](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2469)
 
 InterfaceUserEvents
 
@@ -162,7 +162,7 @@ The title of the event.
 
 > **volunteerGroups**: `object`[]
 
-Defined in: [src/utils/interfaces.ts:2477](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2477)
+Defined in: [src/utils/interfaces.ts:2470](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2470)
 
 An array of volunteer groups associated with the event.
 
@@ -192,7 +192,7 @@ An array of volunteer groups associated with the event.
 
 > **volunteers**: `object`[]
 
-Defined in: [src/utils/interfaces.ts:2484](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2484)
+Defined in: [src/utils/interfaces.ts:2477](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2477)
 
 An array of volunteers associated with the event.
 

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceVolunteerGroupInfo.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceVolunteerGroupInfo.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceVolunteerGroupInfo
 
-Defined in: [src/utils/interfaces.ts:2417](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2417)
+Defined in: [src/utils/interfaces.ts:2410](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2410)
 
 InterfaceVolunteerGroupInfo
 
@@ -18,7 +18,7 @@ Defines the structure for volunteer group information.
 
 > **\_id**: `string`
 
-Defined in: [src/utils/interfaces.ts:2418](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2418)
+Defined in: [src/utils/interfaces.ts:2411](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2411)
 
 The unique identifier of the volunteer group.
 
@@ -28,7 +28,7 @@ The unique identifier of the volunteer group.
 
 > **assignments**: `object`[]
 
-Defined in: [src/utils/interfaces.ts:2432](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2432)
+Defined in: [src/utils/interfaces.ts:2425](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2425)
 
 An array of assignments for the group.
 
@@ -62,7 +62,7 @@ An array of assignments for the group.
 
 > **createdAt**: `string`
 
-Defined in: [src/utils/interfaces.ts:2425](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2425)
+Defined in: [src/utils/interfaces.ts:2418](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2418)
 
 The creation date of the volunteer group record.
 
@@ -72,7 +72,7 @@ The creation date of the volunteer group record.
 
 > **creator**: [`InterfaceUserInfo`](InterfaceUserInfo.md)
 
-Defined in: [src/utils/interfaces.ts:2426](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2426)
+Defined in: [src/utils/interfaces.ts:2419](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2419)
 
 The user who created this volunteer group.
 
@@ -82,7 +82,7 @@ The user who created this volunteer group.
 
 > **description**: `string`
 
-Defined in: [src/utils/interfaces.ts:2420](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2420)
+Defined in: [src/utils/interfaces.ts:2413](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2413)
 
 The description of the volunteer group, or null.
 
@@ -92,7 +92,7 @@ The description of the volunteer group, or null.
 
 > **event**: `object`
 
-Defined in: [src/utils/interfaces.ts:2421](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2421)
+Defined in: [src/utils/interfaces.ts:2414](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2414)
 
 The event associated with the volunteer group.
 
@@ -106,7 +106,7 @@ The event associated with the volunteer group.
 
 > **leader**: [`InterfaceUserInfo`](InterfaceUserInfo.md)
 
-Defined in: [src/utils/interfaces.ts:2427](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2427)
+Defined in: [src/utils/interfaces.ts:2420](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2420)
 
 The leader of the volunteer group.
 
@@ -116,7 +116,7 @@ The leader of the volunteer group.
 
 > **name**: `string`
 
-Defined in: [src/utils/interfaces.ts:2419](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2419)
+Defined in: [src/utils/interfaces.ts:2412](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2412)
 
 The name of the volunteer group.
 
@@ -126,7 +126,7 @@ The name of the volunteer group.
 
 > **volunteers**: `object`[]
 
-Defined in: [src/utils/interfaces.ts:2428](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2428)
+Defined in: [src/utils/interfaces.ts:2421](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2421)
 
 An array of volunteers in the group.
 
@@ -144,6 +144,6 @@ An array of volunteers in the group.
 
 > **volunteersRequired**: `number`
 
-Defined in: [src/utils/interfaces.ts:2424](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2424)
+Defined in: [src/utils/interfaces.ts:2417](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2417)
 
 The number of volunteers required for the group, or null.

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceVolunteerMembership.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceVolunteerMembership.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceVolunteerMembership
 
-Defined in: [src/utils/interfaces.ts:2509](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2509)
+Defined in: [src/utils/interfaces.ts:2502](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2502)
 
 InterfaceVolunteerMembership
 
@@ -18,7 +18,7 @@ Defines the structure for volunteer membership information.
 
 > **\_id**: `string`
 
-Defined in: [src/utils/interfaces.ts:2510](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2510)
+Defined in: [src/utils/interfaces.ts:2503](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2503)
 
 The unique identifier of the volunteer membership.
 
@@ -28,7 +28,7 @@ The unique identifier of the volunteer membership.
 
 > **createdAt**: `string`
 
-Defined in: [src/utils/interfaces.ts:2512](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2512)
+Defined in: [src/utils/interfaces.ts:2505](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2505)
 
 The creation date of the volunteer membership record.
 
@@ -38,7 +38,7 @@ The creation date of the volunteer membership record.
 
 > **event**: `object`
 
-Defined in: [src/utils/interfaces.ts:2513](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2513)
+Defined in: [src/utils/interfaces.ts:2506](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2506)
 
 The event associated with the volunteer membership.
 
@@ -60,7 +60,7 @@ The event associated with the volunteer membership.
 
 > **group**: `object`
 
-Defined in: [src/utils/interfaces.ts:2522](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2522)
+Defined in: [src/utils/interfaces.ts:2515](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2515)
 
 The group associated with the membership.
 
@@ -78,7 +78,7 @@ The group associated with the membership.
 
 > **status**: `string`
 
-Defined in: [src/utils/interfaces.ts:2511](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2511)
+Defined in: [src/utils/interfaces.ts:2504](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2504)
 
 The status of the volunteer membership.
 
@@ -88,7 +88,7 @@ The status of the volunteer membership.
 
 > **volunteer**: `object`
 
-Defined in: [src/utils/interfaces.ts:2518](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2518)
+Defined in: [src/utils/interfaces.ts:2511](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2511)
 
 The volunteer associated with the membership.
 

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceVolunteerRank.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/InterfaceVolunteerRank.md
@@ -4,7 +4,7 @@
 
 # Interface: InterfaceVolunteerRank
 
-Defined in: [src/utils/interfaces.ts:2540](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2540)
+Defined in: [src/utils/interfaces.ts:2533](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2533)
 
 InterfaceVolunteerRank
 
@@ -18,7 +18,7 @@ Defines the structure for volunteer ranking information.
 
 > **hoursVolunteered**: `number`
 
-Defined in: [src/utils/interfaces.ts:2542](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2542)
+Defined in: [src/utils/interfaces.ts:2535](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2535)
 
 The number of hours volunteered.
 
@@ -28,7 +28,7 @@ The number of hours volunteered.
 
 > **rank**: `number`
 
-Defined in: [src/utils/interfaces.ts:2541](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2541)
+Defined in: [src/utils/interfaces.ts:2534](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2534)
 
 The rank of the volunteer.
 
@@ -38,7 +38,7 @@ The rank of the volunteer.
 
 > **user**: `object`
 
-Defined in: [src/utils/interfaces.ts:2543](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2543)
+Defined in: [src/utils/interfaces.ts:2536](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2536)
 
 The user information of the volunteer.
 

--- a/docs/docs/auto-docs/utils/interfaces/interfaces/VoteType.md
+++ b/docs/docs/auto-docs/utils/interfaces/interfaces/VoteType.md
@@ -1,0 +1,17 @@
+[Admin Docs](/)
+
+***
+
+# Interface: VoteType
+
+Defined in: [src/utils/interfaces.ts:2119](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2119)
+
+InterfacePostCard
+
+## Description
+
+Defines the structure for a post card.
+
+## Indexable
+
+\[`key`: `number`\]: `string`

--- a/docs/docs/auto-docs/utils/interfaces/type-aliases/VoteState.md
+++ b/docs/docs/auto-docs/utils/interfaces/type-aliases/VoteState.md
@@ -1,0 +1,25 @@
+[Admin Docs](/)
+
+***
+
+# Type Alias: VoteState
+
+> **VoteState** = `object`
+
+Defined in: [src/utils/interfaces.ts:2120](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2120)
+
+## Properties
+
+### hasVoted
+
+> **hasVoted**: `boolean`
+
+Defined in: [src/utils/interfaces.ts:2120](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2120)
+
+***
+
+### voteType
+
+> **voteType**: [`VoteType`](../interfaces/VoteType.md)
+
+Defined in: [src/utils/interfaces.ts:2120](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/interfaces.ts#L2120)

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "cypress:open": "cypress open",
     "start-server": "start-server-and-test serve http://localhost:4321",
     "cy:open": "npm run start-server cypress:open",
-    "cy:run": "cross-env CYPRESS_COVERAGE=true npm run start-server cypress:run"
+    "cy:run": "cross-env CYPRESS_COVERAGE=true npm run start-server cypress:run",
+    "check:pom": "node scripts/githooks/check_pom.js"
   },
   "eslintConfig": {
     "extends": [

--- a/scripts/githooks/check_pom.js
+++ b/scripts/githooks/check_pom.js
@@ -1,0 +1,49 @@
+// 
+// Page Object Model (POM) Compliance Checker for E2E Tests
+
+// This script validates that all Cypress end-to-end test files in the project
+// follow the Page Object Model (POM) design pattern. It scans through all TypeScript
+// test files in the cypress/e2e directory and checks for direct usage of Cypress
+// commands that should be encapsulated within page object classes.
+
+// The script identifies forbidden Cypress commands (like cy.get(), cy.click(), etc.)
+// that indicate direct DOM interaction instead of using page objects. This helps
+// maintain clean, maintainable, and reusable test code by enforcing the POM pattern.
+
+// Exit codes:
+// - 0: All tests follow POM (no forbidden patterns found)
+// - 1: POM violations detected (forbidden patterns found)
+// 
+import { readFileSync } from "fs";
+import { sync } from "glob";
+
+const forbiddenMethods = [
+  'get', 'contains', 'find', 'children', 'closest',
+  'filter', 'first', 'last', 'next', 'prev', 'siblings',
+  'click', 'dblclick', 'rightclick', 'type', 'select',
+  'check', 'uncheck', 'trigger', 'clear', 'scrollIntoView',
+  'should', 'and', 'within',
+];
+
+const forbiddenPatterns = forbiddenMethods.map(m => `cy.${m}(`);
+
+const files = sync("cypress/e2e/**/*.ts");
+
+let hasError = false;
+
+files.forEach(file => {
+  const content = readFileSync(file, "utf8");
+  forbiddenPatterns.forEach(pattern => {
+    if (content.includes(pattern)) {
+      console.error(`Found "${pattern}" in ${file}`);
+      hasError = true;
+    }
+  });
+});
+
+if (hasError) {
+  console.error("❗ POM violations detected. Please refactor the tests to use page objects.");
+  process.exit(1);
+} else {
+  console.log("✅ All e2e tests follow POM.");
+}


### PR DESCRIPTION
**This PR introduces a new script that checks if the cypress E2E tests that are being written follows Page Object Model pattern.**

<img width="859" height="145" alt="Screenshot 2025-09-30 at 1 19 59 AM" src="https://github.com/user-attachments/assets/33418d97-1695-41e4-8ceb-d60a0027697c" />

**It checks it in the husky pre-commit :**

<img width="1347" height="793" alt="Screenshot 2025-09-30 at 3 10 11 AM" src="https://github.com/user-attachments/assets/75bfc83a-73e7-4411-bb96-8fc7d335f52b" />

