### PR TITLE
test(Groups): achieve 100% coverage for Groups.tsx by fixing leader search test

### DIFF
--- a/src/screens/UserPortal/Volunteer/Groups/Groups.spec.tsx
+++ b/src/screens/UserPortal/Volunteer/Groups/Groups.spec.tsx
@@ -414,22 +414,22 @@ describe('Groups Screen [User Portal]', () => {
     const leaderOption = await screen.findByTestId('leader');
     await userEvent.click(leaderOption);
 
-    // Type in search to trigger the leaderName variable assignment
+    // Type in search to trigger the leaderName variable assignment (line 96)
     const searchInput = screen.getByTestId('searchByInput');
     await userEvent.clear(searchInput);
     await userEvent.type(searchInput, 'Teresa');
 
     // Wait for debounce (300ms) and query with leaderName variable to execute
+    // This ensures line 96 (vars.leaderName = searchTerm.trim()) is covered
     await waitFor(
       () => {
-        // This ensures the query with leaderName has completed
-        const groupNames = screen.getAllByTestId('groupName');
-        expect(groupNames.length).toBeGreaterThanOrEqual(1);
+        // Verify that Group 2 is filtered out (only Teresa's group should show)
+        expect(screen.queryByText('Group 2')).not.toBeInTheDocument();
       },
-      { timeout: 1500 },
+      { timeout: 2000 },
     );
 
-    // Verify the filtered result
+    // Verify the filtered result shows only Group 1 (led by Teresa)
     expect(screen.getByText('Group 1')).toBeInTheDocument();
   });
 


### PR DESCRIPTION

<!--
This section can be deleted after reading.

We employ the following branching strategy to simplify the development process and to ensure that only stable code is pushed to the `master` branch:

- `develop`: For unstable code: New features and bug fixes.
- `master`: Where the stable production ready code lies. Only security related bugs.

NOTE!!!

ONLY SUBMIT PRS AGAINST OUR `DEVELOP` BRANCH. THE DEFAULT IS `MAIN`, SO YOU WILL HAVE TO MODIFY THIS BEFORE SUBMITTING YOUR PR FOR REVIEW. PRS MADE AGAINST `MAIN` WILL BE CLOSED.

-->

<!--
Thanks for submitting a pull request! Please provide enough information so that others can review your pull request.
-->

**What kind of change does this PR introduce?**

Test coverage improvement

**Issue Number:**

Fixes #6395 

**Snapshots/Videos:**

<img width="957" height="32" alt="Screenshot From 2026-01-14 14-11-59" src="https://github.com/user-attachments/assets/30b16502-01cd-44aa-adb0-1cf810641437" />


**If relevant, did you update the documentation?**

Not applicable - no documentation changes required

**Summary**

This PR improves the test coverage for src/screens/UserPortal/Volunteer/Groups/Groups.tsx from
98.14% to 100%.

Problem: Line 96 (vars.leaderName = searchTerm.trim();) was not being covered by existing tests.
This line executes when searching volunteer groups by leader name with a non-empty search term.

Solution:
   - Fixed the 'search filters groups by leader name' test to properly trigger the GraphQL query with
     leaderName variable
   - Updated assertion to verify that Group 2 is filtered out when searching by leader name, ensuring
     the query actually executes
   - Increased timeout to 2000ms to allow debounce to complete and GraphQL query to execute

Mock Isolation: The test file already follows the mock isolation guidelines with vi.clearAllMocks()
in the afterEach hook.

**Does this PR introduce a breaking change?**

No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Other information**

Coverage before: 98.14% (line 96 uncovered)
Coverage after: 100%

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertions and timing for group filtering validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->