### PR TITLE
feat(user-portal): add UserPortalCard foundation component

### DIFF
--- a/docs/docs/auto-docs/components/UserPortal/UserPortalCard/UserPortalCard/variables/default.md
+++ b/docs/docs/auto-docs/components/UserPortal/UserPortalCard/UserPortalCard/variables/default.md
@@ -1,0 +1,38 @@
+[Admin Docs](/)
+
+***
+
+# Variable: default
+
+> `const` **default**: `React.FC`\<[`InterfaceUserPortalCardProps`](../../../../../types/UserPortal/UserPortalCard/interface/interfaces/InterfaceUserPortalCardProps.md)\>
+
+Defined in: [src/components/UserPortal/UserPortalCard/UserPortalCard.tsx:32](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/UserPortal/UserPortalCard/UserPortalCard.tsx#L32)
+
+UserPortalCard
+
+Reusable 3-section layout wrapper for User Portal cards.
+
+Structure:
+[ imageSlot ] [ content (children) ] [ actionsSlot ]
+
+Responsibilities:
+- Centralizes spacing and alignment logic
+- Supports density variants (compact / standard / expanded)
+- Remains content-agnostic and styling-agnostic
+
+Accessibility:
+- role="group"
+- aria-label provided by consumer (i18n required)
+
+## Example
+
+```ts
+<UserPortalCard
+  variant="compact"
+  ariaLabel={t('donation.card')}
+  imageSlot={<Avatar />}
+  actionsSlot={<Button />}
+>
+  <CardContent />
+</UserPortalCard>
+```

--- a/docs/docs/auto-docs/types/UserPortal/UserPortalCard/interface/interfaces/InterfaceUserPortalCardProps.md
+++ b/docs/docs/auto-docs/types/UserPortal/UserPortalCard/interface/interfaces/InterfaceUserPortalCardProps.md
@@ -1,0 +1,85 @@
+[Admin Docs](/)
+
+***
+
+# Interface: InterfaceUserPortalCardProps
+
+Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:20](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/UserPortal/UserPortalCard/interface.ts#L20)
+
+Props for UserPortalCard — a flexible layout wrapper for User Portal cards.
+
+Layout:
+[ imageSlot ] [ children / content ] [ actionsSlot ]
+
+This component centralizes layout, spacing, and density while keeping
+all content and text controlled by consuming components.
+
+## Properties
+
+### actionsSlot?
+
+> `optional` **actionsSlot**: `ReactNode`
+
+Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:23](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/UserPortal/UserPortalCard/interface.ts#L23)
+
+Optional right section (buttons, badges, counters)
+
+***
+
+### ariaLabel?
+
+> `optional` **ariaLabel**: `string`
+
+Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:27](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/UserPortal/UserPortalCard/interface.ts#L27)
+
+Accessible label for the card container (i18n required)
+
+***
+
+### children
+
+> **children**: `ReactNode`
+
+Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:22](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/UserPortal/UserPortalCard/interface.ts#L22)
+
+Main content area (required)
+
+***
+
+### className?
+
+> `optional` **className**: `string`
+
+Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:25](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/UserPortal/UserPortalCard/interface.ts#L25)
+
+Optional additional class for the outer container
+
+***
+
+### dataTestId?
+
+> `optional` **dataTestId**: `string`
+
+Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:26](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/UserPortal/UserPortalCard/interface.ts#L26)
+
+Optional test id prefix for unit/e2e testing
+
+***
+
+### imageSlot?
+
+> `optional` **imageSlot**: `ReactNode`
+
+Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:21](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/UserPortal/UserPortalCard/interface.ts#L21)
+
+Optional left section (avatar, logo, thumbnail, icon)
+
+***
+
+### variant?
+
+> `optional` **variant**: `"compact"` \| `"standard"` \| `"expanded"`
+
+Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:24](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/UserPortal/UserPortalCard/interface.ts#L24)
+
+Visual density preset controlling padding and spacing

--- a/src/components/UserPortal/UserPortalCard/UserPortalCard.module.css
+++ b/src/components/UserPortal/UserPortalCard/UserPortalCard.module.css
@@ -1,0 +1,38 @@
+.container {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.imageSection {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+}
+
+.contentSection {
+  flex: 1 1 auto;
+  min-width: 0; /* allows text truncation */
+}
+
+.actionsSection {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Density variants */
+.variantCompact {
+  padding: 0.5rem 0.75rem;
+}
+
+.variantStandard {
+  padding: 0.75rem 1rem;
+}
+
+.variantExpanded {
+  padding: 1rem 1.25rem;
+}

--- a/src/components/UserPortal/UserPortalCard/UserPortalCard.spec.tsx
+++ b/src/components/UserPortal/UserPortalCard/UserPortalCard.spec.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import UserPortalCard from './UserPortalCard';
+
+describe('UserPortalCard', () => {
+  test('renders with imageSlot, children, and actionsSlot', () => {
+    render(
+      <UserPortalCard
+        ariaLabel="test-card"
+        imageSlot={<div>Image</div>}
+        actionsSlot={<button>Action</button>}
+      >
+        <span>Content</span>
+      </UserPortalCard>,
+    );
+
+    expect(screen.getByText('Image')).toBeInTheDocument();
+    expect(screen.getByText('Content')).toBeInTheDocument();
+    expect(screen.getByText('Action')).toBeInTheDocument();
+  });
+
+  test('renders with only children', () => {
+    render(
+      <UserPortalCard ariaLabel="only-content">
+        <span>Only Content</span>
+      </UserPortalCard>,
+    );
+
+    expect(screen.getByText('Only Content')).toBeInTheDocument();
+    expect(screen.queryByTestId('user-portal-card-image')).toBeNull();
+    expect(screen.queryByTestId('user-portal-card-actions')).toBeNull();
+  });
+
+  test('renders with only imageSlot', () => {
+    render(
+      <UserPortalCard ariaLabel="image-only" imageSlot={<div>Avatar</div>}>
+        <span>Body</span>
+      </UserPortalCard>,
+    );
+
+    expect(screen.getByText('Avatar')).toBeInTheDocument();
+  });
+
+  test('renders with only actionsSlot', () => {
+    render(
+      <UserPortalCard
+        ariaLabel="actions-only"
+        actionsSlot={<button>More</button>}
+      >
+        <span>Body</span>
+      </UserPortalCard>,
+    );
+
+    expect(screen.getByText('More')).toBeInTheDocument();
+  });
+
+  test('applies compact variant class', () => {
+    render(
+      <UserPortalCard ariaLabel="compact" variant="compact">
+        <span>Compact</span>
+      </UserPortalCard>,
+    );
+
+    const card = screen.getByTestId('user-portal-card');
+    expect(card.className).toMatch(/variantCompact/);
+  });
+
+  test('merges custom className', () => {
+    render(
+      <UserPortalCard ariaLabel="custom" className="custom-class">
+        <span>Test</span>
+      </UserPortalCard>,
+    );
+
+    const card = screen.getByTestId('user-portal-card');
+    expect(card.className).toContain('custom-class');
+  });
+
+  test('uses custom dataTestId', () => {
+    render(
+      <UserPortalCard ariaLabel="custom-id" dataTestId="custom-card">
+        <span>Test</span>
+      </UserPortalCard>,
+    );
+
+    expect(screen.getByTestId('custom-card')).toBeInTheDocument();
+    expect(screen.getByTestId('custom-card-content')).toBeInTheDocument();
+  });
+
+  test('applies aria-label from props', () => {
+    render(
+      <UserPortalCard ariaLabel="accessible-card">
+        <span>A11y</span>
+      </UserPortalCard>,
+    );
+
+    const card = screen.getByRole('group');
+    expect(card).toHaveAttribute('aria-label', 'accessible-card');
+  });
+});

--- a/src/components/UserPortal/UserPortalCard/UserPortalCard.tsx
+++ b/src/components/UserPortal/UserPortalCard/UserPortalCard.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import type { InterfaceUserPortalCardProps } from 'types/UserPortal/UserPortalCard/interface';
+import styles from './UserPortalCard.module.css';
+
+/**
+ * UserPortalCard
+ *
+ * Reusable 3-section layout wrapper for User Portal cards.
+ *
+ * Structure:
+ * [ imageSlot ] [ content (children) ] [ actionsSlot ]
+ *
+ * Responsibilities:
+ * - Centralizes spacing and alignment logic
+ * - Supports density variants (compact / standard / expanded)
+ * - Remains content-agnostic and styling-agnostic
+ *
+ * Accessibility:
+ * - role="group"
+ * - aria-label provided by consumer (i18n required)
+ *
+ * @example
+ * <UserPortalCard
+ *   variant="compact"
+ *   ariaLabel={t('donation.card')}
+ *   imageSlot={<Avatar />}
+ *   actionsSlot={<Button />}
+ * >
+ *   <CardContent />
+ * </UserPortalCard>
+ */
+const UserPortalCard: React.FC<InterfaceUserPortalCardProps> = ({
+  imageSlot,
+  children,
+  actionsSlot,
+  variant = 'standard',
+  className,
+  dataTestId = 'user-portal-card',
+  ariaLabel,
+}) => {
+  /**
+   * Maps variant prop to CSS module class.
+   * Variants control density only (padding/spacing).
+   */
+  const variantClass =
+    variant === 'compact'
+      ? styles.variantCompact
+      : variant === 'expanded'
+        ? styles.variantExpanded
+        : styles.variantStandard;
+
+  const containerClassName = [styles.container, variantClass, className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      className={containerClassName}
+      data-testid={dataTestId}
+      role="group"
+      aria-label={ariaLabel}
+    >
+      {imageSlot && (
+        <div
+          className={styles.imageSection}
+          data-testid={`${dataTestId}-image`}
+        >
+          {imageSlot}
+        </div>
+      )}
+
+      <div
+        className={styles.contentSection}
+        data-testid={`${dataTestId}-content`}
+      >
+        {children}
+      </div>
+
+      {actionsSlot && (
+        <div
+          className={styles.actionsSection}
+          data-testid={`${dataTestId}-actions`}
+        >
+          {actionsSlot}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default UserPortalCard;

--- a/src/types/UserPortal/UserPortalCard/interface.ts
+++ b/src/types/UserPortal/UserPortalCard/interface.ts
@@ -1,0 +1,28 @@
+import React from 'react';
+
+/**
+ * Props for UserPortalCard — a flexible layout wrapper for User Portal cards.
+ *
+ * Layout:
+ * [ imageSlot ] [ children / content ] [ actionsSlot ]
+ *
+ * This component centralizes layout, spacing, and density while keeping
+ * all content and text controlled by consuming components.
+ *
+ * @property imageSlot Optional left section (avatar, logo, thumbnail, icon)
+ * @property children Main content area (required)
+ * @property actionsSlot Optional right section (buttons, badges, counters)
+ * @property variant Visual density preset controlling padding and spacing
+ * @property className Optional additional class for the outer container
+ * @property dataTestId Optional test id prefix for unit/e2e testing
+ * @property ariaLabel Accessible label for the card container (i18n required)
+ */
+export interface InterfaceUserPortalCardProps {
+  imageSlot?: React.ReactNode;
+  children: React.ReactNode;
+  actionsSlot?: React.ReactNode;
+  variant?: 'compact' | 'standard' | 'expanded';
+  className?: string;
+  dataTestId?: string;
+  ariaLabel?: string;
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [x] New Feature (Reusable Foundation Component)

---

## Issue Number

- [x] Fixes #5127

---

## Snapshots / Videos

- [x] Not applicable (foundation-level component, no direct UI integration)

---

## If relevant, did you update the documentation?

- [x] Yes
- [x] Auto-generated documentation files were created by existing tooling

---

## Summary

This PR introduces the **UserPortalCard foundation component**, a reusable layout wrapper that standardizes the common three-section card structure used across the User Portal.

The component provides:
- Optional left section (`imageSlot`)
- Main content area (`children`)
- Optional right section (`actionsSlot`)

This is a **PR-1 (foundation-only)** change and does not refactor or modify any existing screens or cards.

---

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

---

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that the new component is covered by unit tests
- [x] I have run the relevant tests locally and all tests pass

### Contribution Guidelines
- [x] I have read the contributing guide
- [x] I created a feature branch from `develop`
- [x] No commits were made directly to `develop`
- [x] PR scope is limited strictly to PR-1 requirements

---

## Other Information

- [x] Accessibility handled via props (`ariaLabel`) to remain i18n-compliant
- [x] No hard-coded user-visible strings are included
- [x] This PR unblocks PR-2 and PR-3 refactor work

---