### PR TITLE
fix: flagged required values

### DIFF
--- a/scripts/validate-tokens.ts
+++ b/scripts/validate-tokens.ts
@@ -17,11 +17,11 @@
  *   - Hex colors (#fff, #ffffff, #ffffffaa)
  *   - RGB/RGBA colors (rgb(0,0,0), rgba(0,0,0,0.5))
  *   - HSL/HSLA colors (hsl(0,0%,0%), hsla(0,0%,0%,0.5))
- *   - CSS spacing properties with px/rem/em values
+ *   - CSS spacing properties with px/rem/em/vh/vw values
  *   - CSS font-size with px/rem/em values
  *   - CSS font-weight with numeric values (100-900)
  *   - CSS line-height with px values
- *   - CSS border-radius with px/rem/em values
+ *   - CSS border-radius with px/rem/em/% values
  *   - CSS border with px values and colors
  *   - CSS box-shadow with hardcoded values
  *   - TSX inline styles with camelCase properties (marginTop, paddingLeft, fontSize, etc.)
@@ -101,13 +101,13 @@ export const CSS_PATTERNS = {
   hslColor:
     /hsla?\(\s*\d{1,3}\s*,\s*[\d.]+%\s*,\s*[\d.]+%\s*(,\s*[\d.]+)?\s*\)/gi,
 
-  // Spacing patterns - matches px, rem, em values
+  // Spacing patterns - matches px, rem, em, vh, vw values
   // Note: padding and margin are handled exclusively by spacingShorthand to avoid double-counting
   spacingPx:
-    /(?:width|height|gap|top|right|bottom|left|inset):\s*-?[\d.]+(px|rem|em)(\s+-?[\d.]+(px|rem|em))*/gi,
+    /(?:width|height|gap|top|right|bottom|left|inset):\s*-?[\d.]+(px|rem|em|vh|vw)(\s+-?[\d.]+(px|rem|em|vh|vw))*/gi,
   // Shorthand spacing - handles all padding/margin patterns (single and multi-value)
   spacingShorthand:
-    /(?:padding|margin):\s*-?[\d.]+(px|rem|em)(\s+-?[\d.]+(px|rem|em))*/gi,
+    /(?:padding|margin):\s*-?[\d.]+(px|rem|em|vh|vw)(\s+-?[\d.]+(px|rem|em|vh|vw))*/gi,
 
   // Typography patterns
   fontSize: /font-size:\s*[\d.]+(px|rem|em)/gi,
@@ -115,15 +115,22 @@ export const CSS_PATTERNS = {
   lineHeightPx: /line-height:\s*[\d.]+(px|rem|em)/gi,
 
   // Border patterns
-  borderRadius: /border-radius:\s*[\d.]+(px|rem|em)(\s+[\d.]+(px|rem|em))*/gi,
+  borderRadius:
+    /border-radius:\s*[\d.]+(px|rem|em|%)(\s+[\d.]+(px|rem|em|%))*/gi,
   borderWidth:
     /border(-top|-right|-bottom|-left)?(-width)?:\s*[\d.]+(px|rem|em)/gi,
   borderFull:
     /border(-top|-right|-bottom|-left)?:\s*[\d.]+(px|rem|em)\s+\w+\s+#[0-9a-fA-F]{3,8}/gi,
 
-  // Box shadow with hardcoded values
+  // Box shadow with hardcoded values and color
   boxShadow:
     /box-shadow:\s*(-?[\d.]+(px|rem|em)\s*){2,4}(#[0-9a-fA-F]{3,8}|rgba?\([^)]+\)|hsla?\([^)]+\))/gi,
+  // Box shadow with bare hardcoded values (no color, e.g. box-shadow: 6px or box-shadow: 2px 4px)
+  boxShadowBare: /box-shadow:\s*-?[\d.]+(px|rem|em)(\s+-?[\d.]+(px|rem|em))*/gi,
+  // Box shadow with hardcoded px values mixed with var() (e.g. box-shadow: 0 var(--x) 5px)
+  // Requires at least one var() to be present; pure hardcoded values are handled by boxShadowBare
+  boxShadowMixed:
+    /box-shadow:\s*(?:(?:-?[\d.]+(?:px|rem|em)?\s+)+)?var\(--[^)]+\)(?:\s+(?:-?[\d.]+(?:px|rem|em)?|var\(--[^)]+\)))*\s+-?[\d.]+(px|rem|em)/gi,
 
   // Outline patterns
   outlineWidth: /outline(-width)?:\s*[\d.]+(px|rem|em)/gi,
@@ -136,12 +143,12 @@ export const CSS_PATTERNS = {
  * Matches patterns like: marginTop: 8, marginTop: '8px', fontSize: 16
  */
 export const TSX_PATTERNS = {
-  // Spacing camelCase properties with numeric or string px/rem/em values
+  // Spacing camelCase properties with numeric or string px/rem/em/vh/vw values
   spacingCamelCase:
-    /(?:margin|padding)(?:Top|Right|Bottom|Left|Inline|Block|InlineStart|InlineEnd|BlockStart|BlockEnd)?:\s*(?:'[^']*(?:px|rem|em)'|"[^"]*(?:px|rem|em)"|[\d.]+)/gi,
+    /(?:margin|padding)(?:Top|Right|Bottom|Left|Inline|Block|InlineStart|InlineEnd|BlockStart|BlockEnd)?:\s*(?:'[^']*(?:px|rem|em|vh|vw)'|"[^"]*(?:px|rem|em|vh|vw)"|[\d.]+)/gi,
   // Width/height with hardcoded values
   dimensionsCamelCase:
-    /(?:width|height|minWidth|minHeight|maxWidth|maxHeight|gap|rowGap|columnGap|top|right|bottom|left):\s*(?:'[^']*(?:px|rem|em)'|"[^"]*(?:px|rem|em)"|[\d.]+)/gi,
+    /(?:width|height|minWidth|minHeight|maxWidth|maxHeight|gap|rowGap|columnGap|top|right|bottom|left):\s*(?:'[^']*(?:px|rem|em|vh|vw)'|"[^"]*(?:px|rem|em|vh|vw)"|[\d.]+)/gi,
 
   // Font size in TSX
   fontSizeCamelCase:
@@ -154,9 +161,9 @@ export const TSX_PATTERNS = {
   lineHeightCamelCase:
     /lineHeight:\s*(?:'[^']*(?:px|rem|em)'|"[^"]*(?:px|rem|em)"|[\d.]+(?:px|rem|em))/gi,
 
-  // Border radius in TSX
+  // Border radius in TSX (includes % to flag values like '50%')
   borderRadiusCamelCase:
-    /borderRadius:\s*(?:'[^']*(?:px|rem|em)'|"[^"]*(?:px|rem|em)"|[\d.]+)/gi,
+    /borderRadius:\s*(?:'[^']*(?:px|rem|em|%)'|"[^"]*(?:px|rem|em|%)"|[\d.]+)/gi,
 
   // Colors in TSX (hex, rgb, hsl)
   colorCamelCase:
@@ -180,8 +187,8 @@ const ALLOWLIST_PATTERNS = [
   /--[\w-]+:\s*/,
   // 0 values without units are valid CSS (allow whitespace, semicolon, comma, or end-of-line)
   /:\s*0(?:px|rem|em)?(?:\s|;|,|$)/,
-  // Percentage values
-  /:\s*[\d.]+%/,
+  // Percentage values — allowed for spacing properties but NOT for border-radius
+  /(?<!border-radius):\s*[\d.]+%/,
   // Common allowed numeric values in specific contexts
   /z-index:\s*\d+/,
   /opacity:\s*[\d.]+/,
@@ -609,6 +616,22 @@ const validateCssLine = (
   addMatches(
     line,
     CSS_PATTERNS.boxShadow,
+    'box-shadow',
+    file,
+    lineNumber,
+    results,
+  );
+  addMatches(
+    line,
+    CSS_PATTERNS.boxShadowBare,
+    'box-shadow',
+    file,
+    lineNumber,
+    results,
+  );
+  addMatches(
+    line,
+    CSS_PATTERNS.boxShadowMixed,
     'box-shadow',
     file,
     lineNumber,

--- a/src/test-utils/validate-tokens-patterns.test.ts
+++ b/src/test-utils/validate-tokens-patterns.test.ts
@@ -82,6 +82,18 @@ describe('CSS_PATTERNS', () => {
       ]);
     });
 
+    test('matches width with vh values', () => {
+      expect('width: 100vh'.match(CSS_PATTERNS.spacingPx)).toEqual([
+        'width: 100vh',
+      ]);
+    });
+
+    test('matches height with vw values', () => {
+      expect('height: 50vw'.match(CSS_PATTERNS.spacingPx)).toEqual([
+        'height: 50vw',
+      ]);
+    });
+
     test('does not match padding or margin (handled by spacingShorthand)', () => {
       expect('padding: 8px'.match(CSS_PATTERNS.spacingPx)).toBeNull();
       expect('margin: 1rem'.match(CSS_PATTERNS.spacingPx)).toBeNull();
@@ -122,6 +134,18 @@ describe('CSS_PATTERNS', () => {
       expect(
         'padding: 8px 16px 8px'.match(CSS_PATTERNS.spacingShorthand),
       ).toEqual(['padding: 8px 16px 8px']);
+    });
+
+    test('matches margin with vh values', () => {
+      expect('margin: 5vh'.match(CSS_PATTERNS.spacingShorthand)).toEqual([
+        'margin: 5vh',
+      ]);
+    });
+
+    test('matches margin with vw values', () => {
+      expect('margin: 5vw'.match(CSS_PATTERNS.spacingShorthand)).toEqual([
+        'margin: 5vw',
+      ]);
     });
   });
 
@@ -194,6 +218,12 @@ describe('CSS_PATTERNS', () => {
       ).toEqual(['border-radius: 4px 8px 4px 8px']);
     });
 
+    test('matches border-radius with percentage', () => {
+      expect('border-radius: 50%'.match(CSS_PATTERNS.borderRadius)).toEqual([
+        'border-radius: 50%',
+      ]);
+    });
+
     test('does not match invalid border-radius values', () => {
       expect(
         'border-radius: inherit'.match(CSS_PATTERNS.borderRadius),
@@ -255,6 +285,33 @@ describe('CSS_PATTERNS', () => {
     });
   });
 
+  describe('boxShadowBare', () => {
+    test('matches box-shadow with single hardcoded value', () => {
+      expect('box-shadow: 6px'.match(CSS_PATTERNS.boxShadowBare)).toEqual([
+        'box-shadow: 6px',
+      ]);
+    });
+
+    test('matches box-shadow with multiple hardcoded values', () => {
+      expect('box-shadow: 2px 4px'.match(CSS_PATTERNS.boxShadowBare)).toEqual([
+        'box-shadow: 2px 4px',
+      ]);
+    });
+
+    test('does not match box-shadow: none', () => {
+      expect('box-shadow: none'.match(CSS_PATTERNS.boxShadowBare)).toBeNull();
+    });
+  });
+
+  describe('boxShadowMixed', () => {
+    test('matches box-shadow with mixed var() and hardcoded px values', () => {
+      const result = 'box-shadow: 0 var(--shadow-offset-md) 5px'.match(
+        CSS_PATTERNS.boxShadowMixed,
+      );
+      expect(result).toEqual(['box-shadow: 0 var(--shadow-offset-md) 5px']);
+    });
+  });
+
   describe('outlineWidth', () => {
     test('matches outline-width with px', () => {
       expect('outline-width: 2px'.match(CSS_PATTERNS.outlineWidth)).toEqual([
@@ -308,6 +365,18 @@ describe('TSX_PATTERNS', () => {
       expect(
         "marginInline: '1rem'".match(TSX_PATTERNS.spacingCamelCase),
       ).toEqual(["marginInline: '1rem'"]);
+    });
+
+    test('matches marginTop with vh value', () => {
+      expect("marginTop: '5vh'".match(TSX_PATTERNS.spacingCamelCase)).toEqual([
+        "marginTop: '5vh'",
+      ]);
+    });
+
+    test('matches paddingLeft with vw value', () => {
+      expect(
+        "paddingLeft: '10vw'".match(TSX_PATTERNS.spacingCamelCase),
+      ).toEqual(["paddingLeft: '10vw'"]);
     });
   });
 
@@ -384,6 +453,12 @@ describe('TSX_PATTERNS', () => {
       expect(
         "borderRadius: '4px'".match(TSX_PATTERNS.borderRadiusCamelCase),
       ).toEqual(["borderRadius: '4px'"]);
+    });
+
+    test('matches borderRadius with percentage value', () => {
+      expect(
+        "borderRadius: '50%'".match(TSX_PATTERNS.borderRadiusCamelCase),
+      ).toEqual(["borderRadius: '50%'"]);
     });
   });
 

--- a/src/test-utils/validate-tokens.test.ts
+++ b/src/test-utils/validate-tokens.test.ts
@@ -252,6 +252,48 @@ describe('validateFiles', () => {
     expect(result.some((r) => r.type === 'box-shadow')).toBe(true);
   });
 
+  test('detects bare hardcoded box-shadow values in CSS files', async () => {
+    readFileSyncMock.mockReturnValue('.test { box-shadow: 6px; }');
+
+    const result = await validateFiles('**/*.css', ['src/style/test.css']);
+
+    expect(result.some((r) => r.type === 'box-shadow')).toBe(true);
+  });
+
+  test('detects mixed var/hardcoded box-shadow values in CSS files', async () => {
+    readFileSyncMock.mockReturnValue(
+      '.test { box-shadow: 0 var(--shadow-offset-md) 5px; }',
+    );
+
+    const result = await validateFiles('**/*.css', ['src/style/test.css']);
+
+    expect(result.some((r) => r.type === 'box-shadow')).toBe(true);
+  });
+
+  test('detects border-radius with percentage values in CSS files', async () => {
+    readFileSyncMock.mockReturnValue('.test { border-radius: 50%; }');
+
+    const result = await validateFiles('**/*.css', ['src/style/test.css']);
+
+    expect(result.some((r) => r.type === 'border-radius')).toBe(true);
+  });
+
+  test('detects vh/vw spacing values in CSS files', async () => {
+    readFileSyncMock.mockReturnValue('.test { margin: 5vw; }');
+
+    const result = await validateFiles('**/*.css', ['src/style/test.css']);
+
+    expect(result.some((r) => r.type === 'spacing')).toBe(true);
+  });
+
+  test('allows margin with percentage values in CSS files', async () => {
+    readFileSyncMock.mockReturnValue('.test { margin: 5%; }');
+
+    const result = await validateFiles('**/*.css', ['src/style/test.css']);
+
+    expect(result.some((r) => r.type === 'spacing')).toBe(false);
+  });
+
   test('detects hardcoded outline in CSS files', async () => {
     readFileSyncMock.mockReturnValue('.test { outline: 2px solid #000; }');
 

--- a/src/test-utils/validate-tokens.test.ts
+++ b/src/test-utils/validate-tokens.test.ts
@@ -244,12 +244,14 @@ describe('validateFiles', () => {
     expect(result[0].type).toBe('border-radius');
   });
 
-  test('detects hardcoded box-shadow in CSS files', async () => {
+  test('detects hardcoded box-shadow in CSS files without duplicate box-shadow findings', async () => {
     readFileSyncMock.mockReturnValue('.test { box-shadow: 2px 4px 8px #000; }');
 
     const result = await validateFiles('**/*.css', ['src/style/test.css']);
+    const boxShadowResults = result.filter((r) => r.type === 'box-shadow');
 
-    expect(result.some((r) => r.type === 'box-shadow')).toBe(true);
+    expect(boxShadowResults).toHaveLength(1);
+    expect(boxShadowResults[0].match).toBe('box-shadow: 2px 4px 8px #000');
   });
 
   test('detects bare hardcoded box-shadow values in CSS files', async () => {


### PR DESCRIPTION
**What kind of change does this PR introduce?**

There were some units and values that were not flagged by the validate-tokens lint,
This PR fixes that to flag every hardcoded values in the style sheets.

**Issue Number: #7163**

<!--Add related issue number here.-->
Fixes #7163

**Snapshots/Videos:**
<img width="1057" height="377" alt="Screenshot 2026-02-11 at 8 44 22 PM" src="https://github.com/user-attachments/assets/a579970f-1396-43fc-b811-e4cbf97c1408" />

**Summary**

The tokens mentioned in the issue are now flagged as shown in the screenshot.
The validation for the box shadow and some units have been added.
The new tests for all the added features have also been added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for viewport-relative units (vh/vw) in spacing and dimension validation.
  * Recognition of percentage values for border-radius.
  * Improved box-shadow detection for hardcoded and mixed hardcoded/variable cases, with duplicate findings avoided.
  * Percentage values allowed in spacing contexts where applicable.

* **Tests**
  * Expanded test coverage for the new patterns and behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->