### PR TITLE
test: add error-path coverage for askAndSetLogErrors in setup.spec.ts

### DIFF
--- a/src/setup/setup.spec.ts
+++ b/src/setup/setup.spec.ts
@@ -428,6 +428,36 @@ describe('Talawa Admin Setup', () => {
     expect(updateEnvFile).toHaveBeenCalledWith('ALLOW_LOGS', 'YES');
   });
 
+  it('should handle errors when inquirer.prompt rejects in askAndSetLogErrors', async () => {
+    const mockError = new Error('Prompt failure');
+
+    vi.spyOn(inquirer, 'prompt').mockRejectedValueOnce(mockError);
+
+    await expect(askAndSetLogErrors()).rejects.toThrow('Prompt failure');
+
+    // Verify updateEnvFile was not called when prompt fails
+    expect(updateEnvFile).not.toHaveBeenCalled();
+  });
+
+  it('should handle errors when updateEnvFile throws in askAndSetLogErrors', async () => {
+    const mockError = new Error('Failed to update environment file');
+
+    vi.spyOn(inquirer, 'prompt').mockResolvedValueOnce({
+      shouldLogErrors: true,
+    });
+
+    vi.mocked(updateEnvFile).mockImplementationOnce(() => {
+      throw mockError;
+    });
+
+    await expect(askAndSetLogErrors()).rejects.toThrow(
+      'Failed to update environment file',
+    );
+
+    // Verify updateEnvFile was called before throwing
+    expect(updateEnvFile).toHaveBeenCalledWith('ALLOW_LOGS', 'YES');
+  });
+
   it('should handle SIGINT (CTRL+C) during setup and exit with code 130', async () => {
     let sigintHandler: (() => void) | undefined;
 


### PR DESCRIPTION
## What kind of change does this PR introduce?
Test coverage improvement

## Issue Number:
Fixes #6823

## Did you add tests for your changes?
Yes - Added 2 new test cases for error scenarios

## Snapshots/Videos:
N/A - Test coverage improvement

## Summary
Added error-path test coverage for the `askAndSetLogErrors` function in `src/setup/setup.spec.ts` as required by coding guidelines section 1.2.

### Changes Made:
- Added test case for `inquirer.prompt` rejection scenario
- Added test case for `updateEnvFile` throwing error
- Both tests verify proper error handling and propagation

### Test Results:
- All 22 tests passing
- No linting errors
- No TypeScript errors
- No formatting issues

## Does this PR introduce a breaking change?
No

## Have you read the Contributing Guidelines?
Yes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for error handling scenarios in the setup configuration process, ensuring proper error propagation and recovery behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->