### PR TITLE
test: add more tests to achieve 100% coverage

### DIFF
--- a/src/screens/UserPortal/Chat/Chat.spec.tsx
+++ b/src/screens/UserPortal/Chat/Chat.spec.tsx
@@ -19,6 +19,15 @@ import '@testing-library/jest-dom';
 import Chat from './Chat';
 import { CHATS_LIST, UNREAD_CHATS } from 'GraphQl/Queries/PlugInQueries';
 
+type MockType = {
+  request: {
+    query: typeof CHATS_LIST | typeof UNREAD_CHATS;
+    variables?: Record<string, unknown>;
+  };
+  result: { data: Record<string, unknown> };
+  error?: Error;
+};
+
 const { mockUseParams } = vi.hoisted(() => ({
   mockUseParams: vi.fn(),
 }));
@@ -35,6 +44,9 @@ vi.mock('components/UserPortal/ContactCard/ContactCard', () => ({
     <div
       data-testid={`contact-card-${props.id}`}
       onClick={() => props.setSelectedContact(props.id)}
+      onKeyDown={(e) => e.key === 'Enter' && props.setSelectedContact(props.id)}
+      role="button"
+      tabIndex={0}
       data-last-message={props.lastMessage}
       data-title={props.title}
       data-unseen={props.unseenMessages}
@@ -54,6 +66,9 @@ vi.mock('components/UserPortal/ChatRoom/ChatRoom', () => ({
       data-testid="chat-room"
       data-selected-contact={selectedContact}
       onClick={() => chatListRefetch()}
+      onKeyDown={(e) => e.key === 'Enter' && chatListRefetch()}
+      role="button"
+      tabIndex={0}
     ></div>
   ),
 }));
@@ -74,6 +89,14 @@ vi.mock(
           toggleCreateGroupChatModal();
           chatsListRefetch();
         }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            toggleCreateGroupChatModal();
+            chatsListRefetch();
+          }
+        }}
+        role="button"
+        tabIndex={0}
       ></div>
     ),
   }),
@@ -96,6 +119,14 @@ vi.mock('components/UserPortal/CreateDirectChat/CreateDirectChat', () => ({
         toggleCreateDirectChatModal();
         chatsListRefetch();
       }}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter') {
+          toggleCreateDirectChatModal();
+          chatsListRefetch();
+        }
+      }}
+      role="button"
+      tabIndex={0}
     ></div>
   ),
 }));
@@ -294,23 +325,13 @@ describe('Chat Component - Comprehensive Coverage', () => {
   });
 
   afterEach(() => {
+    vi.clearAllMocks();
     vi.restoreAllMocks();
   });
 
-  const renderComponent = (customMocks: unknown[] = mocks) =>
+  const renderComponent = (customMocks: MockType[] = mocks as MockType[]) =>
     render(
-      <MockedProvider
-        mocks={
-          customMocks as readonly {
-            request: {
-              query: typeof CHATS_LIST | typeof UNREAD_CHATS;
-              variables?: Record<string, unknown>;
-            };
-            result: { data: Record<string, unknown> };
-          }[]
-        }
-        addTypename={false}
-      >
+      <MockedProvider mocks={customMocks} addTypename={false}>
         <I18nextProvider i18n={i18nForTest}>
           <Provider store={store}>
             <Chat />


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Test improvement (coverage)

**Issue Number:**
Fixes #4848

**Snapshots/Videos:**
<img width="415" height="148" alt="image" src="https://github.com/user-attachments/assets/4415d2b5-a5e2-4974-89cb-ae6556670855" />

**If relevant, did you update the documentation?**
No

**Summary**
This PR improves test coverage for the Chat screen by exhaustively covering all runtime branches in
`src/screens/UserPortal/Chat/Chat.tsx`.

The work focuses purely on tests and does not modify production code.

**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**
- **Only file modified:** `src/screens/UserPortal/Chat/Chat.spec.tsx`
- **Total tests added:** 61
- Covered all branches including:
  - All / Unread / Group filters
  - NewChatType vs legacy GroupChat paths
  - orgId-based filtering
  - LocalStorage selection and fallback logic
  - Modal open flows

**Have you read the contributing guide?**
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded and reorganized Chat component tests for broader coverage, richer mock data, added accessibility and keyboard interaction checks, updated test attributes and IDs, introduced a test SVG asset, and improved helper signatures to support more comprehensive scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->