### PR TITLE
fix: used shared button component

### DIFF
--- a/docs/docs/auto-docs/screens/AdminPortal/OrganizationDashboard/OrganizationDashboard/functions/default.md
+++ b/docs/docs/auto-docs/screens/AdminPortal/OrganizationDashboard/OrganizationDashboard/functions/default.md
@@ -6,7 +6,7 @@
 
 > **default**(): `Element`
 
-Defined in: [src/screens/AdminPortal/OrganizationDashboard/OrganizationDashboard.tsx:59](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/screens/AdminPortal/OrganizationDashboard/OrganizationDashboard.tsx#L59)
+Defined in: [src/screens/AdminPortal/OrganizationDashboard/OrganizationDashboard.tsx:60](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/screens/AdminPortal/OrganizationDashboard/OrganizationDashboard.tsx#L60)
 
 ## Returns
 

--- a/src/screens/AdminPortal/OrgList/OrgList.tsx
+++ b/src/screens/AdminPortal/OrgList/OrgList.tsx
@@ -41,7 +41,6 @@
 import React, { type ChangeEvent, useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery } from '@apollo/client';
 import { Group, Search } from '@mui/icons-material';
-import { Button } from '@mui/material';
 import { Link } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import {
@@ -56,6 +55,7 @@ import PaginationList from 'components/Pagination/PaginationList/PaginationList'
 import { NotificationToast } from 'components/NotificationToast/NotificationToast';
 import NotificationIcon from 'components/NotificationIcon/NotificationIcon';
 import BaseModal from 'shared-components/BaseModal/BaseModal';
+import Button from 'shared-components/Button';
 import EmptyState from 'shared-components/EmptyState/EmptyState';
 import OrganizationCard from 'shared-components/OrganizationCard/OrganizationCard';
 import SearchFilterBar from 'shared-components/SearchFilterBar/SearchFilterBar';

--- a/src/screens/AdminPortal/OrganizationDashboard/OrganizationDashboard.tsx
+++ b/src/screens/AdminPortal/OrganizationDashboard/OrganizationDashboard.tsx
@@ -26,9 +26,10 @@
  */
 import { useQuery } from '@apollo/client';
 import React, { useEffect, useState, JSX } from 'react';
-import { Button, Card } from 'react-bootstrap';
+import Card from 'react-bootstrap/Card';
 import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
+import Button from 'shared-components/Button';
 import { useTranslation } from 'react-i18next';
 import {
   GET_ORGANIZATION_POSTS_COUNT_PG,

--- a/src/shared-components/posts/posts.tsx
+++ b/src/shared-components/posts/posts.tsx
@@ -55,9 +55,9 @@ import {
 } from 'types/Post/interface';
 import useLocalStorage from 'utils/useLocalstorage';
 import { useTranslation } from 'react-i18next';
-import Button from 'react-bootstrap/Button';
 import Row from 'react-bootstrap/Row';
 import { Add } from '@mui/icons-material';
+import Button from 'shared-components/Button';
 import LoadingState from 'shared-components/LoadingState/LoadingState';
 import PageHeader from 'shared-components/Navbar/Navbar';
 import PinnedPostsLayout from 'shared-components/pinnedPosts/pinnedPostsLayout';


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR migrated the use of button from react bootstrap to shared-component button.

**Issue Number: #6452 **

<!--Add related issue number here.-->
Fixes #6452 

**Summary**

The shared button is used to improve the consistency.
Files which are migrated are as follows :- 
1. `OrganizationDashboard.tsx`
2. `OrgList.tsx`
3.  `posts.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated button component imports across admin portal screens to use a shared component implementation for improved UI consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->