### PR TITLE
Test: increased VolunteerGroupDeleteModal.tsx coverage to 100%

### DIFF
--- a/src/screens/EventVolunteers/VolunteerGroups/deleteModal/VolunteerGroupDeleteModal.spec.tsx
+++ b/src/screens/EventVolunteers/VolunteerGroups/deleteModal/VolunteerGroupDeleteModal.spec.tsx
@@ -118,26 +118,16 @@ describe('Testing Group Delete Modal', () => {
     });
   });
 
-  it('Close Delete Modal', async () => {
+  test.each([
+    { testId: 'deletenobtn', description: 'no button' },
+    { testId: 'modalCloseBtn', description: 'close button' },
+  ])('Close Delete Modal using $description', async ({ testId }) => {
     renderGroupDeleteModal(link1, itemProps[0]);
     expect(screen.getByText(t.deleteGroup)).toBeInTheDocument();
 
-    const noBtn = screen.getByTestId('deletenobtn');
-    expect(noBtn).toBeInTheDocument();
-    await userEvent.click(noBtn);
-
-    await waitFor(() => {
-      expect(itemProps[0].hide).toHaveBeenCalled();
-    });
-  });
-
-  it('Close Delete Modal using close button', async () => {
-    renderGroupDeleteModal(link1, itemProps[0]);
-    expect(screen.getByText(t.deleteGroup)).toBeInTheDocument();
-
-    const closeBtn = screen.getByTestId('modalCloseBtn');
-    expect(closeBtn).toBeInTheDocument();
-    await userEvent.click(closeBtn);
+    const btn = screen.getByTestId(testId);
+    expect(btn).toBeInTheDocument();
+    await userEvent.click(btn);
 
     await waitFor(() => {
       expect(itemProps[0].hide).toHaveBeenCalled();


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Improved coverage for ```src/screens/EventVolunteers/VolunteerGroups/deleteModal/VolunteerGroupDeleteModal.tsx``` to 100%

**Issue Number:** #4297

Fixes #4297

**Snapshots/Videos:**
<img width="976" height="43" alt="image" src="https://github.com/user-attachments/assets/0e7fe0f9-249a-428f-bda9-9c0ceed55882" />

**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for the volunteer-group deletion modal: close-button behavior; radio options for applying deletion to entire series vs. single instance with default selection and toggling; new flow for deleting a specific recurring-instance group with mocked delete-for-instance handling; assertions for refresh, modal hide, and success notification; hidden radio controls for non-template and instance-exception groups with parameterized scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->