### PR TITLE
fix(GroupChatDetails): add descriptive alt text to group chat avatar

### DIFF
--- a/src/components/GroupChatDetails/GroupChatDetails.spec.tsx
+++ b/src/components/GroupChatDetails/GroupChatDetails.spec.tsx
@@ -172,6 +172,59 @@ describe('GroupChatDetails', () => {
     fireEvent.click(closeButton);
   });
 
+  it('should have descriptive alt text for group chat avatar', () => {
+    useLocalStorage().setItem('userId', 'user1');
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <GroupChatDetails
+            toggleGroupChatDetailsModal={vi.fn()}
+            groupChatDetailsModalisOpen={true}
+            chat={withSafeChat(filledMockChat)}
+            chatRefetch={vi.fn()}
+          />
+        </MockedProvider>
+      </I18nextProvider>,
+    );
+
+    const avatarImage = screen.getByRole('img');
+    expect(avatarImage).toBeInTheDocument();
+    expect(avatarImage).toHaveAttribute(
+      'alt',
+      'Group chat avatar for Test Group',
+    );
+  });
+
+  it('should have fallback alt text when chat name is empty', () => {
+    useLocalStorage().setItem('userId', 'user1');
+
+    const chatWithoutName = {
+      ...filledMockChat,
+      name: '',
+    };
+
+    render(
+      <I18nextProvider i18n={i18n}>
+        <MockedProvider mocks={mocks} addTypename={false}>
+          <GroupChatDetails
+            toggleGroupChatDetailsModal={vi.fn()}
+            groupChatDetailsModalisOpen={true}
+            chat={withSafeChat(chatWithoutName)}
+            chatRefetch={vi.fn()}
+          />
+        </MockedProvider>
+      </I18nextProvider>,
+    );
+
+    const avatarImage = screen.getByRole('img');
+    expect(avatarImage).toBeInTheDocument();
+    expect(avatarImage).toHaveAttribute(
+      'alt',
+      'Group chat avatar for this group',
+    );
+  });
+
   it('cancelling editing chat title', async () => {
     useLocalStorage().setItem('userId', '2');
 

--- a/src/components/GroupChatDetails/GroupChatDetails.tsx
+++ b/src/components/GroupChatDetails/GroupChatDetails.tsx
@@ -307,7 +307,11 @@ export default function groupChatDetails({
           />
           <div className={styles.groupInfo}>
             {chat?.avatarURL ? (
-              <img className={styles.chatImage} src={chat?.avatarURL} alt="" />
+              <img
+                className={styles.chatImage}
+                src={chat?.avatarURL}
+                alt={`Group chat avatar for ${chat?.name?.trim() || 'this group'}`}
+              />
             ) : (
               <Avatar avatarStyle={styles.groupImage} name={chat.name || ''} />
             )}


### PR DESCRIPTION
## 🐛 Problem

The group chat avatar image in `GroupChatDetails` was rendered with an empty `alt` attribute (`alt=""`).

Since the avatar conveys meaningful information (the identity of the group), this does not comply with **WCAG 2.1 – Success Criterion 1.1.1 (Non-text Content)**.  
Screen reader users would only hear "image" without any contextual information.

---

## ✅ Solution

Replaced the empty `alt` attribute with descriptive alternative text that:

- Includes the group chat name when available
- Provides a safe fallback when the name is undefined or empty
- Handles whitespace-only values using `.trim()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility for group chat avatars: Avatar images now include descriptive alt text to better support screen reader users. The alt text displays the specific group name when available, or defaults to generic text if the group name is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->