### PR TITLE
refactor: move StaticMockLink instantiation to beforeEach hooks

### DIFF
--- a/src/screens/AdminPortal/EventManagement/EventManagement.spec.tsx
+++ b/src/screens/AdminPortal/EventManagement/EventManagement.spec.tsx
@@ -73,7 +73,7 @@ MOCKS_WITH_FIXED_TIME[0].result.data.event.updater = {
   emailAddress: 'jane.doe@example.com',
 };
 
-const mockWithTime = new StaticMockLink(MOCKS_WITH_FIXED_TIME, true);
+let mockWithTime: StaticMockLink;
 
 const renderEventManagement = (): RenderResult => {
   return render(
@@ -112,6 +112,7 @@ describe('Event Management', () => {
   let user: ReturnType<typeof userEvent.setup>;
 
   beforeEach(() => {
+    mockWithTime = new StaticMockLink(MOCKS_WITH_FIXED_TIME, true);
     user = userEvent.setup();
   });
 

--- a/src/screens/AdminPortal/OrgContribution/OrgContribution.spec.tsx
+++ b/src/screens/AdminPortal/OrgContribution/OrgContribution.spec.tsx
@@ -9,7 +9,12 @@ import OrgContribution from './OrgContribution';
 import { store } from 'state/store';
 import i18nForTest from 'utils/i18nForTest';
 import { StaticMockLink } from 'utils/StaticMockLink';
-const link = new StaticMockLink([], true);
+let link: StaticMockLink;
+
+beforeEach(() => {
+  link = new StaticMockLink([], true);
+});
+
 async function wait(ms = 100): Promise<void> {
   await new Promise((resolve) => {
     setTimeout(resolve, ms);

--- a/src/screens/UserPortal/Campaigns/Campaigns.spec.tsx
+++ b/src/screens/UserPortal/Campaigns/Campaigns.spec.tsx
@@ -45,9 +45,9 @@ vi.mock('@mui/x-date-pickers/DateTimePicker', async () => {
 
 const { setItem } = useLocalStorage();
 
-const link1 = new StaticMockLink(MOCKS);
-const link2 = new StaticMockLink(USER_FUND_CAMPAIGNS_ERROR);
-const link3 = new StaticMockLink(MOCKS_WITH_NO_FUNDS);
+let link1: StaticMockLink;
+let link2: StaticMockLink;
+let link3: StaticMockLink;
 
 const cTranslations = JSON.parse(
   JSON.stringify(
@@ -84,6 +84,9 @@ const renderCampaigns = (link: ApolloLink): RenderResult => {
 describe('Testing User Campaigns Screen', () => {
   let user: ReturnType<typeof userEvent.setup>;
   beforeEach(() => {
+    link1 = new StaticMockLink(MOCKS);
+    link2 = new StaticMockLink(USER_FUND_CAMPAIGNS_ERROR);
+    link3 = new StaticMockLink(MOCKS_WITH_NO_FUNDS);
     user = userEvent.setup();
     setItem('userId', 'userId');
   });

--- a/src/screens/UserPortal/Campaigns/PledgeModal.spec.tsx
+++ b/src/screens/UserPortal/Campaigns/PledgeModal.spec.tsx
@@ -281,7 +281,7 @@ const PLEDGE_MODAL_MOCKS = [
   }),
 ];
 
-const link1 = new StaticMockLink(PLEDGE_MODAL_MOCKS);
+let link1: StaticMockLink;
 const translations = JSON.parse(
   JSON.stringify(i18nForTest.getDataByLanguage('en')?.translation.pledges),
 );
@@ -318,6 +318,10 @@ describe('PledgeModal', () => {
         useNavigate: vi.fn(),
       };
     });
+  });
+
+  beforeEach(() => {
+    link1 = new StaticMockLink(PLEDGE_MODAL_MOCKS);
   });
 
   afterAll(() => {

--- a/src/screens/UserPortal/Organizations/Organizations.spec.tsx
+++ b/src/screens/UserPortal/Organizations/Organizations.spec.tsx
@@ -447,9 +447,9 @@ const ERROR_MOCKS = [
   },
 ];
 
-const link = new StaticMockLink(MOCKS, true);
-const emptyLink = new StaticMockLink(EMPTY_MOCKS, true);
-const errorLink = new StaticMockLink(ERROR_MOCKS, true);
+let link: StaticMockLink;
+let emptyLink: StaticMockLink;
+let errorLink: StaticMockLink;
 
 async function wait(ms = 100): Promise<void> {
   await act(() => {
@@ -460,6 +460,9 @@ async function wait(ms = 100): Promise<void> {
 }
 
 beforeEach(() => {
+  link = new StaticMockLink(MOCKS, true);
+  emptyLink = new StaticMockLink(EMPTY_MOCKS, true);
+  errorLink = new StaticMockLink(ERROR_MOCKS, true);
   const { setItem: setItemLocal, clearAllItems: clearAllItemsLocal } =
     useLocalStorage();
   setItem = setItemLocal;

--- a/src/shared-components/CheckIn/CheckInWrapper.spec.tsx
+++ b/src/shared-components/CheckIn/CheckInWrapper.spec.tsx
@@ -21,7 +21,7 @@ vi.mock('shared-components/CRUDModalTemplate/hooks/useModalState', () => ({
   useModalState: vi.fn(),
 }));
 
-const link = new StaticMockLink(checkInQueryMock, true);
+let link: StaticMockLink;
 
 /**
  * This file contains unit tests for the CheckInWrapper component.
@@ -37,6 +37,7 @@ const link = new StaticMockLink(checkInQueryMock, true);
  */
 
 beforeEach(() => {
+  link = new StaticMockLink(checkInQueryMock, true);
   (useModalState as Mock).mockReturnValue({
     isOpen: false,
     open: vi.fn(),


### PR DESCRIPTION
**What kind of change does this PR introduce?**

Refactoring

**Issue Number:**

Fixes #7164

**Snapshots/Videos:**

N/A — test-only change, no UI impact.

**If relevant, did you update the documentation?**

N/A

**Summary**

Moved `StaticMockLink` instantiation from module-level `const` declarations into `beforeEach` hooks across 6 test files. This ensures each test gets a fresh mock link instance, preventing stale state from leaking between tests and improving test isolation.

**Does this PR introduce a breaking change?**

No

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Other information**

Files changed:
- `EventManagement.spec.tsx`
- `OrgContribution.spec.tsx`
- `CheckInWrapper.spec.tsx`
- `Campaigns.spec.tsx`
- `PledgeModal.spec.tsx`
- `Organizations.spec.tsx`

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test setup across multiple test suites to improve test isolation by initializing mock instances before each test rather than sharing a single instance across all tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->