### PR TITLE
Fix organization screen right margin spacing

### DIFF
--- a/src/style/app-fixed.module.css
+++ b/src/style/app-fixed.module.css
@@ -4640,11 +4640,13 @@ form label,
 .expand {
   margin-left: 100px;
   padding-left: 4rem;
+  padding-right: 4rem; 
   animation: moveLeft 0.9s ease-in-out;
 }
 
 .contract {
   padding-left: calc(300px + 2rem + 1.5rem);
+  padding-right: 4rem; 
   animation: moveRight 0.5s ease-in-out;
 }
 


### PR DESCRIPTION
### What was fixed
- Added right-side padding to organization screen content
- Balanced left and right spacing when sidebar is expanded or contracted

### Issue
Fixes #6534


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted right-side spacing for expanded and contracted interface states to improve visual layout and consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->