### PR TITLE
test(e2e): replace text-based selector with data-cy for "View all" buttons

### DIFF
--- a/cypress/pageObjects/AdminPortal/AdminEventPage.ts
+++ b/cypress/pageObjects/AdminPortal/AdminEventPage.ts
@@ -61,8 +61,7 @@ export class AdminEventPage {
 
     // Cypress cannot click this due to calendar cards overlapping the button.
     // This is a known Cypress actionability limitation — force click is required.
-    cy.get('[data-testid="more"]')
-      .filter(':contains("View all")')
+    cy.get('[data-cy="viewAllEventsBtn"]')
       .each(($btn) => {
         cy.wrap($btn).click({ force: true });
       })

--- a/src/components/EventCalender/Monthly/EventCalender.tsx
+++ b/src/components/EventCalender/Monthly/EventCalender.tsx
@@ -490,7 +490,7 @@ const Calendar: React.FC<
               {shouldShowViewMore && (
                 <button
                   className={styles.btn__more}
-                  data-testid="more"
+                  data-cy="viewAllEventsBtn"
                   onClick={() => toggleExpand(index)}
                 >
                   {expanded === index ? 'View less' : 'View all'}


### PR DESCRIPTION
## What kind of change does this PR introduce?
E2E test improvement

## Issue Number
Fixes #6980

## Summary
This PR replaces fragile text-based selectors used for the "View all" buttons in the event calendar with a stable `data-cy` attribute, improving test reliability and maintainability.

### Changes Made
- Added `data-cy="viewAllEventsBtn"` to the "View all" button in `EventCalender.tsx`
- Updated the Cypress selector in `AdminEventPage.ts` to use the new attribute
- Preserved existing force-click behavior for calendar card overlays

### Benefits
-  Locale-independent (not affected by translations)
-  More maintainable test selectors
-  Improved E2E test stability
-  Easier debugging and future-proofing

## Does this PR introduce a breaking change?
No

## Test Plan
- Ran E2E test suite
- Verified all "View all" buttons are detected and clicked correctly
- Confirmed event cards expand as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test selectors and added component testing setup to improve test reliability and enable mounting UI components in tests.

* **Chores**
  * Standardized test configuration and added folders for downloads and fixtures plus component test server settings to streamline local testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->