### PR TITLE
fix(plugin-store): add cancel button to upload plugin modal

### DIFF
--- a/src/screens/PluginStore/UploadPluginModal.tsx
+++ b/src/screens/PluginStore/UploadPluginModal.tsx
@@ -138,6 +138,21 @@ const UploadPluginModal: React.FC<UploadPluginModalProps> = ({
           borderRadius: 12,
         }}
       >
+        <Button
+          onClick={handleClose}
+          area-label="Close"
+          style={{
+            position: 'absolute',
+            top: 16,
+            right: 16,
+            background: 'transparent',
+            fontsize: 24,
+            cursor: 'pointer',
+            color: #666,
+          }}
+        >
+          x
+        </Button>
         {/* Left Panel - Upload */}
         <div
           style={{
@@ -258,13 +273,26 @@ const UploadPluginModal: React.FC<UploadPluginModalProps> = ({
             </div>
           )}
 
-          <div style={{ marginTop: 32 }}>
+          <div style={{ marginTop: 32,
+            display: 'flex',
+            gap: 12,
+           }}>
+            <Button
+              variant="outlined"
+              color="secondary"
+              onClick={handleClose}
+              disabled={isInstalling}
+              style={{ flex: 1 }}
+              data-testid="cancel-upload-plugin-button"
+            >
+              Cancel
+            </Button>
             <Button
               variant="contained"
               color="primary"
               onClick={handleAddPlugin}
               disabled={!selectedFile || !manifest || isInstalling}
-              style={{ width: '100%' }}
+              style={{ flex : 1 }}
               data-testid="upload-plugin-button"
             >
               {isInstalling ? 'Uploading...' : 'Upload Plugin'}


### PR DESCRIPTION
Adds an explicit Cancel button to the Upload Plugin modal.

### Cancel Button
- Added an explicit Cancel button next to the Upload button
<img width="450" height="277" alt="Screenshot 2025-12-15 211147" src="https://github.com/user-attachments/assets/1aba1c65-8e41-40a0-8b57-fbe9bffc0c1a" />

### Close Icon
- Added top-right close button for quick dismissal
<img width="450" height="277" alt="Screenshot 2025-12-15 211109" src="https://github.com/user-attachments/assets/09989743-982a-4bde-b286-4a60f1eb870b" />

## Solution
- Added a Cancel button next to the Upload button
- Cancel action closes the modal and resets state
- Added a top-right close icon using existing handleClose logic
- Improves UX and accessibility

## Related Issue
Closes #5036
 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a close button in the modal's top-right corner for easier dismissal.
  * Added a Cancel button in the action row alongside the Upload button.
  * Reorganized the modal's bottom action buttons to display horizontally for improved navigation and user clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->