### PR TITLE
fix: flaky tests in OrgList and Users screens

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -36,6 +36,9 @@ beforeAll(() => {
 // Basic cleanup after each test
 afterEach(() => {
   cleanup();
+  // Ensure any pending timers are flushed before cleanup
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
 


### PR DESCRIPTION
# Fix(#6986 ): Flaky tests in OrgList and Users screens 

## Description
This PR addresses flaky tests and linting errors in the `OrgList` and `Users` screens.


1. Test Flakiness Fix
Migrated test files from flaky real-time setTimeout delays to deterministic Vitest fake timers with shouldAdvanceTime: true.

## Files Changed
- vitest.setup.ts
- src/screens/Users/Users.spec.tsx
- src/screens/OrgList/OrgList.spec.tsx 

## Checklist
 - [x] My code follows the established code style
 - [x] I have performed a self-review
 - [x] Tests pass locally
 - [x] No new lint errors

## Testing
- Verified that linting passes (except for the documentation generation issue which was bypassed).
- Run `npx vitest run src/screens/Users/Users.spec.tsx` and `npx vitest run src/screens/OrgList/OrgList.spec.tsx `
-  I also attached Screenshots of passed tests 

## Screenshots
1. After run `npx vitest run src/screens/Users/Users.spec.tsx`
<img width="1284" height="485" alt="Screenshot 2026-02-08 175628" src="https://github.com/user-attachments/assets/4c180c77-927d-4262-bc52-7ffe3b521053" />

2. After run `npx vitest run src/screens/OrgList/OrgList.spec.tsx `
<img width="1182" height="915" alt="Screenshot 2026-02-08 180123" src="https://github.com/user-attachments/assets/a78831f0-2a87-40dd-a52a-5a7e85d3de31" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test infrastructure with enhanced timing mechanisms and synchronization across test suites for more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->