### PR TITLE
test: add test coverage for FundModal component

### DIFF
--- a/src/screens/AdminPortal/OrganizationFunds/modal/FundModal.spec.tsx
+++ b/src/screens/AdminPortal/OrganizationFunds/modal/FundModal.spec.tsx
@@ -140,7 +140,7 @@ const mutationReturn = [
 describe('PledgeModal', () => {
   afterEach(() => {
     cleanup();
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('should populate form fields with correct values in edit mode', async () => {
@@ -527,12 +527,14 @@ describe('PledgeModal', () => {
       expect(hide).toHaveBeenCalled();
     });
 
-    expect(
-      screen.getByLabelText(translations.fundName, { exact: false }),
-    ).toHaveValue('');
-    expect(
-      screen.getByLabelText(translations.fundId, { exact: false }),
-    ).toHaveValue('');
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(translations.fundName, { exact: false }),
+      ).toHaveValue('');
+      expect(
+        screen.getByLabelText(translations.fundId, { exact: false }),
+      ).toHaveValue('');
+    });
   });
 
   it('should update fund successfully and call side effects', async () => {
@@ -564,8 +566,10 @@ describe('PledgeModal', () => {
       expect(hide).toHaveBeenCalled();
     });
 
-    expect(
-      screen.getByLabelText(translations.fundName, { exact: false }),
-    ).toHaveValue('');
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(translations.fundName, { exact: false }),
+      ).toHaveValue('');
+    });
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce?**

**Issue Number:**

Closes #6897


This PR adds missing test coverage for the successful create and update fund flows in FundModal.

# What’s covered

* Successful create fund submission

* Successful update fund submission

# Additional coverage

* Ensures form state is reset after successful submission, improving confidence around modal reuse behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the Fund modal, adding simulated create and update flows with form interactions and success assertions.
  * Introduced mocking of the mutation flow to reliably test success paths and form reset behavior.
  * Ensured test isolation by restoring mocks after each test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->