### PR TITLE
Replace text-based selector with stable attribute in AdminEventPage E2E test (#6980)

### DIFF
--- a/cypress/pageObjects/AdminPortal/AdminEventPage.ts
+++ b/cypress/pageObjects/AdminPortal/AdminEventPage.ts
@@ -12,6 +12,7 @@ export class AdminEventPage {
   private readonly _previewUpdateEventBtn = '[data-cy="previewUpdateEventBtn"]';
   private readonly _deleteEventModalBtn = '[data-cy="deleteEventModalBtn"]';
   private readonly _deleteEventBtn = '[data-testid="deleteEventBtn"]';
+  private readonly _viewAllEventsBtn = '[data-cy="viewAllEventsBtn"]';
 
   visitEventPage(): void {
     cy.get(this._eventsTabButton).should('be.visible').click();
@@ -59,5 +60,11 @@ export class AdminEventPage {
     cy.get(this._deleteEventModalBtn).should('be.visible').click();
     cy.get(this._deleteEventBtn).should('be.visible').click();
     cy.assertToast('Event deleted successfully.');
+  }
+
+  clickViewAllEventsButtons(): void {
+    cy.get(this._viewAllEventsBtn).each(($btn) => {
+      cy.wrap($btn).click({ force: true });
+    });
   }
 }

--- a/src/components/EventCalender/Monthly/EventCalender.tsx
+++ b/src/components/EventCalender/Monthly/EventCalender.tsx
@@ -302,6 +302,7 @@ const Calendar: React.FC<
                   className={styles.btn__more}
                   onClick={handleExpandClick}
                   data-testid="view-more-button"
+                  data-cy="viewAllEventsBtn"
                 >
                   {expanded === -100 ? 'View less' : 'View all'}
                 </button>
@@ -468,6 +469,7 @@ const Calendar: React.FC<
                   className={styles.btn__more}
                   data-testid="more"
                   onClick={() => toggleExpand(index)}
+                  data-cy="viewAllEventsBtn"
                 >
                   {expanded === index ? 'View less' : 'View all'}
                 </button>


### PR DESCRIPTION
## Description
Replaced text-based selector with a stable `data-cy` attribute in the AdminEventPage E2E test to improve test reliability and maintainability.

### Changes Made are
- **Component Update**  
  Added a stable `data-cy="viewAllEventsBtn"` attribute to the “View all” button in: - 
  src/components/EventCalender/Monthly/EventCalender.tsx

- **E2E Test Update**  
Updated the Cypress selector to target the new `data-cy` attribute in:  
cypress/pageObjects/AdminPortal/AdminEventPage.ts



<img width="880" height="635" alt="Screenshot 2026-02-05 at 9 27 37 PM" src="https://github.com/user-attachments/assets/79f8a3e0-24e3-4d9e-ad08-c3220af03ad6" />
<img width="880" height="635" alt="Screenshot 2026-02-05 at 9 27 37 PM" src="https://github.com/user-attachments/assets/79f8a3e0-24e3-4d9e-ad08-c3220af03ad6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated test infrastructure for event calendar management with improved element selection capabilities and enhanced automation methods for user interaction testing. These additions strengthen testing coverage for event viewing features and provide more reliable validation of user interactions across multiple calendar views and various event management scenarios throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->