### PR TITLE
Revert "chore(deps): upgrade vite from 6.4.0 to 7.1.12"

### DIFF
--- a/config/vite.config.ts
+++ b/config/vite.config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
     }),
   ],
   server: {
+    allowedHosts: true,
     watch: {
       ignored: ['**/coverage/**', '**/.nyc_output/**'],
     },

--- a/docs/docs/auto-docs/plugin/vite/internalFileWriterPlugin/functions/createInternalFileWriterPlugin.md
+++ b/docs/docs/auto-docs/plugin/vite/internalFileWriterPlugin/functions/createInternalFileWriterPlugin.md
@@ -4,7 +4,7 @@
 
 # Function: createInternalFileWriterPlugin()
 
-> **createInternalFileWriterPlugin**(`options`): `Plugin$1`
+> **createInternalFileWriterPlugin**(`options`): `Plugin`
 
 Defined in: [src/plugin/vite/internalFileWriterPlugin.ts:32](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/plugin/vite/internalFileWriterPlugin.ts#L32)
 
@@ -18,4 +18,4 @@ Vite plugin for internal file operations
 
 ## Returns
 
-`Plugin$1`
+`Plugin`

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
         "typedoc": "^0.28.1",
         "typedoc-plugin-markdown": "^4.5.0",
         "typescript": "^5.8.3",
-        "vite": "^7.1.12",
+        "vite": "^6.3.5",
         "vite-plugin-istanbul": "^7.1.0",
         "vite-plugin-svgr": "^4.3.0",
         "vitest": "^3.2.4"
@@ -24650,23 +24650,23 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.12",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.12.tgz",
-      "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.0.tgz",
+      "integrity": "sha512-oLnWs9Hak/LOlKjeSpOwD6JMks8BeICEdYMJBf6P4Lac/pO9tKiv/XhXnAM7nNfSkZahjlCZu9sS50zL8fSnsw==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
       },
       "bin": {
         "vite": "bin/vite.js"
       },
       "engines": {
-        "node": "^20.19.0 || >=22.12.0"
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
@@ -24675,14 +24675,14 @@
         "fsevents": "~2.3.3"
       },
       "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
         "jiti": ">=1.21.0",
-        "less": "^4.0.0",
+        "less": "*",
         "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
         "terser": "^5.16.0",
         "tsx": "^4.8.1",
         "yaml": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "typedoc": "^0.28.1",
     "typedoc-plugin-markdown": "^4.5.0",
     "typescript": "^5.8.3",
-    "vite": "^7.1.12",
+    "vite": "^6.3.5",
     "vite-plugin-istanbul": "^7.1.0",
     "vite-plugin-svgr": "^4.3.0",
     "vitest": "^3.2.4"

--- a/src/utils/filehash.spec.ts
+++ b/src/utils/filehash.spec.ts
@@ -41,26 +41,9 @@ describe('calculateFileHash', () => {
       return Promise.resolve(buffer);
     });
 
-    // Ensure crypto.subtle exists before trying to mock it
-    if (!globalThis.crypto) {
-      Object.defineProperty(globalThis, 'crypto', {
-        value: {},
-        writable: true,
-        configurable: true,
-      });
-    }
-    if (!globalThis.crypto.subtle) {
-      Object.defineProperty(globalThis.crypto, 'subtle', {
-        value: {},
-        writable: true,
-        configurable: true,
-      });
-    }
-
     Object.defineProperty(crypto.subtle, 'digest', {
       value: mockDigest,
       writable: true,
-      configurable: true,
     });
   });
 


### PR DESCRIPTION
Reverts PalisadoesFoundation/talawa-admin#4602

@jhaayushkumar Your vite configuration broke our test website. You need to resubmit your changes.

<img width="793" height="212" alt="image" src="https://github.com/user-attachments/assets/5fabef42-cb40-4460-a4c8-286040770fc4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development server configuration for improved host compatibility handling
  * Downgraded Vite build tool to version 6.3.5
  * Streamlined internal test setup and configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->