### PR TITLE
fix(pledges): handle missing pledge resources error

### DIFF
--- a/docs/docs/auto-docs/screens/UserPortal/Pledges/Pledges/functions/default.md
+++ b/docs/docs/auto-docs/screens/UserPortal/Pledges/Pledges/functions/default.md
@@ -6,7 +6,7 @@
 
 > **default**(): `Element`
 
-Defined in: [src/screens/UserPortal/Pledges/Pledges.tsx:85](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/screens/UserPortal/Pledges/Pledges.tsx#L85)
+Defined in: [src/screens/UserPortal/Pledges/Pledges.tsx:89](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/screens/UserPortal/Pledges/Pledges.tsx#L89)
 
 ## Returns
 


### PR DESCRIPTION

**What kind of change does this PR introduce?**

a bugfix

**Issue Number:**

Fixes #4668 

**Snapshots/Videos:**

<img width="1907" height="1035" alt="Screenshot from 2025-11-13 23-21-04" src="https://github.com/user-attachments/assets/278de9dd-b4c6-40a6-9657-4586f6f922c8" />

**If relevant, did you update the documentation?**

Yes

**Summary**

- src/screens/UserPortal/Pledges/Pledges.tsx
• Detect Apollo errors with code arguments_associated_resources_not_found, clear displayed pledges to show the empty state, and keep generic errors for other cases.
• Store and reuse a isNoPledgesFoundError flag so the component renders the empty state instead of the red error banner.

- src/screens/UserPortal/Pledges/Pledge.spec.tsx
• Added a GraphQL mock containing the arguments_associated_resources_not_found error and a new test to ensure the UI shows “No Pledges” in that scenario.
• Updated imports to cover Apollo error typing and reorganized mocks.

**Does this PR introduce a breaking change?**

No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for pledges display. When the server indicates no associated resources are available, the app now displays an empty state instead of an error message, providing a better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->