### PR TITLE
fix: add semantic variant i18n keys for StatusBadge

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2107,7 +2107,12 @@
     "disabled": "Disabled",
     "accepted": "Accepted",
     "declined": "Declined",
-    "no_response": "No Response"
+    "no_response": "No Response",
+    "success": "Success",
+    "warning": "Warning",
+    "error": "Error",
+    "info": "Info",
+    "neutral": "Neutral"
   },
   "commentCard": {
     "commentDeletedSuccessfully": "Comment deleted successfully",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -2107,7 +2107,12 @@
     "disabled": "Deshabilitado",
     "accepted": "Aceptado",
     "declined": "Declinado",
-    "no_response": "Sin respuesta"
+    "no_response": "Sin respuesta",
+    "success": "Éxito",
+    "warning": "Advertencia",
+    "error": "Error",
+    "info": "Información",
+    "neutral": "Neutral"
   },
   "commentCard": {
     "commentDeletedSuccessfully": "Comentario eliminado exitosamente",

--- a/public/locales/fr/translation.json
+++ b/public/locales/fr/translation.json
@@ -1032,7 +1032,12 @@
     "disabled": "Désactivé",
     "accepted": "Accepté",
     "declined": "Refusé",
-    "no_response": "Aucune réponse"
+    "no_response": "Aucune réponse",
+    "success": "Succès",
+    "warning": "Avertissement",
+    "error": "Erreur",
+    "info": "Info",
+    "neutral": "Neutre"
   },
   "orgContribution": {
     "title": "Contributions de Talawa",
@@ -1585,7 +1590,6 @@
     "enterName": "Entrez le nom",
     "enterDescription": "Entrez la description",
     "enterLocation": "Entrez l'emplacement",
-
     "registerable": "Est enregistrable",
     "monthlyCalendarView": "Calendrier mensuel",
     "yearlyCalendarView": "Calendrier annuel",

--- a/public/locales/hi/translation.json
+++ b/public/locales/hi/translation.json
@@ -454,7 +454,12 @@
     "disabled": "अक्षम",
     "accepted": "स्वीकृत",
     "declined": "अस्वीकार किया गया",
-    "no_response": "कोई प्रतिक्रिया नहीं"
+    "no_response": "कोई प्रतिक्रिया नहीं",
+    "success": "सफलता",
+    "warning": "चेतावनी",
+    "error": "त्रुटि",
+    "info": "जानकारी",
+    "neutral": "तटस्थ"
   },
   "manageTag": {
     "title": "टैग विवरण",
@@ -1585,7 +1590,6 @@
     "enterName": "नाम दर्ज करें",
     "enterDescription": "विवरण दर्ज करें",
     "enterLocation": "स्थान दर्ज करें",
-
     "registerable": "पंजीकरण योग्य है",
     "monthlyCalendarView": "मासिक कैलेंडर",
     "yearlyCalendarView": "वार्षिक कैलेंडर",

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -968,7 +968,12 @@
     "disabled": "已禁用",
     "accepted": "已接受",
     "declined": "已谢绝",
-    "no_response": "无响应"
+    "no_response": "无响应",
+    "success": "成功",
+    "warning": "警告",
+    "error": "错误",
+    "info": "信息",
+    "neutral": "中性"
   },
   "blockUnblockUser": {
     "title": "阻止/取消阻止用户",
@@ -1585,7 +1590,6 @@
     "enterName": "输入名称",
     "enterDescription": "输入描述",
     "enterLocation": "输入位置",
-
     "registerable": "可注册",
     "monthlyCalendarView": "月历",
     "yearlyCalendarView": "年历",


### PR DESCRIPTION
## Fixes #5250 

## Description

This PR adds 5 missing semantic variant translation keys to the `statusBadge` namespace across all 5 supported locales. PR #5960 added the 10 domain-specific variants (completed, pending, active, etc.), and this PR completes the implementation by adding the 5 semantic variants.

### Changes Made

Added translations for the following semantic variants to all locales:
- `success`
- `warning`
- `error`
- `info`
- `neutral`

### Locales Updated

✅ **English (en)** - Success, Warning, Error, Info, Neutral  
✅ **Spanish (es)** - Éxito, Advertencia, Error, Información, Neutral  
✅ **French (fr)** - Succès, Avertissement, Erreur, Info, Neutre  
✅ **Hindi (hi)** - सफलता, चेतावनी, त्रुटि, जानकारी, तटस्थ  
✅ **Chinese (zh)** - 成功, 警告, 错误, 信息, 中性  

### Completion Status

With this PR, the StatusBadge component now has complete i18n support for all 15 variants:
- ✅ 10 domain-specific variants (from PR #5960)
- ✅ 5 semantic variants (this PR)
- ✅ All 5 supported locales

### Testing

- [x] All 5 locale files properly formatted
- [x] JSON syntax validated
- [x] Consistent key structure across all locales
- [x] No linting or formatting errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancement**
  * Expanded status badge types with new options including Success, Warning, Error, Info, and Neutral. These additional status indicators are now available across all supported languages (English, Spanish, French, Hindi, and Chinese) for improved UI status communication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->