### PR TITLE
Revert "fix(CommunityProfile): add missing return statement in loading state and improve test coverage"

### DIFF
--- a/src/screens/CommunityProfile/CommunityProfile.spec.tsx
+++ b/src/screens/CommunityProfile/CommunityProfile.spec.tsx
@@ -78,7 +78,7 @@ const MOCKS2 = [
           githubURL: null,
           youtubeURL: null,
           instagramURL: null,
-          linkedinURL: null,
+          linkedInURL: null,
           redditURL: null,
           slackURL: null,
           xURL: null,
@@ -90,6 +90,9 @@ const MOCKS2 = [
   {
     request: {
       query: RESET_COMMUNITY,
+      variables: {
+        resetPreLoginImageryId: 'communityId',
+      },
     },
     result: {
       data: {
@@ -118,7 +121,7 @@ const MOCKS3 = [
           githubURL: 'http://sociallink.com',
           youtubeURL: 'http://sociallink.com',
           instagramURL: 'http://sociallink.com',
-          linkedinURL: 'http://sociallink.com',
+          linkedInURL: 'http://sociallink.com',
           redditURL: 'http://sociallink.com',
           slackURL: 'http://sociallink.com',
           xURL: 'http://sociallink.com',
@@ -131,6 +134,9 @@ const MOCKS3 = [
   {
     request: {
       query: RESET_COMMUNITY,
+      variables: {
+        resetPreLoginImageryId: 'communityId',
+      },
     },
     result: {
       data: {
@@ -154,7 +160,107 @@ const LOADING_MOCK = [
         community: null,
       },
     },
-    delay: 100,
+    delay: 100, // Add delay to ensure loading state is rendered
+  },
+];
+
+const ERROR_MOCK = [
+  {
+    request: {
+      query: GET_COMMUNITY_DATA_PG,
+    },
+    result: {
+      data: {
+        community: null,
+      },
+    },
+  },
+  {
+    request: {
+      query: UPDATE_COMMUNITY_PG,
+      variables: {
+        name: 'Test Name',
+        websiteURL: 'https://test.com',
+        facebookURL: '',
+        instagramURL: '',
+        inactivityTimeoutDuration: null,
+        xURL: '',
+        linkedinURL: '',
+        githubURL: '',
+        youtubeURL: '',
+        redditURL: '',
+        slackURL: '',
+      },
+    },
+    error: new Error('Mutation error'),
+  },
+];
+
+const BASE64_MOCKS = [
+  {
+    request: {
+      query: GET_COMMUNITY_DATA_PG,
+    },
+    result: {
+      data: {
+        community: null,
+      },
+    },
+  },
+];
+const UPDATE_SUCCESS_MOCKS = [
+  {
+    request: {
+      query: GET_COMMUNITY_DATA_PG,
+    },
+    result: {
+      data: {
+        community: {
+          createdAt: null,
+          facebookURL: null,
+          githubURL: null,
+          id: null,
+          inactivityTimeoutDuration: null,
+          instagramURL: null,
+          linkedInURL: null,
+          logoMimeType: null,
+          logoURL: null,
+          name: null,
+          redditURL: null,
+          slackURL: null,
+          updatedAt: null,
+          updater: null,
+          websiteURL: null,
+          xURL: null,
+          youtubeURL: null,
+        },
+      },
+    },
+  },
+  {
+    request: {
+      query: UPDATE_COMMUNITY_PG,
+      variables: {
+        name: 'Test Name',
+        websiteURL: 'https://test.com',
+        facebookURL: undefined,
+        instagramURL: undefined,
+        xURL: undefined,
+        linkedinURL: undefined,
+        githubURL: undefined,
+        youtubeURL: undefined,
+        redditURL: undefined,
+        slackURL: undefined,
+        inactivityTimeoutDuration: null,
+      },
+    },
+    result: {
+      data: {
+        updateCommunity: {
+          id: '123',
+        },
+      },
+    },
   },
 ];
 
@@ -263,6 +369,7 @@ describe('Testing Community Profile Screen', () => {
 
     expect(communityName).toHaveValue(profileVariables.name);
     expect(websiteLink).toHaveValue(profileVariables.websiteURL);
+    // expect(logo).toBeTruthy();
     expect(facebook).toHaveValue(profileVariables.socialURL);
     expect(instagram).toHaveValue(profileVariables.socialURL);
     expect(X).toHaveValue(profileVariables.socialURL);
@@ -337,8 +444,6 @@ describe('Testing Community Profile Screen', () => {
       </MockedProvider>,
     );
 
-    await wait();
-
     expect(screen.getByPlaceholderText(/Community Name/i)).toHaveValue('');
     expect(screen.getByPlaceholderText(/Website Link/i)).toHaveValue('');
     expect(screen.getByTestId(/facebook/i)).toHaveValue('');
@@ -362,51 +467,13 @@ describe('Testing Community Profile Screen', () => {
       </MockedProvider>,
     );
 
+    // Loader should be present during loading state
     expect(screen.getByTestId('spinner-wrapper')).toBeInTheDocument();
-
-    await wait();
   });
 
-  test('should handle error in resetData mutation', async () => {
-    const ERROR_RESET_MOCK = [
-      {
-        request: {
-          query: GET_COMMUNITY_DATA_PG,
-        },
-        result: {
-          data: {
-            community: {
-              createdAt: '2022-01-01T12:00:00Z',
-              updatedAt: '2022-01-01T12:00:00Z',
-              id: 'communityId',
-              name: 'testName',
-              logoURL: 'http://logo.com',
-              logoMimeType: 'image/png',
-              websiteURL: 'http://websitelink.com',
-              facebookURL: 'http://sociallink.com',
-              githubURL: 'http://sociallink.com',
-              youtubeURL: 'http://sociallink.com',
-              instagramURL: 'http://sociallink.com',
-              linkedinURL: 'http://sociallink.com',
-              redditURL: 'http://sociallink.com',
-              slackURL: 'http://sociallink.com',
-              xURL: 'http://sociallink.com',
-              inactivityTimeoutDuration: 30,
-              updater: null,
-            },
-          },
-        },
-      },
-      {
-        request: {
-          query: RESET_COMMUNITY,
-        },
-        error: new Error('Reset mutation error'),
-      },
-    ];
-
+  test('should handle mutation error correctly', async () => {
     render(
-      <MockedProvider addTypename={false} mocks={ERROR_RESET_MOCK}>
+      <MockedProvider addTypename={false} mocks={ERROR_MOCK}>
         <BrowserRouter>
           <I18nextProvider i18n={i18n}>
             <CommunityProfile />
@@ -415,10 +482,19 @@ describe('Testing Community Profile Screen', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    const nameInput = screen.getByPlaceholderText(/Community Name/i);
+    const websiteInput = screen.getByPlaceholderText(/Website Link/i);
+    const logoInput = screen.getByTestId('fileInput');
 
-    const resetChangesBtn = screen.getByTestId('resetChangesBtn');
-    await userEvent.click(resetChangesBtn);
+    await userEvent.type(nameInput, 'Test Name');
+    await userEvent.type(websiteInput, 'https://test.com');
+    await userEvent.upload(
+      logoInput,
+      new File([''], 'test.png', { type: 'image/png' }),
+    );
+
+    const submitButton = screen.getByTestId('saveChangesBtn');
+    await userEvent.click(submitButton);
     await wait();
 
     expect(errorHandler).toHaveBeenCalled();
@@ -428,9 +504,9 @@ describe('Testing Community Profile Screen', () => {
     );
   });
 
-  test('should enable buttons when only name is filled', async () => {
+  test('should handle null base64 conversion when updating logo', async () => {
     render(
-      <MockedProvider addTypename={false} link={link1}>
+      <MockedProvider addTypename={false} mocks={BASE64_MOCKS}>
         <BrowserRouter>
           <I18nextProvider i18n={i18n}>
             <CommunityProfile />
@@ -439,23 +515,27 @@ describe('Testing Community Profile Screen', () => {
       </MockedProvider>,
     );
 
+    const mockFile = new File([''], 'test.png', { type: 'image/png' });
+    vi.mock('utils/convertToBase64', () => ({
+      default: vi.fn().mockResolvedValue(null),
+    }));
+
+    const fileInput = screen.getByTestId('fileInput') as HTMLInputElement;
+    fireEvent.change(fileInput, {
+      target: { files: [mockFile] },
+    });
     await wait();
 
-    const nameInput = screen.getByPlaceholderText(/Community Name/i);
-    const saveBtn = screen.getByTestId('saveChangesBtn');
-    const resetBtn = screen.getByTestId('resetChangesBtn');
+    // Ensure state or UI behavior when base64 conversion fails
+    expect(fileInput.value).toBe('');
 
-    expect(saveBtn).toBeDisabled();
-    expect(resetBtn).toBeDisabled();
-
-    await userEvent.type(nameInput, 'Test Name');
-    expect(saveBtn).not.toBeDisabled();
-    expect(resetBtn).not.toBeDisabled();
+    // Ensure no success toast is shown for null conversion
+    expect(toast.success).not.toHaveBeenCalled();
   });
 
-  test('should enable buttons when only websiteURL is filled', async () => {
+  test('should show success toast when profile is updated successfully', async () => {
     render(
-      <MockedProvider addTypename={false} link={link1}>
+      <MockedProvider addTypename={false} mocks={UPDATE_SUCCESS_MOCKS}>
         <BrowserRouter>
           <I18nextProvider i18n={i18n}>
             <CommunityProfile />
@@ -464,175 +544,28 @@ describe('Testing Community Profile Screen', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    // Wait for initial query to complete
+    await wait(100);
 
+    const nameInput = screen.getByPlaceholderText(/Community Name/i);
     const websiteInput = screen.getByPlaceholderText(/Website Link/i);
-    const saveBtn = screen.getByTestId('saveChangesBtn');
-
-    await userEvent.type(websiteInput, 'https://test.com');
-    expect(saveBtn).not.toBeDisabled();
-  });
-
-  test('should handle logo file upload and trigger state update', async () => {
-    render(
-      <MockedProvider addTypename={false} link={link1}>
-        <BrowserRouter>
-          <I18nextProvider i18n={i18n}>
-            <CommunityProfile />
-          </I18nextProvider>
-        </BrowserRouter>
-      </MockedProvider>,
-    );
-
-    await wait();
-
-    const logoInput = screen.getByTestId('fileInput');
-    const nameInput = screen.getByPlaceholderText(/Community Name/i);
-    const saveBtn = screen.getByTestId('saveChangesBtn');
-
-    expect(saveBtn).toBeDisabled();
 
     await userEvent.type(nameInput, 'Test Name');
-    expect(saveBtn).not.toBeDisabled();
+    await userEvent.type(websiteInput, 'https://test.com');
 
-    const mockFile = new File(['test content'], 'test.png', {
-      type: 'image/png',
-    });
-    fireEvent.change(logoInput, {
-      target: { files: [mockFile] },
-    });
+    const submitButton = screen.getByTestId('saveChangesBtn');
+    await userEvent.click(submitButton);
 
-    expect(saveBtn).not.toBeDisabled();
-  });
-
-  test('should handle file input change without file selection', async () => {
-    render(
-      <MockedProvider addTypename={false} link={link1}>
-        <BrowserRouter>
-          <I18nextProvider i18n={i18n}>
-            <CommunityProfile />
-          </I18nextProvider>
-        </BrowserRouter>
-      </MockedProvider>,
-    );
-
-    await wait();
-
-    const logoInput = screen.getByTestId('fileInput') as HTMLInputElement;
-
-    fireEvent.change(logoInput, { target: { files: [] } });
-    await wait();
-
-    expect(logoInput.files?.length).toBe(0);
-  });
-
-  test('should update all social media URLs correctly', async () => {
-    render(
-      <MockedProvider addTypename={false} link={link1}>
-        <BrowserRouter>
-          <I18nextProvider i18n={i18n}>
-            <CommunityProfile />
-          </I18nextProvider>
-        </BrowserRouter>
-      </MockedProvider>,
-    );
-
-    await wait();
-
-    const facebookInput = screen.getByTestId('facebook');
-    const instagramInput = screen.getByTestId('instagram');
-    const xInput = screen.getByTestId('X');
-    const linkedInInput = screen.getByTestId('linkedIn');
-    const githubInput = screen.getByTestId('github');
-    const youtubeInput = screen.getByTestId('youtube');
-    const redditInput = screen.getByTestId('reddit');
-    const slackInput = screen.getByTestId('slack');
-
-    await userEvent.type(facebookInput, 'https://facebook.com/test');
-    await userEvent.type(instagramInput, 'https://instagram.com/test');
-    await userEvent.type(xInput, 'https://x.com/test');
-    await userEvent.type(linkedInInput, 'https://linkedin.com/test');
-    await userEvent.type(githubInput, 'https://github.com/test');
-    await userEvent.type(youtubeInput, 'https://youtube.com/test');
-    await userEvent.type(redditInput, 'https://reddit.com/test');
-    await userEvent.type(slackInput, 'https://slack.com/test');
-
-    expect(facebookInput).toHaveValue('https://facebook.com/test');
-    expect(instagramInput).toHaveValue('https://instagram.com/test');
-    expect(xInput).toHaveValue('https://x.com/test');
-    expect(linkedInInput).toHaveValue('https://linkedin.com/test');
-    expect(githubInput).toHaveValue('https://github.com/test');
-    expect(youtubeInput).toHaveValue('https://youtube.com/test');
-    expect(redditInput).toHaveValue('https://reddit.com/test');
-    expect(slackInput).toHaveValue('https://slack.com/test');
-  });
-
-  test('should populate form fields with fetched community data', async () => {
-    render(
-      <MockedProvider addTypename={false} link={link3}>
-        <BrowserRouter>
-          <I18nextProvider i18n={i18n}>
-            <CommunityProfile />
-          </I18nextProvider>
-        </BrowserRouter>
-      </MockedProvider>,
-    );
-
-    await wait();
-
-    expect(screen.getByPlaceholderText(/Community Name/i)).toHaveValue(
-      'testName',
-    );
-    expect(screen.getByPlaceholderText(/Website Link/i)).toHaveValue(
-      'http://websitelink.com',
-    );
-    expect(screen.getByTestId('facebook')).toHaveValue('http://sociallink.com');
-    expect(screen.getByTestId('instagram')).toHaveValue(
-      'http://sociallink.com',
-    );
-    expect(screen.getByTestId('X')).toHaveValue('http://sociallink.com');
-    expect(screen.getByTestId('linkedIn')).toHaveValue('http://sociallink.com');
-    expect(screen.getByTestId('github')).toHaveValue('http://sociallink.com');
-    expect(screen.getByTestId('youtube')).toHaveValue('http://sociallink.com');
-    expect(screen.getByTestId('reddit')).toHaveValue('http://sociallink.com');
-    expect(screen.getByTestId('slack')).toHaveValue('http://sociallink.com');
-  });
-
-  test('should clear logo field before setting new file', async () => {
-    render(
-      <MockedProvider addTypename={false} link={link3}>
-        <BrowserRouter>
-          <I18nextProvider i18n={i18n}>
-            <CommunityProfile />
-          </I18nextProvider>
-        </BrowserRouter>
-      </MockedProvider>,
-    );
-
-    await wait();
-
-    const logoInput = screen.getByTestId('fileInput') as HTMLInputElement;
-    const mockFile = new File(['test content'], 'test.png', {
-      type: 'image/png',
-    });
-
-    fireEvent.change(logoInput, {
-      target: { files: [mockFile] },
-    });
-
-    expect(logoInput.files).toHaveLength(1);
-    expect(logoInput.files?.[0].name).toBe('test.png');
-    expect(logoInput.files?.[0].size).toBe(12);
-
-    const mockFile2 = new File(['test content 2'], 'test2.png', {
-      type: 'image/png',
-    });
-    fireEvent.change(logoInput, {
-      target: { files: [mockFile2] },
-    });
-
-    expect(logoInput.files).toHaveLength(1);
-    expect(logoInput.files?.[0].name).toBe('test2.png');
-    expect(logoInput.files?.[0].size).toBe(14);
+    // Increase wait time and add error handling
+    try {
+      await wait(1000); // Increased wait time
+      expect(errorHandler).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.any(Error),
+      );
+    } catch (error) {
+      console.error('Mutation error:', error);
+      throw error;
+    }
   });
 });

--- a/src/screens/CommunityProfile/CommunityProfile.tsx
+++ b/src/screens/CommunityProfile/CommunityProfile.tsx
@@ -175,6 +175,7 @@ const CommunityProfile = (): JSX.Element => {
    * Resets profile data to initial values and performs a reset operation.
    */
   const resetData = async (): Promise<void> => {
+    const preLoginData: PreLoginImageryDataType | undefined = data?.community;
     try {
       setProfileVariable({
         name: '',
@@ -191,7 +192,9 @@ const CommunityProfile = (): JSX.Element => {
         slackURL: '',
       });
 
-      await resetPreLoginImagery();
+      await resetPreLoginImagery({
+        variables: { resetPreLoginImageryId: preLoginData?.id },
+      });
       toast.success(t(`resetData`) as string);
     } catch (error: unknown) {
       errorHandler(t, error as Error);
@@ -216,7 +219,7 @@ const CommunityProfile = (): JSX.Element => {
   };
 
   if (loading) {
-    return <Loader />;
+    <Loader />;
   }
 
   return (


### PR DESCRIPTION
Reverts PalisadoesFoundation/talawa-admin#4440


1. This has to be reverted. It's causing our push.yml workflow to fail. 
2. @hxrshxz please resubmit your PR and ensure all code rabbit suggestions are followed.

- https://github.com/PalisadoesFoundation/talawa-admin/actions/runs/18515638573

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading behavior on the Community Profile screen.
  * More reliable profile updates, with clear error handling when updates fail.
  * Correct handling when imagery/logo data is missing, preventing false success messages.
  * Ensured action buttons reflect valid/invalid input states accurately.

* **Tests**
  * Expanded coverage for loading, error, and success flows.
  * Added scenarios for update failures and successful updates.
  * Simulated file uploads to validate logo interactions and form behavior.
  * Strengthened timing and sequencing to better mirror real user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->