### PR TITLE
Added auto-assign github workflow

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -93,6 +93,7 @@ jobs:
                 issue_number: issueNumber,
                 body: `❌ @${user} This workflow only supports self-assignment. Use \`/assign\` without specifying a username.`,
               });
+              return;
             }            
 
             if (isUnassign) {


### PR DESCRIPTION
Added auto-assign github workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds comment-based /assign and /unassign commands to manage issue assignees.
  * Enforces an org-wide open-assignment limit (default 2, configurable) and posts warnings when the limit is reached.
  * Commands ignore bot comments and post clear success, warning, and error notifications for each operation.
  * Improved error handling with fallback messages and acknowledgement of a potential transient race condition during assignment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->