### PR TITLE
Linting for '@mui/material' 'TextField' and 'FormControl' 1768577792

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -80,11 +80,22 @@ const restrictedImports = [
       'Direct imports from @dicebear/core are not allowed. Use the shared createAvatar wrapper instead.',
   },
   {
-    id: 'mui-chip',
     name: '@mui/material',
     importNames: ['Chip'],
     message:
       'Do not import Chip from @mui/material. Use the shared StatusBadge component from src/shared-components/StatusBadge/ instead.',
+  },
+  {
+    name: '@mui/material',
+    importNames: ['TextField'],
+    message:
+      'Do not import TextField from @mui/material. Use the shared FormFieldGroup component from src/shared-components/FormFieldGroup/ instead.',
+  },
+  {
+    name: '@mui/material',
+    importNames: ['FormControl'],
+    message:
+      'Do not import FormControl from @mui/material. Use the shared FormFieldGroup component from src/shared-components/FormFieldGroup/ instead.',
   },
 ];
 
@@ -420,20 +431,6 @@ export default [
       'src/types/shared-components/createAvatar/**/*.{ts,tsx}',
     ],
     rules: restrictImportsExcept(['dicebear-core']),
-  },
-  /**
-   * Exemption: StatusBadge component files
-   *
-   * StatusBadge files need direct Chip access from @mui/material for wrapper implementation.
-   * These files are the only ones allowed to import Chip directly from @mui/material.
-   * Allowed ID: mui-chip.
-   */
-  {
-    files: [
-      'src/shared-components/StatusBadge/**/*.{ts,tsx}',
-      'src/types/shared-components/StatusBadge/**/*.{ts,tsx}',
-    ],
-    rules: restrictImportsExcept(['mui-chip']),
   },
   // Cypress-specific configuration
   {


### PR DESCRIPTION
Linting for '@mui/material' 'TextField' and 'FormControl' 1768577792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ESLint configuration to improve code consistency and reusability patterns by enforcing the use of shared form components (FormFieldGroup) across the codebase instead of direct Material-UI imports.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->