### PR TITLE
fix: added the lint for native HTML button

### DIFF
--- a/scripts/eslint/config/base.js
+++ b/scripts/eslint/config/base.js
@@ -11,6 +11,7 @@ import {
   securityRestrictions,
   searchInputRestrictions,
   modalStateRestrictions,
+  nativeButtonRestrictions,
 } from '../rules/rules.js';
 
 export const baseTypeScriptConfig = {
@@ -124,6 +125,7 @@ export const baseTypeScriptConfig = {
       ...securityRestrictions,
       ...searchInputRestrictions,
       ...modalStateRestrictions,
+      ...nativeButtonRestrictions,
     ],
     'no-restricted-imports': ['error', { paths: restrictedImportPaths }],
   },

--- a/scripts/eslint/config/special.js
+++ b/scripts/eslint/config/special.js
@@ -3,7 +3,10 @@ import graphql from '@graphql-eslint/eslint-plugin';
 import ts from '@typescript-eslint/eslint-plugin';
 import tsParser from '@typescript-eslint/parser';
 import prettier from 'eslint-plugin-prettier';
-import { securityRestrictions } from '../rules/rules.js';
+import {
+  securityRestrictions,
+  nativeButtonRestrictions,
+} from '../rules/rules.js';
 
 export const graphqlConfig = {
   files: ['*.graphql'],
@@ -59,6 +62,10 @@ export const searchComponentsExemption = {
     'src/shared-components/SearchBar/SearchBar.tsx',
   ],
   rules: {
-    'no-restricted-syntax': ['error', ...securityRestrictions],
+    'no-restricted-syntax': [
+      'error',
+      ...securityRestrictions,
+      ...nativeButtonRestrictions,
+    ],
   },
 };

--- a/scripts/eslint/config/special.js
+++ b/scripts/eslint/config/special.js
@@ -6,6 +6,7 @@ import prettier from 'eslint-plugin-prettier';
 import {
   securityRestrictions,
   nativeButtonRestrictions,
+  modalStateRestrictions
 } from '../rules/rules.js';
 
 export const graphqlConfig = {
@@ -66,6 +67,7 @@ export const searchComponentsExemption = {
       'error',
       ...securityRestrictions,
       ...nativeButtonRestrictions,
+      ...modalStateRestrictions
     ],
   },
 };

--- a/scripts/eslint/rules/native-button.js
+++ b/scripts/eslint/rules/native-button.js
@@ -1,0 +1,10 @@
+/**
+ * Native button restrictions - enforce usage of the shared Button component.
+ */
+export const nativeButtonRestrictions = [
+  {
+    selector: "JSXOpeningElement[name.name='button']",
+    message:
+      'Direct native <button> usage is not allowed. Use the shared Button component from src/shared-components/Button/ instead.',
+  },
+];

--- a/scripts/eslint/rules/rules.js
+++ b/scripts/eslint/rules/rules.js
@@ -11,6 +11,7 @@ import { securityRestrictions } from './security.js';
 import { searchInputRestrictions } from './search-input.js';
 import preferCrudModalTemplate from './prefer-crud-modal-template.js';
 import { modalStateRestrictions } from './modal-state.js';
+import { nativeButtonRestrictions } from './native-button.js';
 
 export {
   restrictedImports,
@@ -21,4 +22,5 @@ export {
   searchInputRestrictions,
   preferCrudModalTemplate,
   modalStateRestrictions,
+  nativeButtonRestrictions,
 };

--- a/scripts/eslint/rules/rules.spec.js
+++ b/scripts/eslint/rules/rules.spec.js
@@ -396,6 +396,9 @@ describe('ESLint Syntax Restrictions', () => {
         expect(nativeButtonRestrictions[0]?.selector).toContain(
           "name.name='button'",
         );
+        expect(nativeButtonRestrictions[0]?.message).toContain(
+          'shared Button component',
+        );
       });
     });
 

--- a/scripts/eslint/rules/rules.spec.js
+++ b/scripts/eslint/rules/rules.spec.js
@@ -10,6 +10,7 @@ import {
   securityRestrictions,
   searchInputRestrictions,
   modalStateRestrictions,
+  nativeButtonRestrictions,
 } from './rules.js';
 
 const filename = fileURLToPath(import.meta.url);
@@ -223,6 +224,47 @@ describe('ESLint Syntax Restrictions', () => {
     });
   });
 
+  describe('Native button restrictions', () => {
+    it('should error on direct native button usage', async () => {
+      const code = `
+        import React from 'react';
+
+        function TestComponent() {
+          return <button type="button">Click me</button>;
+        }
+      `;
+
+      const messages = await lintCode(code);
+      const nativeButtonError = messages.find(
+        (msg) =>
+          msg.ruleId === 'no-restricted-syntax' &&
+          msg.message.includes('Direct native <button> usage is not allowed'),
+      );
+
+      expect(nativeButtonError).toBeDefined();
+    });
+
+    it('should allow shared Button component usage', async () => {
+      const code = `
+        import React from 'react';
+        import Button from 'shared-components/Button';
+
+        function TestComponent() {
+          return <Button type="button">Click me</Button>;
+        }
+      `;
+
+      const messages = await lintCode(code);
+      const nativeButtonError = messages.find(
+        (msg) =>
+          msg.ruleId === 'no-restricted-syntax' &&
+          msg.message.includes('Direct native <button> usage is not allowed'),
+      );
+
+      expect(nativeButtonError).toBeUndefined();
+    });
+  });
+
   describe('Modal state restrictions', () => {
     it('should error on useState with modalState variable name', async () => {
       const code = `
@@ -348,6 +390,15 @@ describe('ESLint Syntax Restrictions', () => {
   });
 
   describe('ESLint Rule Data Tests', () => {
+    describe('nativeButtonRestrictions data integrity', () => {
+      it('should include a JSX button selector', () => {
+        expect(nativeButtonRestrictions.length).toBeGreaterThan(0);
+        expect(nativeButtonRestrictions[0]?.selector).toContain(
+          "name.name='button'",
+        );
+      });
+    });
+
     describe('restrictedImports data integrity', () => {
       it('should have all required import restrictions', () => {
         expect(restrictedImports.length).toBeGreaterThan(20);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR enables the lint for the use of native HTML button.

**Issue Number: #5787**

<!--Add related issue number here.-->
Fixes #5787

**Snapshots/Videos:**

This is for the testing whether the lint throws error on the use of the native HTML button.

<img width="701" height="474" alt="Screenshot 2026-02-09 at 5 32 07 PM" src="https://github.com/user-attachments/assets/ae6b3988-5ac1-4a58-89ed-965ad324bca8" />

It perfectly throws the error on the use of the native HTML button.

<img width="1210" height="310" alt="Screenshot 2026-02-09 at 5 31 56 PM" src="https://github.com/user-attachments/assets/7b578c98-5f3d-4b03-9e2d-6d0e6fffa9b6" />



**Summary**

This adds the lint for the HTML button and restricts the use of the native button and enforces the use of shared button component.
The tests have also been added in the `rules.spec.js`
This solves this comment https://github.com/PalisadoesFoundation/talawa-admin/pull/7085#issuecomment-3862013161

**Does this PR introduce a breaking change?**

This PR doesn't allows the use the native HTML button rather it enforces the use of shared button component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated enforcement of button component standardization to ensure consistent UI patterns across the codebase.

* **Tests**
  * Added new test suite validating button component usage and compliance with component standardization requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->