### PR TITLE
refactor: migrate fireEvent to userEvent in test files

### DIFF
--- a/src/screens/AdminPortal/OrganizationDashboard/OrganizationDashboard.spec.tsx
+++ b/src/screens/AdminPortal/OrganizationDashboard/OrganizationDashboard.spec.tsx
@@ -10,7 +10,7 @@ import {
   screen,
   waitFor,
 } from '@testing-library/react';
-import { fireEvent } from '@testing-library/dom';
+import userEvent from '@testing-library/user-event';
 
 import type { MockedResponse } from '@apollo/client/testing';
 import { MockedProvider } from '@apollo/client/testing';
@@ -103,6 +103,7 @@ describe('OrganizationDashboard', () => {
   // ... existing tests ...
 
   it('navigates to requests page when clicking on membership requests card', async () => {
+    const user = userEvent.setup();
     renderWithProviders({ mocks: MOCKS });
 
     await waitFor(() => {
@@ -119,7 +120,7 @@ describe('OrganizationDashboard', () => {
     expect(requestsCardButton).not.toBeNull();
 
     if (requestsCardButton) {
-      fireEvent.click(requestsCardButton);
+      await user.click(requestsCardButton);
     } else {
       throw new Error('Membership requests card button not found');
     }
@@ -179,6 +180,7 @@ describe('OrganizationDashboard', () => {
   });
 
   it('shows success toast when clicking on membership requests view button', async () => {
+    const user = userEvent.setup();
     renderWithProviders({ mocks: MOCKS });
 
     await waitFor(() => {
@@ -188,19 +190,19 @@ describe('OrganizationDashboard', () => {
     });
 
     const viewRequestsBtn = screen.getByTestId('viewAllMembershipRequests');
-    fireEvent.click(viewRequestsBtn);
+    await user.click(viewRequestsBtn);
     expect(routerMocks.navigate).toHaveBeenCalledWith('/admin/requests/orgId');
 
     const viewLeaderBtn = screen.getByTestId('viewAllLeadeboard');
-    fireEvent.click(viewLeaderBtn);
+    await user.click(viewLeaderBtn);
     expect(toastMocks.success).toHaveBeenCalledWith('comingSoon');
 
     const viewEventsBtn = screen.getByTestId('viewAllEvents');
-    fireEvent.click(viewEventsBtn);
+    await user.click(viewEventsBtn);
     expect(routerMocks.navigate).toHaveBeenCalledWith('/admin/orgevents/orgId');
 
     const viewPostBtn = screen.getByTestId('viewAllPosts');
-    fireEvent.click(viewPostBtn);
+    await user.click(viewPostBtn);
     expect(routerMocks.navigate).toHaveBeenCalledWith('/admin/orgpost/orgId');
   });
 
@@ -256,40 +258,46 @@ describe('OrganizationDashboard', () => {
   });
 
   it('handles navigation to posts page', async () => {
+    const user = userEvent.setup();
     renderWithProviders({ mocks: MOCKS });
 
     await waitFor(() => {
-      const postsCountElement = screen.getByTestId('postsCount');
-      fireEvent.click(postsCountElement);
-
-      expect(routerMocks.navigate).toHaveBeenCalledWith('/admin/orgpost/orgId');
+      expect(screen.queryAllByTestId('fallback-ui').length).toBe(0);
     });
+
+    const postsCountElement = await screen.findByTestId('postsCount');
+    await user.click(postsCountElement);
+
+    expect(routerMocks.navigate).toHaveBeenCalledWith('/admin/orgpost/orgId');
   });
 
   it('handles navigation to events page', async () => {
+    const user = userEvent.setup();
     renderWithProviders({ mocks: MOCKS });
 
     await waitFor(() => {
-      const eventsCountElement = screen.getByTestId('eventsCount');
-      fireEvent.click(eventsCountElement);
-
-      expect(routerMocks.navigate).toHaveBeenCalledWith(
-        '/admin/orgevents/orgId',
-      );
+      expect(screen.queryAllByTestId('fallback-ui').length).toBe(0);
     });
+
+    const eventsCountElement = await screen.findByTestId('eventsCount');
+    await user.click(eventsCountElement);
+
+    expect(routerMocks.navigate).toHaveBeenCalledWith('/admin/orgevents/orgId');
   });
 
   it('handles navigation to blocked users page', async () => {
+    const user = userEvent.setup();
     renderWithProviders({ mocks: MOCKS });
 
     await waitFor(() => {
-      const blockedUsersCountElement = screen.getByTestId('blockedUsersCount');
-      fireEvent.click(blockedUsersCountElement);
-
-      expect(routerMocks.navigate).toHaveBeenCalledWith(
-        '/admin/blockuser/orgId',
-      );
+      expect(screen.queryAllByTestId('fallback-ui').length).toBe(0);
     });
+
+    const blockedUsersCountElement =
+      await screen.findByTestId('blockedUsersCount');
+    await user.click(blockedUsersCountElement);
+
+    expect(routerMocks.navigate).toHaveBeenCalledWith('/admin/blockuser/orgId');
   });
 
   it('renders loading state for dashboard cards', async () => {
@@ -570,6 +578,7 @@ describe('OrganizationDashboard', () => {
     });
 
     it('navigates to venues page when clicking on venues card', async () => {
+      const user = userEvent.setup();
       renderWithProviders({ mocks: MOCKS });
 
       await waitFor(() => {
@@ -581,7 +590,7 @@ describe('OrganizationDashboard', () => {
       });
 
       const venuesCard = screen.getByTestId('venuesCount');
-      fireEvent.click(venuesCard);
+      await user.click(venuesCard);
 
       await waitFor(() => {
         expect(routerMocks.navigate).toHaveBeenCalledWith(
@@ -657,6 +666,7 @@ describe('OrganizationDashboard', () => {
 
   describe('Async navigation handlers', () => {
     it('handles async navigation for view all events button', async () => {
+      const user = userEvent.setup();
       renderWithProviders({ mocks: MOCKS });
 
       await waitFor(() => {
@@ -665,9 +675,8 @@ describe('OrganizationDashboard', () => {
 
       const viewAllEventsButton = screen.getByTestId('viewAllEvents');
 
-      await waitFor(async () => {
-        fireEvent.click(viewAllEventsButton);
-        await new Promise((resolve) => setTimeout(resolve, 0));
+      await user.click(viewAllEventsButton);
+      await waitFor(() => {
         expect(routerMocks.navigate).toHaveBeenCalledWith(
           '/admin/orgevents/orgId',
         );
@@ -675,6 +684,7 @@ describe('OrganizationDashboard', () => {
     });
 
     it('handles async navigation for view all posts button', async () => {
+      const user = userEvent.setup();
       renderWithProviders({ mocks: MOCKS });
 
       await waitFor(() => {
@@ -683,9 +693,8 @@ describe('OrganizationDashboard', () => {
 
       const viewAllPostsButton = screen.getByTestId('viewAllPosts');
 
-      await waitFor(async () => {
-        fireEvent.click(viewAllPostsButton);
-        await new Promise((resolve) => setTimeout(resolve, 0));
+      await user.click(viewAllPostsButton);
+      await waitFor(() => {
         expect(routerMocks.navigate).toHaveBeenCalledWith(
           '/admin/orgpost/orgId',
         );
@@ -693,6 +702,7 @@ describe('OrganizationDashboard', () => {
     });
 
     it('handles async navigation for view all membership requests button', async () => {
+      const user = userEvent.setup();
       renderWithProviders({ mocks: MOCKS });
 
       await waitFor(() => {
@@ -703,9 +713,8 @@ describe('OrganizationDashboard', () => {
         'viewAllMembershipRequests',
       );
 
-      await waitFor(async () => {
-        fireEvent.click(viewAllRequestsButton);
-        await new Promise((resolve) => setTimeout(resolve, 0));
+      await user.click(viewAllRequestsButton);
+      await waitFor(() => {
         expect(routerMocks.navigate).toHaveBeenCalledWith(
           '/admin/requests/orgId',
         );

--- a/src/screens/AdminPortal/OrganizationFundCampaign/OrganizationFundCampaign.spec.tsx
+++ b/src/screens/AdminPortal/OrganizationFundCampaign/OrganizationFundCampaign.spec.tsx
@@ -6,7 +6,6 @@ import {
 } from 'shared-components/DateRangePicker';
 import type { RenderResult } from '@testing-library/react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { fireEvent } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
@@ -215,14 +214,14 @@ describe('FundCampaigns Screen', () => {
   });
 
   it('Search the Campaigns list by Name', async () => {
+    const user = userEvent.setup();
     mockRouteParams();
     renderFundCampaign(link1);
     const searchField = await screen.findByTestId('searchFullName');
 
     // SearchBar now uses onChange instead of searchBtn
-    fireEvent.change(searchField, {
-      target: { value: '2' },
-    });
+    await user.clear(searchField);
+    await user.type(searchField, '2');
 
     await waitFor(() => {
       expect(screen.getByText('Campaign 2')).toBeInTheDocument();
@@ -308,12 +307,13 @@ describe('FundCampaigns Screen', () => {
   });
 
   it('Click on Campaign Name', async () => {
+    const user = userEvent.setup();
     mockRouteParams();
     renderFundCampaign(link1);
 
     const campaignName = await screen.findAllByTestId('campaignName');
     expect(campaignName[0]).toBeInTheDocument();
-    fireEvent.click(campaignName[0]);
+    await user.click(campaignName[0]);
 
     await waitFor(() => {
       expect(screen.getByTestId('pledgeScreen')).toBeInTheDocument();
@@ -321,6 +321,7 @@ describe('FundCampaigns Screen', () => {
   });
 
   it('Click on View Pledge (via row click)', async () => {
+    const user = userEvent.setup();
     mockRouteParams();
     renderFundCampaign(link1);
 
@@ -328,7 +329,7 @@ describe('FundCampaigns Screen', () => {
     expect(campaignName[0]).toBeInTheDocument();
 
     // Row click navigates to pledge screen
-    fireEvent.click(campaignName[0]);
+    await user.click(campaignName[0]);
 
     await waitFor(() => {
       expect(screen.getByTestId('pledgeScreen')).toBeInTheDocument();
@@ -419,15 +420,15 @@ describe('FundCampaigns Screen', () => {
   });
 
   it('should display no results empty state when search yields no matches', async () => {
+    const user = userEvent.setup();
     mockRouteParams();
     renderFundCampaign(link1);
 
     const searchField = await screen.findByTestId('searchFullName');
 
     // Search for a term that doesn't match any campaign
-    fireEvent.change(searchField, {
-      target: { value: 'NonExistentCampaign' },
-    });
+    await user.clear(searchField);
+    await user.type(searchField, 'NonExistentCampaign');
 
     // Assert EmptyState is rendered
     const emptyState = await screen.findByTestId('campaigns-search-empty');
@@ -447,15 +448,15 @@ describe('FundCampaigns Screen', () => {
   });
 
   it('should clear search input when clear button is clicked', async () => {
+    const user = userEvent.setup();
     mockRouteParams();
     renderFundCampaign(link1);
 
     const searchField = await screen.findByTestId('searchFullName');
 
     // Search for a term
-    fireEvent.change(searchField, {
-      target: { value: 'Campaign' },
-    });
+    await user.clear(searchField);
+    await user.type(searchField, 'Campaign');
 
     await waitFor(() => {
       expect(searchField).toHaveValue('Campaign');
@@ -463,7 +464,7 @@ describe('FundCampaigns Screen', () => {
 
     // Click the clear button
     const clearButton = screen.getByRole('button', { name: /clear/i });
-    await userEvent.click(clearButton);
+    await user.click(clearButton);
 
     await waitFor(() => {
       expect(searchField).toHaveValue('');

--- a/src/screens/AdminPortal/Requests/Requests.spec.tsx
+++ b/src/screens/AdminPortal/Requests/Requests.spec.tsx
@@ -1039,7 +1039,6 @@ describe('Testing Requests screen', () => {
     await wait(100);
 
     await userEvent.clear(searchInput);
-    fireEvent.change(searchInput, { target: { value: '' } });
     await wait(200);
 
     expect(screen.getByRole('grid')).toBeInTheDocument();

--- a/src/screens/EventVolunteers/Requests/Requests.spec.tsx
+++ b/src/screens/EventVolunteers/Requests/Requests.spec.tsx
@@ -13,7 +13,6 @@ import {
 } from 'shared-components/DateRangePicker';
 import type { RenderResult } from '@testing-library/react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { fireEvent } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
@@ -132,6 +131,7 @@ describe('Testing Requests Screen', () => {
   });
 
   it('Check Sorting Functionality', async () => {
+    const user = userEvent.setup();
     renderRequests(link1);
 
     await waitFor(() => {
@@ -142,10 +142,10 @@ describe('Testing Requests Screen', () => {
     expect(sortBtn).toBeInTheDocument();
 
     // Sort by createdAt_DESC
-    fireEvent.click(sortBtn);
+    await user.click(sortBtn);
     const createdAtDESC = await screen.findByTestId('createdAt_DESC');
     expect(createdAtDESC).toBeInTheDocument();
-    fireEvent.click(createdAtDESC);
+    await user.click(createdAtDESC);
 
     let volunteerName = await screen.findAllByTestId('volunteerName');
     expect(volunteerName[0]).toHaveTextContent('Teresa Bradley');
@@ -153,10 +153,10 @@ describe('Testing Requests Screen', () => {
     // Sort by createdAt_ASC
     sortBtn = await screen.findByTestId('sort');
     expect(sortBtn).toBeInTheDocument();
-    fireEvent.click(sortBtn);
+    await user.click(sortBtn);
     const createdAtASC = await screen.findByTestId('createdAt_ASC');
     expect(createdAtASC).toBeInTheDocument();
-    fireEvent.click(createdAtASC);
+    await user.click(createdAtASC);
 
     volunteerName = await screen.findAllByTestId('volunteerName');
     expect(volunteerName[0]).toHaveTextContent('John Doe');
@@ -273,6 +273,7 @@ describe('Testing Requests Screen', () => {
   });
 
   it('should filter requests by individual type', async () => {
+    const user = userEvent.setup();
     renderRequests(link5);
     await waitFor(() => {
       expect(screen.getByTestId('searchBy')).toBeInTheDocument();
@@ -284,11 +285,11 @@ describe('Testing Requests Screen', () => {
 
     // Click filter button
     const filterBtn = await screen.findByTestId('filter');
-    fireEvent.click(filterBtn);
+    await user.click(filterBtn);
 
     // Select individual filter
     const individualFilter = await screen.findByTestId('individual');
-    fireEvent.click(individualFilter);
+    await user.click(individualFilter);
 
     await waitFor(() => {
       // Should only show individual requests (2 requests without group)
@@ -300,6 +301,7 @@ describe('Testing Requests Screen', () => {
   });
 
   it('should filter requests by group type', async () => {
+    const user = userEvent.setup();
     renderRequests(link5);
     await waitFor(() => {
       expect(screen.getByTestId('searchBy')).toBeInTheDocument();
@@ -311,11 +313,11 @@ describe('Testing Requests Screen', () => {
 
     // Click filter button
     const filterBtn = await screen.findByTestId('filter');
-    fireEvent.click(filterBtn);
+    await user.click(filterBtn);
 
     // Select group filter
     const groupFilter = await screen.findByTestId('group');
-    fireEvent.click(groupFilter);
+    await user.click(groupFilter);
 
     await waitFor(() => {
       // Should only show group requests (1 request with group)
@@ -326,6 +328,7 @@ describe('Testing Requests Screen', () => {
   });
 
   it('should show all requests when filter is set to all', async () => {
+    const user = userEvent.setup();
     renderRequests(link5);
     await waitFor(() => {
       expect(screen.getByTestId('searchBy')).toBeInTheDocument();
@@ -333,11 +336,11 @@ describe('Testing Requests Screen', () => {
 
     // Click filter button
     const filterBtn = await screen.findByTestId('filter');
-    fireEvent.click(filterBtn);
+    await user.click(filterBtn);
 
     // First set to individual filter
     const individualFilter = await screen.findByTestId('individual');
-    fireEvent.click(individualFilter);
+    await user.click(individualFilter);
 
     await waitFor(() => {
       const filteredNames = screen.getAllByTestId('volunteerName');
@@ -346,11 +349,11 @@ describe('Testing Requests Screen', () => {
 
     // Now click filter button again
     const filterBtnAgain = await screen.findByTestId('filter');
-    fireEvent.click(filterBtnAgain);
+    await user.click(filterBtnAgain);
 
     // Select 'all' filter to show all requests again
     const allFilter = await screen.findByTestId('all');
-    fireEvent.click(allFilter);
+    await user.click(allFilter);
 
     await waitFor(() => {
       // Should show all requests again (2 individual + 1 group = 3)

--- a/src/screens/UserPortal/UserGlobalScreen/UserGlobalScreen.spec.tsx
+++ b/src/screens/UserPortal/UserGlobalScreen/UserGlobalScreen.spec.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import UserGlobalScreen from './UserGlobalScreen';
 
@@ -142,32 +143,35 @@ describe('UserGlobalScreen', () => {
       expect(screen.queryByTestId('openMenu')).not.toBeInTheDocument();
     });
 
-    it('should toggle to open menu button when close button is clicked', () => {
+    it('should toggle to open menu button when close button is clicked', async () => {
+      const user = userEvent.setup();
       renderComponent();
 
       const closeButton = screen.getByTestId('closeMenu');
-      fireEvent.click(closeButton);
+      await user.click(closeButton);
 
       expect(screen.getByTestId('openMenu')).toBeInTheDocument();
       expect(screen.queryByTestId('closeMenu')).not.toBeInTheDocument();
     });
 
-    it('should toggle back to close menu button when open button is clicked', () => {
+    it('should toggle back to close menu button when open button is clicked', async () => {
+      const user = userEvent.setup();
       renderComponent();
 
       // First click to show open button
       const closeButton = screen.getByTestId('closeMenu');
-      fireEvent.click(closeButton);
+      await user.click(closeButton);
 
       // Then click open button to show close button again
       const openButton = screen.getByTestId('openMenu');
-      fireEvent.click(openButton);
+      await user.click(openButton);
 
       expect(screen.getByTestId('closeMenu')).toBeInTheDocument();
       expect(screen.queryByTestId('openMenu')).not.toBeInTheDocument();
     });
 
-    it('should pass correct hideDrawer state to UserSidebar', () => {
+    it('should pass correct hideDrawer state to UserSidebar', async () => {
+      const user = userEvent.setup();
       renderComponent();
 
       // Initially hideDrawer should be false (first render)
@@ -175,19 +179,20 @@ describe('UserGlobalScreen', () => {
 
       // Click to hide drawer
       const closeButton = screen.getByTestId('closeMenu');
-      fireEvent.click(closeButton);
+      await user.click(closeButton);
 
       // Now hideDrawer should be true - check within the sidebar
       const sidebar = screen.getByTestId('user-sidebar');
       expect(sidebar.textContent).toContain('true');
     });
 
-    it('should allow UserSidebar to toggle drawer state', () => {
+    it('should allow UserSidebar to toggle drawer state', async () => {
+      const user = userEvent.setup();
       renderComponent();
 
       // Click the mock sidebar toggle button
       const sidebarToggle = screen.getByText('Mock Sidebar Toggle');
-      fireEvent.click(sidebarToggle);
+      await user.click(sidebarToggle);
 
       // State should change
       expect(screen.getByTestId('openMenu')).toBeInTheDocument();
@@ -331,40 +336,43 @@ describe('UserGlobalScreen', () => {
       expect(mainContainer).toHaveClass('pageContainer');
     });
 
-    it('should apply expand class when drawer is hidden', () => {
+    it('should apply expand class when drawer is hidden', async () => {
+      const user = userEvent.setup();
       renderComponent();
 
       // Hide the drawer
       const closeButton = screen.getByTestId('closeMenu');
-      fireEvent.click(closeButton);
+      await user.click(closeButton);
 
       const mainContainer = screen.getByTestId('mainpageright');
       expect(mainContainer).toHaveClass('pageContainer', 'expand');
     });
 
-    it('should apply contract class when drawer is shown', () => {
+    it('should apply contract class when drawer is shown', async () => {
+      const user = userEvent.setup();
       renderComponent();
 
       // Hide drawer first
       const closeButton = screen.getByTestId('closeMenu');
-      fireEvent.click(closeButton);
+      await user.click(closeButton);
 
       // Then show drawer again
       const openButton = screen.getByTestId('openMenu');
-      fireEvent.click(openButton);
+      await user.click(openButton);
 
       const mainContainer = screen.getByTestId('mainpageright');
       expect(mainContainer).toHaveClass('pageContainer', 'contract');
     });
 
-    it('should apply correct button classes', () => {
+    it('should apply correct button classes', async () => {
+      const user = userEvent.setup();
       renderComponent();
 
       const closeButton = screen.getByTestId('closeMenu');
       expect(closeButton).toHaveClass('collapseSidebarButton');
 
       // Toggle to open button
-      fireEvent.click(closeButton);
+      await user.click(closeButton);
 
       const openButton = screen.getByTestId('openMenu');
       expect(openButton).toHaveClass('opendrawer');
@@ -398,15 +406,16 @@ describe('UserGlobalScreen', () => {
   });
 
   describe('Edge Cases', () => {
-    it('should handle rapid successive button clicks', () => {
+    it('should handle rapid successive button clicks', async () => {
+      const user = userEvent.setup();
       renderComponent();
 
       const closeButton = screen.getByTestId('closeMenu');
 
       // Rapid clicks
-      fireEvent.click(closeButton);
-      fireEvent.click(screen.getByTestId('openMenu'));
-      fireEvent.click(screen.getByTestId('closeMenu'));
+      await user.click(closeButton);
+      await user.click(screen.getByTestId('openMenu'));
+      await user.click(screen.getByTestId('closeMenu'));
 
       // Should end up with open menu button
       expect(screen.getByTestId('openMenu')).toBeInTheDocument();


### PR DESCRIPTION
## Description

This PR migrates test files from `fireEvent` to `userEvent` as part of the fireEvent to userEvent migration initiative.

## Changes Made

- Migrated `src/screens/AdminPortal/OrganizationDashboard/OrganizationDashboard.spec.tsx`
- Migrated `src/screens/UserPortal/UserGlobalScreen/UserGlobalScreen.spec.tsx`
- Migrated `src/screens/AdminPortal/Requests/Requests.spec.tsx`
- Migrated `src/screens/EventVolunteers/Requests/Requests.spec.tsx`
- Migrated `src/screens/AdminPortal/OrganizationFundCampaign/OrganizationFundCampaign.spec.tsx`

**Migration Details:**
- Replaced all `fireEvent.click()` calls with `await user.click()`
- Replaced all `fireEvent.change()` calls with `await user.type()` and `await user.clear()`
- Added `userEvent.setup()` at the beginning of each test
- Made all test functions `async` where needed
- Ensured all `userEvent` calls are properly awaited

## Testing

- All tests pass locally
- No TypeScript errors
- All fireEvent imports removed from migrated files

## Related Issues

Fixes: #6619 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Reworked UI tests across AdminPortal, EventVolunteers, and UserPortal to use user-event interactions (async user setup and awaited actions) instead of synthetic DOM events, improving realism and reliability of interactions, timing, and assertions. No public APIs or exported behaviors were changed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->