### PR TITLE
Fix: switch between private and public org.

### DIFF
--- a/src/GraphQl/Queries/Queries.ts
+++ b/src/GraphQl/Queries/Queries.ts
@@ -601,6 +601,7 @@ const ORGANIZATION_BASIC_FIELDS = gql`
     avatarURL
     createdAt
     updatedAt
+    isUserRegistrationRequired
   }
 `;
 

--- a/src/components/OrgSettings/General/OrgUpdate/OrgUpdate.spec.tsx
+++ b/src/components/OrgSettings/General/OrgUpdate/OrgUpdate.spec.tsx
@@ -62,6 +62,7 @@ const mockOrgData = {
     avatarURL: null,
     createdAt: '2024-02-24T00:00:00Z',
     updatedAt: '2024-02-24T00:00:00Z',
+    isUserRegistrationRequired: false,
   },
 };
 
@@ -90,6 +91,7 @@ describe('OrgUpdate Component', () => {
             state: 'Test State',
             postalCode: '12345',
             countryCode: 'US',
+            userRegistrationRequired: false,
           },
         },
       },
@@ -184,7 +186,7 @@ describe('OrgUpdate Component', () => {
 
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith(
-        'Organization updated successfully',
+        i18n.t('orgUpdate.successfulUpdated'),
       );
     });
   });
@@ -230,6 +232,7 @@ describe('OrgUpdate Component', () => {
             state: 'Test State',
             postalCode: '12345',
             countryCode: 'US',
+            userRegistrationRequired: false,
           },
         },
       },
@@ -278,7 +281,6 @@ describe('OrgUpdate Component', () => {
   }));
 
   it('handles file upload', async () => {
-    const convertToBase64 = (await import('utils/convertToBase64')).default;
     const file = new File(['test'], 'test.png', { type: 'image/png' });
 
     render(
@@ -448,16 +450,7 @@ describe('OrgUpdate Component', () => {
                 avatarURL: null,
                 createdAt: '2024-02-24T00:00:00Z',
                 updatedAt: '2024-02-24T00:00:00Z',
-                creator: {
-                  id: '1',
-                  name: 'Test Creator',
-                  emailAddress: 'creator@test.com',
-                },
-                updater: {
-                  id: '1',
-                  name: 'Test Updater',
-                  emailAddress: 'updater@test.com',
-                },
+                isUserRegistrationRequired: false,
               },
             },
           },
@@ -476,6 +469,7 @@ describe('OrgUpdate Component', () => {
                 state: 'Test State',
                 postalCode: '12345',
                 countryCode: 'US',
+                userRegistrationRequired: false,
               },
             },
           },
@@ -591,6 +585,7 @@ describe('OrgUpdate Component', () => {
                 state: 'Test State',
                 postalCode: '12345',
                 countryCode: 'US',
+                userRegistrationRequired: false,
               },
             },
           },
@@ -640,6 +635,7 @@ describe('OrgUpdate Component', () => {
         avatarURL: null,
         createdAt: '2024-02-24T00:00:00Z',
         updatedAt: '2024-02-24T00:00:00Z',
+        isUserRegistrationRequired: false,
       },
     };
 
@@ -679,17 +675,17 @@ describe('OrgUpdate Component', () => {
         .closest('.d-flex')
         ?.querySelector('input[type="checkbox"]');
       expect(userRegSwitch).toBeInTheDocument();
-      expect(userRegSwitch).not.toBeChecked();
+      expect(userRegSwitch).toBeChecked();
 
       if (userRegSwitch) {
         fireEvent.click(userRegSwitch);
-        expect(userRegSwitch).toBeChecked();
+        expect(userRegSwitch).not.toBeChecked();
       }
 
       if (userRegSwitch) {
         fireEvent.click(userRegSwitch);
       }
-      expect(userRegSwitch).not.toBeChecked();
+      expect(userRegSwitch).toBeChecked();
     });
 
     it('toggles visibility switch correctly', async () => {
@@ -783,6 +779,7 @@ describe('OrgUpdate Component', () => {
                 state: 'Test State',
                 postalCode: '12345',
                 countryCode: 'US',
+                userRegistrationRequired: false,
               },
             },
           },
@@ -814,13 +811,10 @@ describe('OrgUpdate Component', () => {
 
       await waitFor(
         () => {
-          expect(toast.error).toHaveBeenCalledWith(
-            'Failed to update organization',
-          );
+          expect(toast.error).toHaveBeenCalledWith(i18n.t('failedToUpdateOrg'));
         },
         { timeout: 2000 },
       );
-
       expect(saveButton).not.toBeDisabled();
       expect(saveButton).toHaveTextContent('Save Changes');
     });

--- a/src/components/OrgSettings/General/OrgUpdate/OrgUpdate.tsx
+++ b/src/components/OrgSettings/General/OrgUpdate/OrgUpdate.tsx
@@ -11,7 +11,6 @@ import { UPDATE_ORGANIZATION_MUTATION } from 'GraphQl/Mutations/mutations';
 import { GET_ORGANIZATION_BASIC_DATA } from 'GraphQl/Queries/Queries';
 import Loader from 'components/Loader/Loader';
 import { Col, Form, Row } from 'react-bootstrap';
-import convertToBase64 from 'utils/convertToBase64';
 import { errorHandler } from 'utils/errorHandler';
 import styles from 'style/app-fixed.module.css';
 import type { InterfaceAddress } from 'utils/interfaces';
@@ -99,6 +98,7 @@ function OrgUpdate(props: InterfaceOrgUpdateProps): JSX.Element {
     postalCode: string;
     countryCode: string;
     avatarURL: string | null;
+    isUserRegistrationRequired: boolean | null;
   }
 
   const {
@@ -135,6 +135,9 @@ function OrgUpdate(props: InterfaceOrgUpdateProps): JSX.Element {
         },
         orgImage: null,
       });
+      setuserRegistrationRequiredChecked(
+        data.organization.isUserRegistrationRequired ?? false,
+      );
     }
     return () => {
       isMounted = false;
@@ -181,6 +184,7 @@ function OrgUpdate(props: InterfaceOrgUpdateProps): JSX.Element {
         postalCode: formState.address.postalCode,
         countryCode: formState.address?.countryCode,
         ...(formState.avatar ? { avatar: formState.avatar } : {}),
+        userRegistrationRequired: userRegistrationRequiredChecked,
       };
 
       // Filter out empty fields
@@ -300,7 +304,7 @@ function OrgUpdate(props: InterfaceOrgUpdateProps): JSX.Element {
               <Form.Switch
                 className="custom-switch"
                 placeholder={t('userRegistrationRequired')}
-                checked={userRegistrationRequiredChecked}
+                checked={!userRegistrationRequiredChecked}
                 onChange={(): void =>
                   setuserRegistrationRequiredChecked(
                     !userRegistrationRequiredChecked,


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixed ```Is Public``` button to switch between private and public org successfully.

**Issue Number:** #4234

Fixes #4234

**Snapshots/Videos:**

https://github.com/user-attachments/assets/7164b2e5-817b-4789-98cf-21bb7f54c76d

**Summary**

Previously admin was unable to switch between private and public org, this pr fixis ```Is Public``` button to switch between private and public org successfully.

**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->