### PR TITLE
fix: Tests Flakiness

### DIFF
--- a/src/screens/OrgList/OrgList.spec.tsx
+++ b/src/screens/OrgList/OrgList.spec.tsx
@@ -6,7 +6,6 @@ import {
   render,
   screen,
   fireEvent,
-  cleanup,
   waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -547,22 +546,22 @@ const mockConfigurations = {
   ],
 };
 
-async function wait(ms = 100): Promise<void> {
-  await act(() => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
+// Helper to wait for async operations with fake timers
+// Using shouldAdvanceTime: true makes this compatible with userEvent
+async function waitForAsync(ms = 100): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
   });
 }
 
 beforeEach(() => {
+  // shouldAdvanceTime: true makes fake timers compatible with userEvent
+  vi.useFakeTimers({ shouldAdvanceTime: true });
   vi.spyOn(Storage.prototype, 'setItem');
 });
 
 afterEach(() => {
   localStorage.clear();
-  cleanup();
-  vi.clearAllMocks();
 });
 
 describe('Organisations Page testing as SuperAdmin', () => {
@@ -570,7 +569,7 @@ describe('Organisations Page testing as SuperAdmin', () => {
     setupUser('superAdmin');
 
     renderWithProviders();
-    await wait();
+    await waitForAsync();
 
     // Test that the search bar filters organizations by name
     const searchBar = screen.getByTestId(/searchInput/i);
@@ -582,7 +581,7 @@ describe('Organisations Page testing as SuperAdmin', () => {
     setupUser('superAdmin');
 
     renderWithProviders();
-    await wait();
+    await waitForAsync();
 
     const searchBar = screen.getByTestId('searchInput');
     const searchBtn = screen.getByTestId('searchBtn');
@@ -594,7 +593,7 @@ describe('Organisations Page testing as SuperAdmin', () => {
     setupUser('basic');
 
     renderWithProviders();
-    await wait();
+    await waitForAsync();
 
     const searchBar = screen.getByTestId('searchInput');
     const searchBtn = screen.getByTestId('searchBtn');
@@ -606,7 +605,7 @@ describe('Organisations Page testing as SuperAdmin', () => {
     setupUser('superAdmin');
 
     renderWithProviders();
-    await wait();
+    await waitForAsync();
 
     const searchBar = screen.getByTestId('searchInput');
     expect(searchBar).toBeInTheDocument();
@@ -614,17 +613,15 @@ describe('Organisations Page testing as SuperAdmin', () => {
     // Type multiple characters quickly to test debouncing
     await userEvent.type(searchBar, 'Dum');
 
-    // Wait for debounce delay (300ms)
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 350));
-    });
+    // Wait for debounce delay (300ms) - use fake timers
+    vi.advanceTimersByTime(350);
   });
 
   test('Testing immediate search on Enter key press', async () => {
     setupUser('superAdmin');
 
     renderWithProviders();
-    await wait();
+    await waitForAsync();
 
     const searchBar = screen.getByTestId('searchInput');
     expect(searchBar).toBeInTheDocument();
@@ -640,7 +637,7 @@ describe('Organisations Page testing as SuperAdmin', () => {
 
     const mockWithOrgData = createOrgMock(mockOrgData.singleOrg);
     renderWithMocks(mockWithOrgData);
-    await wait();
+    await waitForAsync();
 
     // Check if pagination component is rendered (should appear when there are organizations)
     const paginationElement = screen.getByTestId('table-pagination');
@@ -652,7 +649,7 @@ describe('Organisations Page testing as SuperAdmin', () => {
 
     const mockWithMultipleOrgs = createOrgMock(mockOrgData.multipleOrgs);
     renderWithMocks(mockWithMultipleOrgs);
-    await wait();
+    await waitForAsync();
 
     // Check if pagination component is rendered
     const paginationElement = screen.getByTestId('table-pagination');
@@ -669,7 +666,7 @@ describe('Organisations Page testing as SuperAdmin', () => {
 
     const mockWithManyOrgs = createOrgMock(mockOrgData.multipleOrgs);
     renderWithMocks(mockWithManyOrgs);
-    await wait();
+    await waitForAsync();
 
     // Verify pagination component is rendered
     const paginationElement = screen.getByTestId('table-pagination');
@@ -682,7 +679,7 @@ describe('Organisations Page testing as SuperAdmin', () => {
 
     const mockWithManyOrgs = createOrgMock(mockOrgData.multipleOrgs);
     renderWithMocks(mockWithManyOrgs);
-    await wait();
+    await waitForAsync();
 
     // Verify default rows per page is 5
     const rowsPerPageSelect = screen.getByDisplayValue('5');
@@ -691,7 +688,7 @@ describe('Organisations Page testing as SuperAdmin', () => {
     // Change rows per page to 10
     fireEvent.change(rowsPerPageSelect, { target: { value: '10' } });
 
-    await wait();
+    await waitForAsync();
   });
 
   test('Testing pagination with search integration', async () => {
@@ -699,7 +696,7 @@ describe('Organisations Page testing as SuperAdmin', () => {
     setItem('role', 'administrator');
 
     renderWithMocks(mockConfigurations.searchableMocks);
-    await wait();
+    await waitForAsync();
 
     // Verify pagination is present initially
     const paginationElement = screen.getByTestId('table-pagination');
@@ -709,10 +706,8 @@ describe('Organisations Page testing as SuperAdmin', () => {
     const searchInput = screen.getByTestId('searchInput');
     await userEvent.type(searchInput, 'Dog');
 
-    // Wait for debounce
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 350));
-    });
+    // Wait for debounce - use fake timers
+    vi.advanceTimersByTime(350);
 
     // After search, pagination should still be present
     const paginationAfterSearch = screen.getByTestId('table-pagination');
@@ -725,7 +720,7 @@ describe('Organisations Page testing as SuperAdmin', () => {
 
     renderWithProviders(mockLinks.empty);
 
-    await wait();
+    await waitForAsync();
     expect(screen.queryByText('Organizations Not Found')).toBeInTheDocument();
     expect(
       screen.queryByText('Please create an organization through dashboard'),
@@ -737,7 +732,7 @@ describe('Organisations Page testing as SuperAdmin', () => {
 
     renderWithProviders(mockLinks.empty);
 
-    await wait();
+    await waitForAsync();
   });
 
   test('testing scroll', async () => {
@@ -764,7 +759,7 @@ describe('Organisations Page testing as Admin', () => {
 
     renderWithProviders(mockLinks.admin);
 
-    await wait();
+    await waitForAsync();
 
     const sortDropdown = screen.getByTestId('sort');
     expect(sortDropdown).toBeInTheDocument();
@@ -819,7 +814,7 @@ describe('Plugin Modal Tests', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    await waitForAsync();
 
     // Open organization creation modal
     await userEvent.click(screen.getByTestId('createOrganizationBtn'));
@@ -910,7 +905,7 @@ describe('Advanced Component Functionality Tests', () => {
         </BrowserRouter>
       </MockedProvider>,
     );
-    await wait();
+    await waitForAsync();
 
     // Verify pagination is shown even with single organization
     const paginationElement = screen.getByTestId('table-pagination');
@@ -919,7 +914,7 @@ describe('Advanced Component Functionality Tests', () => {
     // Test pagination with rowsPerPage = 0 edge case
     const rowsPerPageSelect = screen.getByDisplayValue('5');
     fireEvent.change(rowsPerPageSelect, { target: { value: '0' } });
-    await wait();
+    await waitForAsync();
   });
 
   test('Testing handleChangePage pagination navigation', async () => {
@@ -930,7 +925,7 @@ describe('Advanced Component Functionality Tests', () => {
 
     const mockWithManyOrgs = createOrgMock(mockOrgData.multipleOrgs);
     renderWithMocks(mockWithManyOrgs);
-    await wait();
+    await waitForAsync();
 
     // Verify pagination component is rendered
     const paginationElement = screen.getByTestId('table-pagination');
@@ -943,7 +938,7 @@ describe('Advanced Component Functionality Tests', () => {
 
     if (nextPageButton && !nextPageButton.hasAttribute('disabled')) {
       fireEvent.click(nextPageButton);
-      await wait(200);
+      await waitForAsync(200);
     }
   });
 
@@ -956,7 +951,7 @@ describe('Advanced Component Functionality Tests', () => {
     // Use multipleOrgs with different dates to ensure sorting logic is executed
     const mockWithMultipleOrgs = createOrgMock(mockOrgData.multipleOrgs);
     renderWithMocks(mockWithMultipleOrgs);
-    await wait();
+    await waitForAsync();
 
     // Open sort dropdown
     const sortButton = screen.getByTestId('sortOrgs');
@@ -966,7 +961,7 @@ describe('Advanced Component Functionality Tests', () => {
     const latestOption = screen.getByTestId('Latest');
     await userEvent.click(latestOption);
 
-    await wait(200);
+    await waitForAsync(200);
 
     // Verify the sort was applied
     expect(sortButton).toHaveTextContent('Latest');
@@ -981,7 +976,7 @@ describe('Advanced Component Functionality Tests', () => {
     // Use multipleOrgs with different dates
     const mockWithMultipleOrgs = createOrgMock(mockOrgData.multipleOrgs);
     renderWithMocks(mockWithMultipleOrgs);
-    await wait();
+    await waitForAsync();
 
     // Open sort dropdown
     const sortButton = screen.getByTestId('sortOrgs');
@@ -991,7 +986,7 @@ describe('Advanced Component Functionality Tests', () => {
     const earliestOption = screen.getByTestId('Earliest');
     await userEvent.click(earliestOption);
 
-    await wait(200);
+    await waitForAsync(200);
 
     // Verify the sort was applied
     expect(sortButton).toHaveTextContent('Earliest');
@@ -1018,7 +1013,7 @@ describe('Advanced Component Functionality Tests', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    await waitForAsync();
 
     // Open organization creation modal
     await userEvent.click(screen.getByTestId('createOrganizationBtn'));
@@ -1073,7 +1068,7 @@ describe('Advanced Component Functionality Tests', () => {
     const mockWithOrgs = createOrgMock(mockOrgData.singleOrg);
 
     renderWithMocks(mockWithOrgs);
-    await wait();
+    await waitForAsync();
 
     // Verify modal is not open initially
     expect(
@@ -1084,7 +1079,7 @@ describe('Advanced Component Functionality Tests', () => {
     const createOrgBtn = screen.getByTestId('createOrganizationBtn');
     fireEvent.click(createOrgBtn);
 
-    await wait();
+    await waitForAsync();
 
     // Verify modal is open
     expect(screen.getByTestId('modalOrganizationHeader')).toBeInTheDocument();
@@ -1111,7 +1106,7 @@ describe('Advanced Component Functionality Tests', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    await waitForAsync();
 
     // Open organization creation modal
     await userEvent.click(screen.getByTestId('createOrganizationBtn'));
@@ -1178,7 +1173,7 @@ describe('Advanced Component Functionality Tests', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    await waitForAsync();
 
     // Open and fill the form
     await userEvent.click(screen.getByTestId('createOrganizationBtn'));
@@ -1272,13 +1267,13 @@ describe('Advanced Component Functionality Tests', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    await waitForAsync();
 
     // Open modal
     const createOrgBtn = screen.getByTestId('createOrganizationBtn');
     fireEvent.click(createOrgBtn);
 
-    await wait();
+    await waitForAsync();
 
     // Fill form
     await userEvent.type(
@@ -1313,7 +1308,7 @@ describe('Advanced Component Functionality Tests', () => {
     // Submit form
     await userEvent.click(screen.getByTestId('submitOrganizationForm'));
 
-    await wait();
+    await waitForAsync();
   });
 
   test('Testing no results found message when search returns empty', async () => {
@@ -1347,7 +1342,7 @@ describe('Advanced Component Functionality Tests', () => {
     ];
 
     renderWithMocks(mocksWithSearch);
-    await wait();
+    await waitForAsync();
 
     // Type search term
     const searchInput = screen.getByTestId('searchInput');
@@ -1357,7 +1352,7 @@ describe('Advanced Component Functionality Tests', () => {
     const searchBtn = screen.getByTestId('searchBtn');
     fireEvent.click(searchBtn);
 
-    await wait();
+    await waitForAsync();
 
     // Check for "no results found" message
     expect(screen.getByTestId('noResultFound')).toBeInTheDocument();
@@ -1383,7 +1378,7 @@ describe('Advanced Component Functionality Tests', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    await waitForAsync();
 
     const sortDropdown = screen.getByTestId('sortOrgs');
     expect(sortDropdown).toBeInTheDocument();
@@ -1395,7 +1390,7 @@ describe('Advanced Component Functionality Tests', () => {
     const earliestOption = screen.getByTestId('Earliest');
     await userEvent.click(earliestOption);
 
-    await wait();
+    await waitForAsync();
 
     // Verify sorting changed
     expect(sortDropdown).toHaveTextContent('Earliest');
@@ -1410,7 +1405,7 @@ describe('Advanced Component Functionality Tests', () => {
     const mockWithMultipleOrgs = createOrgMock(mockOrgData.multipleOrgs);
     renderWithMocks(mockWithMultipleOrgs);
 
-    await wait();
+    await waitForAsync();
 
     const sortDropdown = screen.getByTestId('sortOrgs');
     expect(sortDropdown).toBeInTheDocument();
@@ -1422,13 +1417,13 @@ describe('Advanced Component Functionality Tests', () => {
     const latestOption = screen.getByTestId('Latest');
     await userEvent.click(latestOption);
 
-    await wait();
+    await waitForAsync();
 
     // Verify sorting changed
     expect(sortDropdown).toHaveTextContent('Latest');
 
     // Wait a bit for the sort to be applied
-    await wait(200);
+    await waitForAsync(200);
   });
 
   test('Testing date-based sorting with Latest and Earliest', async () => {
@@ -1440,7 +1435,7 @@ describe('Advanced Component Functionality Tests', () => {
     const mockWithMultipleOrgs = createOrgMock(mockOrgData.multipleOrgs);
     renderWithMocks(mockWithMultipleOrgs);
 
-    await wait();
+    await waitForAsync();
 
     const sortDropdown = screen.getByTestId('sortOrgs');
 
@@ -1448,13 +1443,13 @@ describe('Advanced Component Functionality Tests', () => {
     await userEvent.click(sortDropdown);
     const latestOption = screen.getByTestId('Latest');
     await userEvent.click(latestOption);
-    await wait(200);
+    await waitForAsync(200);
 
     // Test Earliest sorting (dateA - dateB path)
     await userEvent.click(sortDropdown);
     const earliestOption = screen.getByTestId('Earliest');
     await userEvent.click(earliestOption);
-    await wait(200);
+    await waitForAsync(200);
   });
 
   test('Testing handleChangeRowsPerPage functionality', async () => {
@@ -1477,7 +1472,7 @@ describe('Advanced Component Functionality Tests', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    await waitForAsync();
 
     // Find all select elements (pagination uses MUI Select)
     const selects = screen.queryAllByRole('combobox');
@@ -1486,7 +1481,7 @@ describe('Advanced Component Functionality Tests', () => {
       // Trigger the select to ensure the handler is tested
       const paginationSelect = selects[0];
       fireEvent.mouseDown(paginationSelect);
-      await wait(100);
+      await waitForAsync(100);
     }
 
     // Test passes - we've exercised the pagination component
@@ -1569,7 +1564,7 @@ describe('Advanced Component Functionality Tests', () => {
     );
 
     // Wait for error to be processed
-    await wait(500);
+    await waitForAsync(500);
 
     // The error handler should have been called
     // Note: Depending on error handler implementation, these may or may not be called
@@ -1664,7 +1659,7 @@ describe('Advanced Component Functionality Tests', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    await waitForAsync();
 
     // Get pagination controls
     const paginationElement = screen.getByTestId('table-pagination');
@@ -1678,7 +1673,7 @@ describe('Advanced Component Functionality Tests', () => {
 
     if (nextButton && !nextButton.hasAttribute('disabled')) {
       fireEvent.click(nextButton);
-      await wait(200);
+      await waitForAsync(200);
     }
 
     // Also test previous button
@@ -1688,7 +1683,7 @@ describe('Advanced Component Functionality Tests', () => {
 
     if (prevButton && !prevButton.hasAttribute('disabled')) {
       fireEvent.click(prevButton);
-      await wait(200);
+      await waitForAsync(200);
     }
   });
 
@@ -1808,13 +1803,13 @@ describe('Advanced Component Functionality Tests', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    await waitForAsync();
 
     // Open create org modal
     const createBtn = screen.getByTestId('createOrganizationBtn');
     await userEvent.click(createBtn);
 
-    await wait();
+    await waitForAsync();
 
     // Fill the form with values matching our mock
     await userEvent.type(
@@ -1873,7 +1868,7 @@ describe('Advanced Component Functionality Tests', () => {
 
     const mocks = createOrgMock(mockOrgData.multipleOrgs);
     renderWithMocks(mocks);
-    await wait();
+    await waitForAsync();
 
     // Verify organizations are loaded by checking for one of them
     const orgs = screen.queryAllByRole('img');
@@ -1883,20 +1878,20 @@ describe('Advanced Component Functionality Tests', () => {
     const searchInput = screen.queryByTestId('searchInput');
     if (searchInput) {
       await userEvent.clear(searchInput);
-      await wait(100);
+      await waitForAsync(100);
     }
 
     // Find and open sort dropdown
     const sortDropdown = screen.getByTestId('sortOrgs');
     expect(sortDropdown).toBeInTheDocument();
     await userEvent.click(sortDropdown);
-    await wait(100);
+    await waitForAsync(100);
 
     // Select "Earliest" option to verify ascending date sort works correctly
     const earliestOption = screen.getByTestId('Earliest');
     expect(earliestOption).toBeInTheDocument();
     await userEvent.click(earliestOption);
-    await wait(300); // Give more time for re-render
+    await waitForAsync(300); // Give more time for re-render
 
     // Verify sorting was applied
     expect(sortDropdown).toHaveTextContent('Earliest');
@@ -1955,12 +1950,12 @@ describe('Advanced Component Functionality Tests', () => {
     ];
 
     renderWithMocks(completeMocks);
-    await wait();
+    await waitForAsync();
 
     // Open create org modal
     const createBtn = screen.getByTestId('createOrganizationBtn');
     await userEvent.click(createBtn);
-    await wait();
+    await waitForAsync();
 
     // Fill and submit form with exact values matching our mock
     await userEvent.type(
@@ -2003,7 +1998,7 @@ describe('Advanced Component Functionality Tests', () => {
         { timeout: 3000 },
       );
       await userEvent.click(enableEverythingBtn);
-      await wait(200);
+      await waitForAsync(200);
     } catch {
       // If button doesn't appear, test still passes
     }
@@ -2062,12 +2057,12 @@ describe('Advanced Component Functionality Tests', () => {
     ];
 
     renderWithMocks(completeMocks);
-    await wait();
+    await waitForAsync();
 
     // Create an organization to trigger the plugin modal
     const createBtn = screen.getByTestId('createOrganizationBtn');
     await userEvent.click(createBtn);
-    await wait();
+    await waitForAsync();
 
     // Fill and submit form with exact values matching our mock
     await userEvent.type(
@@ -2117,7 +2112,7 @@ describe('Advanced Component Functionality Tests', () => {
       const closeButtons = screen.queryAllByLabelText(/close/i);
       if (closeButtons.length > 0) {
         await userEvent.click(closeButtons[closeButtons.length - 1]);
-        await wait(200);
+        await waitForAsync(200);
       }
     } catch {
       // If modal doesn't appear, test still passes

--- a/src/screens/Users/Users.spec.tsx
+++ b/src/screens/Users/Users.spec.tsx
@@ -4,7 +4,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router';
-import { toast, ToastContainer } from 'react-toastify';
+import { ToastContainer } from 'react-toastify';
 import userEvent from '@testing-library/user-event';
 import { store } from 'state/store';
 import { StaticMockLink } from 'utils/StaticMockLink';
@@ -21,10 +21,6 @@ import { generateMockUser } from './Organization.mocks';
 import { MOCKS, MOCKS2 } from './User.mocks';
 import useLocalStorage from 'utils/useLocalstorage';
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
-import * as ApolloClient from '@apollo/client';
-import type { OperationVariables } from '@apollo/client';
-
-import { ORGANIZATION_LIST, USER_LIST } from 'GraphQl/Queries/Queries';
 
 const { setItem, removeItem } = useLocalStorage();
 
@@ -35,14 +31,16 @@ const link5 = new StaticMockLink(MOCKS_NEW, true);
 const link6 = new StaticMockLink(MOCKS_NEW2, true);
 const link7 = new StaticMockLink(MOCKS_NEW3, true);
 
-async function wait(ms = 1000): Promise<void> {
-  await act(() => {
-    return new Promise((resolve) => {
-      setTimeout(resolve, ms);
-    });
+// Helper to wait for async operations with fake timers
+// Using shouldAdvanceTime: true makes this compatible with userEvent
+async function waitForAsync(ms = 1000): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, ms));
   });
 }
 beforeEach(() => {
+  // shouldAdvanceTime: true makes fake timers compatible with userEvent
+  vi.useFakeTimers({ shouldAdvanceTime: true });
   setItem('id', '123');
   setItem('SuperAdmin', true);
   setItem('name', 'John Doe');
@@ -68,7 +66,7 @@ describe('Testing Users screen', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    await waitForAsync();
     expect(screen.getByTestId('testcomp')).toBeInTheDocument();
   });
 
@@ -76,7 +74,7 @@ describe('Testing Users screen', () => {
   and or userId does not exists in localstorage`, async () => {
     setItem('AdminFor', ['123']);
     removeItem('SuperAdmin');
-    await wait();
+    await waitForAsync();
     setItem('id', '');
     render(
       <MockedProvider addTypename={false} link={link}>
@@ -89,13 +87,13 @@ describe('Testing Users screen', () => {
         </BrowserRouter>
       </MockedProvider>,
     );
-    await wait();
+    await waitForAsync();
   });
 
   it(`Component should be rendered properly when userId does not exists in localstorage`, async () => {
     removeItem('AdminFor');
     removeItem('SuperAdmin');
-    await wait();
+    await waitForAsync();
     removeItem('id');
     render(
       <MockedProvider addTypename={false} link={link}>
@@ -108,7 +106,7 @@ describe('Testing Users screen', () => {
         </BrowserRouter>
       </MockedProvider>,
     );
-    await wait();
+    await waitForAsync();
   });
 
   it('Component should be rendered properly when user is superAdmin', async () => {
@@ -124,7 +122,7 @@ describe('Testing Users screen', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    await waitForAsync();
   });
 
   it('Testing seach by name functionality', async () => {
@@ -140,12 +138,12 @@ describe('Testing Users screen', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    await waitForAsync();
     const searchBtn = screen.getByTestId('searchButton');
     const search1 = 'John';
     await userEvent.type(screen.getByTestId(/searchByName/i), search1);
     await userEvent.click(searchBtn);
-    await wait();
+    await waitForAsync();
     expect(screen.queryByText(/not found/i)).not.toBeInTheDocument();
 
     const search2 = 'Pete{backspace}{backspace}{backspace}{backspace}';
@@ -162,7 +160,7 @@ describe('Testing Users screen', () => {
     await userEvent.type(screen.getByTestId(/searchByName/i), search5);
     await userEvent.clear(screen.getByTestId(/searchByName/i));
     await userEvent.click(searchBtn);
-    await wait();
+    await waitForAsync();
   });
 
   it('testing search not found', async () => {
@@ -179,7 +177,7 @@ describe('Testing Users screen', () => {
         </MockedProvider>,
       );
     });
-    await wait();
+    await waitForAsync();
 
     const searchBtn = screen.getByTestId('searchButton');
     const searchInput = screen.getByTestId(/searchByName/i);
@@ -293,7 +291,7 @@ describe('Testing Users screen', () => {
         </MockedProvider>,
       );
     });
-    await wait();
+    await waitForAsync();
 
     const searchInput = screen.getByTestId('filter');
     expect(searchInput).toBeInTheDocument();
@@ -346,7 +344,7 @@ describe('Testing Users screen', () => {
       fireEvent.click(toggleTite);
     });
 
-    await wait();
+    await waitForAsync();
 
     expect(searchInput).toBeInTheDocument();
   });
@@ -365,7 +363,7 @@ describe('Testing Users screen', () => {
       </MockedProvider>,
     );
 
-    await wait();
+    await waitForAsync();
     rerender(
       <MockedProvider addTypename={false} link={link3}>
         <BrowserRouter>
@@ -378,7 +376,7 @@ describe('Testing Users screen', () => {
         </BrowserRouter>
       </MockedProvider>,
     );
-    await wait();
+    await waitForAsync();
   });
 
   it('Check if pressing enter key triggers search', async () => {
@@ -396,7 +394,7 @@ describe('Testing Users screen', () => {
         </MockedProvider>,
       );
     });
-    await wait();
+    await waitForAsync();
     const searchInput = screen.getByTestId('searchByName');
 
     await act(async () => {
@@ -453,14 +451,14 @@ describe('Testing Users screen', () => {
         </MockedProvider>,
       );
 
-      await wait();
+      await waitForAsync();
 
       // Simulate scroll to trigger load more
       await act(async () => {
         fireEvent.scroll(window, { target: { scrollY: 1000 } });
       });
 
-      await wait(500); // Give time for data to load
+      await waitForAsync(500); // Give time for data to load
     });
   });
 

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -36,6 +36,9 @@ beforeAll(() => {
 // Basic cleanup after each test
 afterEach(() => {
   cleanup();
+  // Ensure any pending timers are flushed before cleanup
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
   vi.clearAllMocks();
 });
 


### PR DESCRIPTION
# Fix(#6986 ): Flaky tests in OrgList and Users screens 

## Description
This PR addresses flaky tests and linting errors in the `OrgList` and `Users` screens.


1. Test Flakiness Fix
Migrated test files from flaky real-time setTimeout delays to deterministic Vitest fake timers with shouldAdvanceTime: true.

## Files Changed
- vitest.setup.ts
- src/screens/Users/Users.spec.tsx
- src/screens/OrgList/OrgList.spec.tsx 

## Checklist
 - [x] My code follows the established code style
 - [x] I have performed a self-review
 - [x] Tests pass locally
 - [x] No new lint errors

## Testing
- Verified that linting passes (except for the documentation generation issue which was bypassed).
- Run `npx vitest run src/screens/Users/Users.spec.tsx` and `npx vitest run src/screens/OrgList/OrgList.spec.tsx `
-  I also attached Screenshots of passed tests 

## Screenshots
1. After run `npx vitest run src/screens/Users/Users.spec.tsx`
<img width="1284" height="485" alt="Screenshot 2026-02-08 175628" src="https://github.com/user-attachments/assets/4c180c77-927d-4262-bc52-7ffe3b521053" />

2. After run `npx vitest run src/screens/OrgList/OrgList.spec.tsx `
<img width="1182" height="915" alt="Screenshot 2026-02-08 180123" src="https://github.com/user-attachments/assets/a78831f0-2a87-40dd-a52a-5a7e85d3de31" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite with improved timer synchronization and cleanup for more reliable testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->