### PR TITLE
chore(eslint): Restrict direct @dicebear/core imports to Avatar wrappers

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -70,7 +70,7 @@ const restrictedImports = [
     id: 'dicebear-core',
     name: '@dicebear/core',
     message:
-      'Direct imports from @dicebear/core are forbidden. Use the shared Avatar component instead.',
+      'Direct imports from @dicebear/core are not allowed. Use the shared createAvatar wrapper instead.',
   },
 ];
 
@@ -376,10 +376,19 @@ export default [
       'prettier/prettier': ['error', { endOfLine: 'auto' }],
     },
   },
+  /**
+   * Exemption: Avatar and createAvatar component files
+   *
+   * Avatar and createAvatar files need direct `@dicebear/core` access for wrapper implementation.
+   * These files are the only ones allowed to import from `@dicebear/core`.
+   * Allowed ID: dicebear-core.
+   */
   {
     files: [
       'src/shared-components/Avatar/**/*.{ts,tsx,d.ts}',
-      'src/shared-components/createAvatar/**/*.{ts,tsx}', 
+      'src/shared-components/createAvatar/**/*.{ts,tsx}',
+      'src/types/shared-components/Avatar/**/*.{ts,tsx,d.ts}',
+      'src/types/shared-components/createAvatar/**/*.{ts,tsx}',
     ],
     rules: restrictImportsExcept(['dicebear-core']),
   },


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Disallows importing createAvatar directly from @dicebear/core across the codebase.

Allows direct usage only within avatar-related wrapper and type files:

src/shared-components/Avatar/**

src/shared-components/createAvatar/**

src/types/shared-components/Avatar/**

src/types/shared-components/createAvatar/**


**Why this is needed**
As part of the Avatar shared component refactor, avatar generation should go through a single, standardized wrapper.
This rule prevents new direct usages of @dicebear/core, keeping avatar behavior consistent and easier to maintain.

**Scope of the change**
ESLint configuration only.
No runtime or functional changes.
No refactoring of existing code.
Prevents future violations without affecting current usage.

**Related issues**

Closes #6379

Related to #6169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Strengthened ESLint to block direct imports from @dicebear/core and require the shared createAvatar wrapper instead.
  * Applied stricter import restrictions across Avatar-related code to enforce that policy (duplicate override entry present).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->