### PR TITLE
fix(test): resolve flaky OrganizationTags sort test #7098

### DIFF
--- a/src/screens/AdminPortal/OrganizationTags/OrganizationTags.spec.tsx
+++ b/src/screens/AdminPortal/OrganizationTags/OrganizationTags.spec.tsx
@@ -255,7 +255,7 @@ describe('Organisation Tags Page', () => {
         const buttons = screen.getAllByTestId('manageTagBtn');
         expect(buttons.length).toEqual(2);
       },
-      { timeout: 500 },
+      { timeout: 3000 },
     );
   });
 
@@ -360,36 +360,45 @@ describe('Organisation Tags Page', () => {
     const input = screen.getByPlaceholderText(translations.searchByName);
 
     // Trigger search by changing the input value
-    // The mock PageHeader's onChange handler calls onSearch with the input value
     await userEvent.clear(input);
     await userEvent.type(input, 'searchUserTag');
 
-    // Wait for the search results to load
-    await waitFor(() => {
-      expect(screen.getAllByTestId('tagName')[0]).toHaveTextContent(
-        'userTag 1',
-      );
-    });
+    // Wait for the search results to load (searchUserTag1 comes first in DESCENDING order)
+    await waitFor(
+      () => {
+        expect(screen.getAllByTestId('tagName')[0]).toHaveTextContent(
+          'userTag searchUserTag1',
+        );
+      },
+      { timeout: 3000 },
+    );
+
     await userEvent.click(screen.getByTestId('sortTags-toggle'));
     // Click the "Oldest" button to sort in ascending order
     await userEvent.click(screen.getByTestId('sortTags-item-oldest'));
 
-    // Wait for tags to be re-ordered (oldest first)
-    await waitFor(() => {
-      expect(screen.getAllByTestId('tagName')[0]).toHaveTextContent(
-        'userTag 10',
-      );
-    });
+    // Wait for Apollo re-query to complete and tags to be re-ordered (oldest first)
+    // In ASCENDING order with search "searchUserTag", searchUserTag2 comes first
+    await waitFor(
+      () => {
+        expect(screen.getAllByTestId('tagName')[0]).toHaveTextContent(
+          'userTag searchUserTag2',
+        );
+      },
+      { timeout: 3000 },
+    );
 
-    // Click "Latest" to switch back to descending order
     await userEvent.click(screen.getByTestId('sortTags-item-latest'));
 
-    // Wait for tags to be re-ordered back (latest first)
-    await waitFor(() => {
-      expect(screen.getAllByTestId('tagName')[0]).toHaveTextContent(
-        'userTag 1',
-      );
-    });
+    // Wait for Apollo re-query to complete and tags to return to DESCENDING order
+    await waitFor(
+      () => {
+        expect(screen.getAllByTestId('tagName')[0]).toHaveTextContent(
+          'userTag searchUserTag1',
+        );
+      },
+      { timeout: 3000 },
+    );
   });
 
   test('fetches more tags with infinite scroll', async () => {
@@ -645,7 +654,7 @@ describe('Organisation Tags Page', () => {
         // Should still find the tags because whitespace is trimmed
         expect(buttons.length).toEqual(2);
       },
-      { timeout: 500 },
+      { timeout: 3000 },
     );
   });
 


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Bugfix

**Issue Number:**

Fixes #7098

**Snapshots/Videos:**

N/A

**If relevant, did you update the documentation?**

N/A - Test fix only

**Summary**

This PR resolves the flaky test "fetches the tags by the sort order, i.e. latest or oldest first" in OrganizationTags.spec.tsx that was failing intermittently in CI Shard 3.

**Root Cause:** Race condition where waitFor assertions executed before Apollo Client re-query completed under high CPU load.

**Solution:** 
- Added `{ timeout: 3000 }` to waitFor wrappers to allow more time for Apollo re-query completion
- Corrected expected values to match actual mock data:
  - "userTag 1" → "userTag searchUserTag1"
  - "userTag 10" → "userTag searchUserTag2"

**Testing Done:**
- ✅ All 35 tests in OrganizationTags.spec.tsx pass
- ✅ Stress tested with 3 consecutive runs - all passed
- ✅ ESLint: 0 warnings
- ✅ TypeScript: No errors
- ✅ All pre-commit hooks pass

**Does this PR introduce a breaking change?**

No

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**

This fix ensures the test suite runs reliably in CI environments with varying CPU loads.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated organization-tags tests to better handle debounced search and subsequent re-queries: adjusted expected result ordering for different sort directions, increased wait timeouts for debounced updates, and clarified test comments to reflect asynchronous re-query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->