### PR TITLE
test(group-modal): properly trigger NaN branch using '-' input

### DIFF
--- a/src/screens/UserPortal/Volunteer/Groups/GroupModal.spec.tsx
+++ b/src/screens/UserPortal/Volunteer/Groups/GroupModal.spec.tsx
@@ -959,10 +959,9 @@ describe('Testing GroupModal', () => {
         name: /volunteers required/i,
       });
 
-      // Type non-numeric input - browser will prevent 'abc' from being entered in number input
-      // So we need to use fireEvent.change to simulate this edge case
       await user.clear(vrInput);
-      await user.type(vrInput, '{a}');
+      // Lone '-' triggers parseInt NaN for number input
+      await user.type(vrInput, '-');
       await waitFor(() => {
         expect(vrInput).toHaveValue(null);
       });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bug fix (test correctness / edge-case coverage)

**Issue Number:**

Fixes #6647

**Snapshots/Videos:**

N/A (test-only change, no UI impact)

**If relevant, did you update the documentation?**

N/A

**Summary**

This PR applies a follow-up fix suggested by CodeRabbit to correctly exercise the `NaN` validation branch in the `volunteersRequired` test inside `GroupModal.spec.tsx`.

Previously, the test attempted to type `{a}` into an HTML number input, but browsers reject alphabetic characters at the input level, so the validation handler never received a value and the `NaN` path was not covered.

This change replaces the input with `'-'`, which is accepted by number inputs and results in `parseInt('-', 10)` returning `NaN`, properly exercising the intended validation logic.

This is a test-only fix and does not modify any production code or user-facing behavior.

**Does this PR introduce a breaking change?**

No — this PR only updates a test case and does not affect runtime behavior.

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented the suggested fix from CodeRabbit AI
- [x] I have documented the reasoning in the PR description

### Test Coverage
- [x] I have written/updated tests for the change
- [x] I have verified that test coverage remains ≥ 95%
- [x] I have run the test suite locally and all tests pass

**Other information**

This PR is a small follow-up to a CodeRabbit suggestion posted after the previous PR was merged.  
Scope is intentionally limited to the single affected test case.

**Have you read the contributing guide?**

Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated tests to cover an edge case where entering a lone minus sign into the volunteer-required field is treated as invalid and cleared on blur, ensuring the field becomes empty/null. Test comments and expectations were adjusted to reflect this parsing behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->