### PR TITLE
feat: add ESLint rule to restrict Chip imports

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -72,6 +72,13 @@ const restrictedImports = [
     message:
       'Direct imports from @dicebear/core are not allowed. Use the shared createAvatar wrapper instead.',
   },
+  {
+    id: 'mui-chip',
+    name: '@mui/material',
+    importNames: ['Chip'],
+    message:
+      'Do not import Chip from @mui/material. Use the shared StatusBadge component from src/shared-components/StatusBadge/ instead.',
+  },
 ];
 
 const stripId = (entry) => {
@@ -391,6 +398,20 @@ export default [
       'src/types/shared-components/createAvatar/**/*.{ts,tsx}',
     ],
     rules: restrictImportsExcept(['dicebear-core']),
+  },
+  /**
+   * Exemption: StatusBadge component files
+   *
+   * StatusBadge files need direct Chip access from @mui/material for wrapper implementation.
+   * These files are the only ones allowed to import Chip directly from @mui/material.
+   * Allowed ID: mui-chip.
+   */
+  {
+    files: [
+      'src/shared-components/StatusBadge/**/*.{ts,tsx}',
+      'src/types/shared-components/StatusBadge/**/*.{ts,tsx}',
+    ],
+    rules: restrictImportsExcept(['mui-chip']),
   },
   // Cypress-specific configuration
   {


### PR DESCRIPTION
### Fixes #6396

---

Adds an ESLint rule to enforce usage of the standardized `StatusBadge` component instead of direct `Chip` imports from `@mui/material`.

## Changes Made

### Added Restriction Rule
- Added `mui-chip` restriction to the `restrictedImports` array
- Blocks `import { Chip } from '@mui/material'` across the codebase
- Provides clear error message directing developers to use `StatusBadge` component


## Files Modified

- **eslint.config.js**
  - Added `mui-chip` entry to `restrictedImports` array
  - Added exemption block for StatusBadge component files

## Testing

- ✅ ESLint configuration syntax is valid
- ✅ Rule will be enforced by CI on all new PRs
- ✅ StatusBadge component files are exempt from the rule
- ✅ All other files must use StatusBadge instead of Chip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code standards to enforce consistent usage of a shared component wrapper, improving code consistency and maintainability for the development team.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->