### PR TITLE
refactor: migrate NotificationToast imports to shared-components (Batch 1)

### DIFF
--- a/docs/docs/auto-docs/components/AdminPortal/Advertisements/core/AdvertisementEntry/AdvertisementEntry/functions/default.md
+++ b/docs/docs/auto-docs/components/AdminPortal/Advertisements/core/AdvertisementEntry/AdvertisementEntry/functions/default.md
@@ -6,7 +6,7 @@
 
 > **default**(`__namedParameters`): `Element`
 
-Defined in: [src/components/AdminPortal/Advertisements/core/AdvertisementEntry/AdvertisementEntry.tsx:55](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/AdminPortal/Advertisements/core/AdvertisementEntry/AdvertisementEntry.tsx#L55)
+Defined in: [src/components/AdminPortal/Advertisements/core/AdvertisementEntry/AdvertisementEntry.tsx:56](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/AdminPortal/Advertisements/core/AdvertisementEntry/AdvertisementEntry.tsx#L56)
 
 ## Parameters
 

--- a/docs/docs/auto-docs/components/UsersTableItem/UsersTableItem/functions/default.md
+++ b/docs/docs/auto-docs/components/UsersTableItem/UsersTableItem/functions/default.md
@@ -6,7 +6,7 @@
 
 > **default**(`props`): `Element`
 
-Defined in: [src/components/UsersTableItem/UsersTableItem.tsx:34](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/UsersTableItem/UsersTableItem.tsx#L34)
+Defined in: [src/components/UsersTableItem/UsersTableItem.tsx:35](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/UsersTableItem/UsersTableItem.tsx#L35)
 
 ## Parameters
 

--- a/docs/docs/auto-docs/shared-components/posts/createPostModal/createPostModal/functions/default.md
+++ b/docs/docs/auto-docs/shared-components/posts/createPostModal/createPostModal/functions/default.md
@@ -6,7 +6,7 @@
 
 > **default**(`__namedParameters`): `Element`
 
-Defined in: [src/shared-components/posts/createPostModal/createPostModal.tsx:33](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/shared-components/posts/createPostModal/createPostModal.tsx#L33)
+Defined in: [src/shared-components/posts/createPostModal/createPostModal.tsx:34](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/shared-components/posts/createPostModal/createPostModal.tsx#L34)
 
 ## Parameters
 

--- a/docs/docs/auto-docs/utils/useSession/functions/default.md
+++ b/docs/docs/auto-docs/utils/useSession/functions/default.md
@@ -6,7 +6,7 @@
 
 > **default**(): `UseSessionReturnType`
 
-Defined in: [src/utils/useSession.tsx:32](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/useSession.tsx#L32)
+Defined in: [src/utils/useSession.tsx:31](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/utils/useSession.tsx#L31)
 
 Custom hook for managing user session timeouts in a React application.
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,7 @@ import UserScreen from 'screens/UserPortal/UserScreen/UserScreen';
 import UserGlobalScreen from 'screens/UserPortal/UserGlobalScreen/UserGlobalScreen';
 import LoadingState from 'shared-components/LoadingState/LoadingState';
 import PageNotFound from 'screens/Public/PageNotFound/PageNotFound';
-import { NotificationToastContainer } from 'components/NotificationToast/NotificationToast';
+import { NotificationToastContainer } from 'shared-components/NotificationToast/NotificationToast';
 import { useTranslation } from 'react-i18next';
 import { ErrorBoundaryWrapper } from 'shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper';
 

--- a/src/components/AdminPortal/AddPeopleToTag/AddPeopleToTag.spec.tsx
+++ b/src/components/AdminPortal/AddPeopleToTag/AddPeopleToTag.spec.tsx
@@ -20,7 +20,7 @@ import {
   MOCKS_ERROR,
 } from './AddPeopleToTagsMocks';
 import type { TFunction } from 'i18next';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 
 const link = new StaticMockLink(MOCKS, true);
 const link2 = new StaticMockLink(MOCKS_ERROR, true);
@@ -42,7 +42,7 @@ const toastMocks = vi.hoisted(() => {
   };
 });
 
-vi.mock('components/NotificationToast/NotificationToast', async () => {
+vi.mock('shared-components/NotificationToast/NotificationToast', async () => {
   return {
     NotificationToast: toastMocks,
   };

--- a/src/components/AdminPortal/AddPeopleToTag/AddPeopleToTag.tsx
+++ b/src/components/AdminPortal/AddPeopleToTag/AddPeopleToTag.tsx
@@ -69,7 +69,7 @@ import {
 } from 'types/AdminPortal/Tag/utils';
 import SearchBar from 'shared-components/SearchBar/SearchBar';
 import { ErrorBoundaryWrapper } from 'shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 
 const GRID_COLUMN_MIN_WIDTH = 100;
 

--- a/src/components/AdminPortal/Advertisements/Advertisements.module.css
+++ b/src/components/AdminPortal/Advertisements/Advertisements.module.css
@@ -1,0 +1,56 @@
+.containerAdvertisements {
+  background-color: var(--containerAdvertisemens-bg);
+  border-radius: var(--radius-xl);
+  width: auto;
+  margin-inline-start: var(--space-4);
+}
+
+.pMessageAdvertisement {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-medium);
+  line-height: 1.2;
+  padding-bottom: var(--space-7);
+}
+
+.justifyspAdvertisements {
+  display: grid;
+  width: 100%;
+  margin-top: var(--space-8);
+  grid-template-rows: auto;
+  grid-template-columns: repeat(6, 1fr);
+  grid-gap: var(--space-4) var(--space-3);
+}
+
+@media (max-width: 1024px) {
+  .justifyspAdvertisements {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.rowAdvertisements {
+  margin-top: var(--space-6);
+  display: grid;
+  width: 100%;
+  grid-template-rows: auto;
+  grid-gap: var(--space-4) var(--space-3);
+  overflow: hidden;
+}
+
+.colAdvertisements {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4);
+}
+
+.listBoxAdvertisements {
+  display: grid;
+  width: 100%;
+  grid-template-rows: auto;
+  grid-template-columns: repeat(6, 1fr);
+  grid-gap: var(--space-4) var(--space-3);
+}

--- a/src/components/AdminPortal/Advertisements/Advertisements.spec.tsx
+++ b/src/components/AdminPortal/Advertisements/Advertisements.spec.tsx
@@ -7,7 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { store } from 'state/store';
 import i18nForTest from 'utils/i18nForTest';
 import Advertisement from './Advertisements';
@@ -73,7 +73,7 @@ vi.mock('@apollo/client', async () => {
   };
 });
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     success: vi.fn(),
     error: vi.fn(),

--- a/src/components/AdminPortal/Advertisements/Advertisements.tsx
+++ b/src/components/AdminPortal/Advertisements/Advertisements.tsx
@@ -32,7 +32,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import styles from 'style/app-fixed.module.css';
+import styles from './Advertisements.module.css';
 import { useQuery } from '@apollo/client';
 import { ORGANIZATION_ADVERTISEMENT_LIST } from 'GraphQl/Queries/Queries';
 import { Col, Row, Tab, Tabs } from 'react-bootstrap';

--- a/src/components/AdminPortal/Advertisements/Advertisements.tsx
+++ b/src/components/AdminPortal/Advertisements/Advertisements.tsx
@@ -44,7 +44,7 @@ import InfiniteScroll from 'react-infinite-scroll-component';
 import type { Advertisement } from 'types/AdminPortal/Advertisement/type';
 import LoadingState from 'shared-components/LoadingState/LoadingState';
 import { AdvertisementSkeleton } from './skeleton/AdvertisementSkeleton';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import PageHeader from 'shared-components/Navbar/Navbar';
 import { ErrorBoundaryWrapper } from 'shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper';
 

--- a/src/components/AdminPortal/Advertisements/core/AdvertisementEntry/AdvertisementEntry.tsx
+++ b/src/components/AdminPortal/Advertisements/core/AdvertisementEntry/AdvertisementEntry.tsx
@@ -34,7 +34,7 @@
  * />
  * ```
  */
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styles from './AdvertisementEntry.module.css';
 import { Card, Col, Row, Carousel } from 'react-bootstrap';
@@ -51,6 +51,7 @@ import { ErrorBoundaryWrapper } from 'shared-components/ErrorBoundaryWrapper/Err
 import { BaseModal } from 'shared-components/BaseModal';
 import LoadingState from 'shared-components/LoadingState/LoadingState';
 import StatusBadge from 'shared-components/StatusBadge/StatusBadge';
+import { useModalState } from 'shared-components/CRUDModalTemplate/hooks/useModalState';
 
 function AdvertisementEntry({
   advertisement,
@@ -70,14 +71,14 @@ function AdvertisementEntry({
   const { t: tErrors } = useTranslation('errors');
 
   // State for loading button
-  const [buttonLoading, setButtonLoading] = useState(false);
+  const [buttonLoading, setButtonLoading] = React.useState(false);
 
   // State for dropdown menu visibility
-  const [dropdown, setDropdown] = useState(false);
+  const [dropdown, setDropdown] = React.useState(false);
   const dropdownRef = React.useRef<HTMLDivElement>(null);
 
   // State for delete confirmation modal visibility
-  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const deleteModal = useModalState();
 
   // Mutation hook for deleting an advertisement
   const [deleteAd] = useMutation(DELETE_ADVERTISEMENT_MUTATION, {
@@ -110,7 +111,7 @@ function AdvertisementEntry({
   /**
    * Toggles the visibility of the delete confirmation modal.
    */
-  const toggleShowDeleteModal = (): void => setShowDeleteModal((prev) => !prev);
+  const toggleShowDeleteModal = (): void => deleteModal.toggle();
 
   /**
    * Handles advertisement deletion.
@@ -183,14 +184,14 @@ function AdvertisementEntry({
           <Col key={idx}>
             <Card className={styles.addCard}>
               <div className={styles.dropdownContainer} ref={dropdownRef}>
-                <button
+                <Button
                   className={styles.dropdownButton}
                   onClick={() => setDropdown(!dropdown)}
                   data-testid="moreiconbtn"
                   data-cy="dropdownbtn"
                 >
                   <MoreVertIcon />
-                </button>
+                </Button>
                 {dropdown && (
                   <ul className={styles.dropdownmenu}>
                     <li>
@@ -343,7 +344,7 @@ function AdvertisementEntry({
                 </div>
 
                 <BaseModal
-                  show={showDeleteModal}
+                  show={deleteModal.isOpen}
                   onHide={toggleShowDeleteModal}
                   title={t('deleteAdvertisement')}
                   footer={deleteModalFooter}

--- a/src/components/AdminPortal/Advertisements/core/AdvertisementEntry/AdvertisementEntry.tsx
+++ b/src/components/AdminPortal/Advertisements/core/AdvertisementEntry/AdvertisementEntry.tsx
@@ -44,7 +44,7 @@ import { useMutation } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
 import AdvertisementRegister from '../AdvertisementRegister/AdvertisementRegister';
 import MoreVertIcon from '@mui/icons-material/MoreVert';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { Advertisement } from 'types/AdminPortal/Advertisement/type';
 import { ORGANIZATION_ADVERTISEMENT_LIST } from 'GraphQl/Queries/AdvertisementQueries';
 import { ErrorBoundaryWrapper } from 'shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper';

--- a/src/components/AdminPortal/Advertisements/core/AdvertisementRegister/AdvertisementRegister.spec.tsx
+++ b/src/components/AdminPortal/Advertisements/core/AdvertisementRegister/AdvertisementRegister.spec.tsx
@@ -6,7 +6,7 @@ import { Provider } from 'react-redux';
 import { store } from 'state/store';
 import { I18nextProvider } from 'react-i18next';
 import { MockedProvider } from '@apollo/client/testing';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import userEvent from '@testing-library/user-event';
 import { vi, it } from 'vitest';
 import {
@@ -37,7 +37,7 @@ vi.mock('react-router', async () => {
 
 global.URL.createObjectURL = vi.fn(() => 'mocked-url');
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     success: vi.fn(),
     error: vi.fn(),

--- a/src/components/AdminPortal/Advertisements/core/AdvertisementRegister/AdvertisementRegister.tsx
+++ b/src/components/AdminPortal/Advertisements/core/AdvertisementRegister/AdvertisementRegister.tsx
@@ -53,7 +53,7 @@ import {
 } from 'GraphQl/Mutations/mutations';
 import { useMutation } from '@apollo/client';
 import { useTranslation } from 'react-i18next';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import { ORGANIZATION_ADVERTISEMENT_LIST } from 'GraphQl/Queries/Queries';

--- a/src/components/AdminPortal/EventManagement/EventRegistrant/EventRegistrants.spec.tsx
+++ b/src/components/AdminPortal/EventManagement/EventRegistrant/EventRegistrants.spec.tsx
@@ -15,7 +15,7 @@ import { store } from 'state/store';
 import { StaticMockLink } from 'utils/StaticMockLink';
 import i18n from 'utils/i18nForTest';
 import { vi } from 'vitest';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { ProfileAvatarDisplay } from 'shared-components/ProfileAvatarDisplay/ProfileAvatarDisplay';
 
 import {
@@ -34,7 +34,7 @@ import {
 } from 'GraphQl/Queries/Queries';
 
 // Mock NotificationToast
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     success: vi.fn(),
     error: vi.fn(),

--- a/src/components/AdminPortal/EventManagement/EventRegistrant/EventRegistrants.tsx
+++ b/src/components/AdminPortal/EventManagement/EventRegistrant/EventRegistrants.tsx
@@ -49,9 +49,9 @@ import { CheckInWrapper } from 'shared-components/CheckIn/CheckInWrapper';
 import type { InterfaceUserAttendee } from 'types/shared-components/User/interface';
 import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import DataTable from 'shared-components/DataTable/DataTable';
+import Button from 'shared-components/Button/Button';
 import { IColumnDef } from 'types/shared-components/DataTable/interface';
 import { ErrorBoundaryWrapper } from 'shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper';
-import Button from 'shared-components/Button/Button';
 
 function EventRegistrants(): JSX.Element {
   const { t } = useTranslation('translation', { keyPrefix: 'eventRegistrant' });

--- a/src/components/AdminPortal/EventManagement/EventRegistrant/EventRegistrants.tsx
+++ b/src/components/AdminPortal/EventManagement/EventRegistrant/EventRegistrants.tsx
@@ -47,7 +47,7 @@ import { useParams } from 'react-router';
 import { EventRegistrantsWrapper } from 'components/AdminPortal/EventRegistrantsModal/EventRegistrantsWrapper';
 import { CheckInWrapper } from 'shared-components/CheckIn/CheckInWrapper';
 import type { InterfaceUserAttendee } from 'types/shared-components/User/interface';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import DataTable from 'shared-components/DataTable/DataTable';
 import { IColumnDef } from 'types/shared-components/DataTable/interface';
 import { ErrorBoundaryWrapper } from 'shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper';

--- a/src/components/AdminPortal/EventRegistrantsModal/EventRegistrantsWrapper.spec.tsx
+++ b/src/components/AdminPortal/EventRegistrantsModal/EventRegistrantsWrapper.spec.tsx
@@ -8,7 +8,7 @@ import { Provider } from 'react-redux';
 import { store } from 'state/store';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from 'utils/i18nForTest';
-import { NotificationToastContainer } from 'components/NotificationToast/NotificationToast';
+import { NotificationToastContainer } from 'shared-components/NotificationToast/NotificationToast';
 import userEvent from '@testing-library/user-event';
 import {
   LocalizationProvider,

--- a/src/components/AdminPortal/EventRegistrantsModal/Modal/AddOnSpot/AddOnSpotAttendee.spec.tsx
+++ b/src/components/AdminPortal/EventRegistrantsModal/Modal/AddOnSpot/AddOnSpotAttendee.spec.tsx
@@ -21,7 +21,7 @@ const sharedMocks = vi.hoisted(() => ({
   useParams: vi.fn(),
 }));
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: sharedMocks.NotificationToast,
 }));
 

--- a/src/components/AdminPortal/EventRegistrantsModal/Modal/AddOnSpot/AddOnSpotAttendee.tsx
+++ b/src/components/AdminPortal/EventRegistrantsModal/Modal/AddOnSpot/AddOnSpotAttendee.tsx
@@ -47,7 +47,7 @@ import type {
 import { useTranslation } from 'react-i18next';
 import { errorHandler } from 'utils/errorHandler';
 import LoadingState from 'shared-components/LoadingState/LoadingState';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { ErrorBoundaryWrapper } from 'shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper';
 
 const AddOnSpotAttendee: React.FC<InterfaceAddOnSpotAttendeeProps> = ({

--- a/src/components/AdminPortal/EventRegistrantsModal/Modal/AddOnSpot/AddOnSpotAttendee.tsx
+++ b/src/components/AdminPortal/EventRegistrantsModal/Modal/AddOnSpot/AddOnSpotAttendee.tsx
@@ -36,7 +36,7 @@ import {
   FormTextField,
   FormSelectField,
 } from 'shared-components/FormFieldGroup/FormFieldGroup';
-import { BaseModal } from 'shared-components/BaseModal';
+import { CRUDModalTemplate } from 'shared-components/CRUDModalTemplate/CRUDModalTemplate';
 import styles from './AddOnSpotAttendee.module.css';
 import { useParams } from 'react-router';
 import { useMutation } from '@apollo/client';
@@ -46,7 +46,7 @@ import type {
 } from 'types/AdminPortal/EventRegistrantsModal/AddOnSpot';
 import { useTranslation } from 'react-i18next';
 import { errorHandler } from 'utils/errorHandler';
-import LoadingState from 'shared-components/LoadingState/LoadingState';
+
 import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { ErrorBoundaryWrapper } from 'shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper';
 
@@ -131,13 +131,13 @@ const AddOnSpotAttendee: React.FC<InterfaceAddOnSpotAttendeeProps> = ({
       resetButtonAriaLabel={tErrors('resetButtonAriaLabel')}
       resetButtonText={tErrors('resetButton')}
     >
-      <BaseModal
-        show={show}
-        onHide={handleClose}
-        backdrop="static"
+      <CRUDModalTemplate
+        open={show}
+        onClose={handleClose}
         centered={true}
-        headerClassName={styles.modalHeader}
         title={t('title')}
+        loading={isSubmitting}
+        showFooter={false}
       >
         <form onSubmit={handleSubmit} data-testid="onspot-attendee-form">
           <div className="d-flex justify-content-between">
@@ -193,18 +193,15 @@ const AddOnSpotAttendee: React.FC<InterfaceAddOnSpotAttendeeProps> = ({
             <option value="Other">{t('other')}</option>
           </FormSelectField>
           <br />
-          <LoadingState isLoading={isSubmitting} variant="inline">
-            <Button
-              variant="success"
-              type="submit"
-              className={`border-1 mx-4 ${styles.addButton}`}
-              disabled={isSubmitting}
-            >
-              {t('addAttendee')}
-            </Button>
-          </LoadingState>
+          <Button
+            type="submit"
+            className={`btn btn-success border-1 mx-4 ${styles.addButton}`}
+            disabled={isSubmitting}
+          >
+            {t('addAttendee')}
+          </Button>
         </form>
-      </BaseModal>
+      </CRUDModalTemplate>
     </ErrorBoundaryWrapper>
   );
 };

--- a/src/components/AdminPortal/EventRegistrantsModal/Modal/EventRegistrantsModal.spec.tsx
+++ b/src/components/AdminPortal/EventRegistrantsModal/Modal/EventRegistrantsModal.spec.tsx
@@ -25,7 +25,7 @@ import {
   EVENT_DETAILS,
 } from 'GraphQl/Queries/Queries';
 import { ADD_EVENT_ATTENDEE } from 'GraphQl/Mutations/mutations';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import userEvent from '@testing-library/user-event';
 import {
   InterfaceBaseModalProps,
@@ -101,7 +101,7 @@ vi.mock('./InviteByEmail/InviteByEmailModal', () => ({
 }));
 
 // Mock NotificationToast
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     success: vi.fn(),
     error: vi.fn(),

--- a/src/components/AdminPortal/EventRegistrantsModal/Modal/EventRegistrantsModal.tsx
+++ b/src/components/AdminPortal/EventRegistrantsModal/Modal/EventRegistrantsModal.tsx
@@ -55,7 +55,7 @@ import AddOnSpotAttendee from './AddOnSpot/AddOnSpotAttendee';
 import InviteByEmailModal from './InviteByEmail/InviteByEmailModal';
 import type { InterfaceUser } from 'types/shared-components/User/interface';
 import styles from './EventRegistrantsModal.module.css';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { BaseModal } from 'shared-components/BaseModal';
 import { ErrorBoundaryWrapper } from 'shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper';
 import { InterfaceEventRegistrantsModalProps } from 'types/AdminPortal/EventRegistrantsModal/interface';

--- a/src/components/AdminPortal/EventRegistrantsModal/Modal/InviteByEmail/InviteByEmailModal.spec.tsx
+++ b/src/components/AdminPortal/EventRegistrantsModal/Modal/InviteByEmail/InviteByEmailModal.spec.tsx
@@ -8,9 +8,9 @@ import i18nForTest from 'utils/i18nForTest';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';
 import { SEND_EVENT_INVITATIONS } from 'GraphQl/Mutations/mutations';
 import dayjs from 'dayjs';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     error: vi.fn(),
     success: vi.fn(),

--- a/src/components/AdminPortal/EventRegistrantsModal/Modal/InviteByEmail/InviteByEmailModal.tsx
+++ b/src/components/AdminPortal/EventRegistrantsModal/Modal/InviteByEmail/InviteByEmailModal.tsx
@@ -26,7 +26,7 @@ import { SEND_EVENT_INVITATIONS } from 'GraphQl/Mutations/mutations';
 import { useTranslation } from 'react-i18next';
 import type { ApolloError } from '@apollo/client/errors';
 import LoadingState from 'shared-components/LoadingState/LoadingState';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import styles from './InviteByEmailModal.module.css';
 import type { InterfaceInviteByEmailModalProps } from 'types/AdminPortal/EventRegistrantsModal/InviteByEmail/interface';
 

--- a/src/components/AdminPortal/OrgPeopleListCard/OrgPeopleListCard.spec.tsx
+++ b/src/components/AdminPortal/OrgPeopleListCard/OrgPeopleListCard.spec.tsx
@@ -9,9 +9,9 @@ import { REMOVE_MEMBER_MUTATION_PG } from 'GraphQl/Mutations/mutations';
 import i18nForTest from 'utils/i18nForTest';
 import { StaticMockLink } from 'utils/StaticMockLink';
 import { describe, test, expect, vi, beforeEach } from 'vitest';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     success: vi.fn(),
     error: vi.fn(),

--- a/src/components/AdminPortal/OrgPeopleListCard/OrgPeopleListCard.tsx
+++ b/src/components/AdminPortal/OrgPeopleListCard/OrgPeopleListCard.tsx
@@ -33,7 +33,7 @@ import React from 'react';
 import BaseModal from 'shared-components/BaseModal/BaseModal';
 import Button from 'shared-components/Button';
 import { useMutation } from '@apollo/client';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { useTranslation } from 'react-i18next';
 import { REMOVE_MEMBER_MUTATION_PG } from 'GraphQl/Mutations/mutations';
 import { useParams, Navigate } from 'react-router';

--- a/src/components/AdminPortal/OrgSettings/ActionItemCategories/Modal/ActionItemCategoryModal.spec.tsx
+++ b/src/components/AdminPortal/OrgSettings/ActionItemCategories/Modal/ActionItemCategoryModal.spec.tsx
@@ -13,7 +13,7 @@ import type { ApolloLink } from '@apollo/client';
 import { MOCKS, MOCKS_ERROR } from '../OrgActionItemCategoryMocks';
 import type { IActionItemCategoryModal } from './ActionItemCategoryModal';
 import CategoryModal from './ActionItemCategoryModal';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { it, vi, describe, beforeEach } from 'vitest';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -33,7 +33,7 @@ dayjs.extend(utc);
  * - 100% code coverage including all conditional branches
  */
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     success: vi.fn(),
     error: vi.fn(),

--- a/src/components/AdminPortal/OrgSettings/ActionItemCategories/Modal/ActionItemCategoryModal.tsx
+++ b/src/components/AdminPortal/OrgSettings/ActionItemCategories/Modal/ActionItemCategoryModal.tsx
@@ -12,7 +12,7 @@ import {
   UPDATE_ACTION_ITEM_CATEGORY_MUTATION,
   DELETE_ACTION_ITEM_CATEGORY_MUTATION,
 } from 'GraphQl/Mutations/ActionItemCategoryMutations';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { ErrorBoundaryWrapper } from 'shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper';
 
 export interface IActionItemCategoryModal {

--- a/src/components/AdminPortal/OrgSettings/General/DeleteOrg/DeleteOrg.spec.tsx
+++ b/src/components/AdminPortal/OrgSettings/General/DeleteOrg/DeleteOrg.spec.tsx
@@ -6,6 +6,7 @@ import type { DocumentNode } from '@apollo/client';
 import { useMutation, useQuery } from '@apollo/client';
 import useLocalStorage from 'utils/useLocalstorage';
 import DeleteOrg from './DeleteOrg';
+
 import { errorHandler } from 'utils/errorHandler';
 import { describe, beforeEach, it, expect, vi, type Mock } from 'vitest';
 import {
@@ -46,7 +47,7 @@ vi.mock('utils/useLocalstorage', () => ({
   })),
 }));
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     success: vi.fn(),
     error: vi.fn(),

--- a/src/components/AdminPortal/OrganizationScreen/OrganizationScreen.spec.tsx
+++ b/src/components/AdminPortal/OrganizationScreen/OrganizationScreen.spec.tsx
@@ -33,7 +33,7 @@ const toastMocks = vi.hoisted(() => {
   };
 });
 
-vi.mock('components/NotificationToast/NotificationToast', async () => {
+vi.mock('shared-components/NotificationToast/NotificationToast', async () => {
   return {
     NotificationToast: toastMocks,
   };

--- a/src/components/AdminPortal/OrganizationScreen/OrganizationScreen.tsx
+++ b/src/components/AdminPortal/OrganizationScreen/OrganizationScreen.tsx
@@ -39,7 +39,7 @@ import type { InterfaceMapType } from 'utils/interfaces';
 import { useQuery } from '@apollo/client';
 import { GET_ORGANIZATION_EVENTS_PG } from 'GraphQl/Queries/Queries';
 import useLocalStorage from 'utils/useLocalstorage';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 
 const OrganizationScreen = (): JSX.Element => {
   const { getItem, setItem } = useLocalStorage();

--- a/src/components/AdminPortal/SecuredRoute/SecuredRoute.tsx
+++ b/src/components/AdminPortal/SecuredRoute/SecuredRoute.tsx
@@ -26,7 +26,7 @@
 import React, { useEffect, useRef } from 'react';
 import { Navigate, Outlet } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import PageNotFound from 'screens/Public/PageNotFound/PageNotFound';
 import useLocalStorage from 'utils/useLocalstorage';
 

--- a/src/components/AdminPortal/SecuredRoute/securedRoute.spec.tsx
+++ b/src/components/AdminPortal/SecuredRoute/securedRoute.spec.tsx
@@ -4,9 +4,9 @@ import { render, screen } from '@testing-library/react';
 import { vi, beforeEach, afterEach, describe, it, expect } from 'vitest';
 import SecuredRoute from './SecuredRoute';
 import useLocalStorage from 'utils/useLocalstorage';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     warning: vi.fn(),
     // Backward-compat in case any older code/tests still assert `warn`

--- a/src/components/AdminPortal/TagActions/TagActions.spec.tsx
+++ b/src/components/AdminPortal/TagActions/TagActions.spec.tsx
@@ -20,7 +20,7 @@ import {
   MOCKS_ERROR_SUBTAGS_QUERY,
 } from './TagActionsMocks';
 import type { TFunction } from 'i18next';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 
 const link1 = new StaticMockLink(MOCKS, true);
 const link2 = new StaticMockLink(MOCKS_ERROR_SUBTAGS_QUERY, true);
@@ -33,7 +33,7 @@ async function wait(ms = 500): Promise<void> {
   });
 }
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     error: vi.fn(),
     success: vi.fn(),

--- a/src/components/AdminPortal/TagActions/TagActions.tsx
+++ b/src/components/AdminPortal/TagActions/TagActions.tsx
@@ -47,7 +47,7 @@ import {
 } from 'GraphQl/Mutations/TagMutations';
 import { TAGS_QUERY_DATA_CHUNK_SIZE } from 'utils/organizationTagsUtils';
 import TagNode from './Node/TagNode';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { CursorPaginationManager } from 'components/CursorPaginationManager/CursorPaginationManager';
 import InfiniteScrollLoader from 'shared-components/InfiniteScrollLoader/InfiniteScrollLoader';
 import type { InterfaceTagActionsProps } from 'types/AdminPortal/TagActions/interface';

--- a/src/components/AdminPortal/TagActions/TagActions.tsx
+++ b/src/components/AdminPortal/TagActions/TagActions.tsx
@@ -36,7 +36,7 @@ import type { FormEvent } from 'react';
 import React, { useEffect, useState } from 'react';
 import Button from 'shared-components/Button';
 import SearchBar from 'shared-components/SearchBar/SearchBar';
-import BaseModal from 'shared-components/BaseModal/BaseModal';
+import { CRUDModalTemplate } from 'shared-components/CRUDModalTemplate/CRUDModalTemplate';
 import { useParams } from 'react-router';
 import type { InterfaceTagData } from 'utils/interfaces';
 import styles from './TagActions.module.css';
@@ -238,38 +238,17 @@ const TagActions: React.FC<InterfaceTagActionsProps> = ({
 
   return (
     <>
-      <BaseModal
-        show={tagActionsModalIsOpen}
-        onHide={hideTagActionsModal}
-        backdrop="static"
+      <CRUDModalTemplate
+        open={tagActionsModalIsOpen}
+        onClose={hideTagActionsModal}
         centered
         title={
           tagActionType === 'assignToTags'
             ? t('assignToTags')
             : t('removeFromTags')
         }
-        headerClassName={styles.modalHeader}
-        dataTestId="modalOrganizationHeader"
-        footer={
-          <>
-            <Button
-              className={`btn btn-danger ${styles.removeButton}`}
-              onClick={(): void => hideTagActionsModal()}
-              data-testid="closeTagActionsModalBtn"
-            >
-              {tCommon('cancel')}
-            </Button>
-            <Button
-              type="submit"
-              value="add"
-              form="tagActionForm"
-              data-testid="tagActionSubmitBtn"
-              className={`btn ${styles.addButton}`}
-            >
-              {tagActionType === 'assignToTags' ? t('assign') : t('remove')}
-            </Button>
-          </>
-        }
+        data-testid="modalOrganizationHeader"
+        showFooter={false}
       >
         <form id="tagActionForm" onSubmit={handleTagAction}>
           <div className="pb-0">
@@ -287,7 +266,7 @@ const TagActions: React.FC<InterfaceTagActionsProps> = ({
                     className={`badge bg-dark-subtle text-secondary-emphasis lh-lg my-2 ms-2 d-flex align-items-center ${styles.tagBadge}`}
                   >
                     {tag.name}
-                    <button
+                    <Button
                       className={`${styles.removeFilterIcon} fa fa-times ms-2 text-body-tertiary border-0 bg-transparent`}
                       onClick={() => deSelectTag(tag)}
                       data-testid={`clearSelectedTag${tag._id}`}
@@ -381,7 +360,25 @@ const TagActions: React.FC<InterfaceTagActionsProps> = ({
             </ul>
           </div>
         </form>
-      </BaseModal>
+        <div className="d-flex justify-content-end gap-2 mt-3">
+          <Button
+            className={`btn btn-danger ${styles.removeButton}`}
+            onClick={(): void => hideTagActionsModal()}
+            data-testid="closeTagActionsModalBtn"
+          >
+            {tCommon('cancel')}
+          </Button>
+          <Button
+            type="submit"
+            value="add"
+            form="tagActionForm"
+            data-testid="tagActionSubmitBtn"
+            className={`btn ${styles.addButton}`}
+          >
+            {tagActionType === 'assignToTags' ? t('assign') : t('remove')}
+          </Button>
+        </div>
+      </CRUDModalTemplate>
     </>
   );
 };

--- a/src/components/AdminPortal/Venues/Modal/VenueModal.spec.tsx
+++ b/src/components/AdminPortal/Venues/Modal/VenueModal.spec.tsx
@@ -19,7 +19,7 @@ import {
   UPDATE_VENUE_MUTATION,
 } from 'GraphQl/Mutations/mutations';
 import { ApolloLink, Observable } from '@apollo/client';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 
 // Mock Setup
 const MOCKS = [
@@ -236,7 +236,7 @@ vi.mock('react-router-dom', async () => {
   return { ...actual, useParams: () => ({ orgId: mockId }) };
 });
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     success: vi.fn(),
     error: vi.fn(),

--- a/src/components/AdminPortal/Venues/Modal/VenueModal.spec.tsx
+++ b/src/components/AdminPortal/Venues/Modal/VenueModal.spec.tsx
@@ -1,7 +1,8 @@
 import React, { act } from 'react';
 import { MockedProvider } from '@apollo/react-testing';
 import type { RenderResult } from '@testing-library/react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter, MemoryRouter } from 'react-router-dom';
 import { I18nextProvider } from 'react-i18next';

--- a/src/components/AdminPortal/Venues/Modal/VenueModal.tsx
+++ b/src/components/AdminPortal/Venues/Modal/VenueModal.tsx
@@ -43,7 +43,7 @@ import {
   UPDATE_VENUE_MUTATION,
 } from 'GraphQl/Mutations/mutations';
 import { errorHandler } from 'utils/errorHandler';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { CRUDModalTemplate } from 'shared-components/CRUDModalTemplate/CRUDModalTemplate';
 import { InterfaceQueryVenueListItem } from 'utils/interfaces';
 

--- a/src/components/ChangeLanguageDropdown/ChangeLanguageDropDown.spec.tsx
+++ b/src/components/ChangeLanguageDropdown/ChangeLanguageDropDown.spec.tsx
@@ -28,7 +28,7 @@ const sharedMocks = vi.hoisted(() => ({
   },
 }));
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: sharedMocks.NotificationToast,
 }));
 

--- a/src/components/ChangeLanguageDropdown/ChangeLanguageDropDown.tsx
+++ b/src/components/ChangeLanguageDropdown/ChangeLanguageDropDown.tsx
@@ -23,7 +23,7 @@ import { UPDATE_CURRENT_USER_MUTATION } from 'GraphQl/Mutations/mutations';
 import { useMutation } from '@apollo/client';
 import useLocalStorage from 'utils/useLocalstorage';
 import { urlToFile } from 'utils/urlToFile';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { ErrorBoundaryWrapper } from 'shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper';
 import { useTranslation } from 'react-i18next';
 import DropDownButton from 'shared-components/DropDownButton';

--- a/src/components/EventStats/Statistics/AverageRating/AverageRating.spec.tsx
+++ b/src/components/EventStats/Statistics/AverageRating/AverageRating.spec.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import { store } from 'state/store';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from 'utils/i18nForTest';
-import { NotificationToastContainer } from 'components/NotificationToast/NotificationToast';
+import { NotificationToastContainer } from 'shared-components/NotificationToast/NotificationToast';
 import { vi, describe, expect, it } from 'vitest';
 import { nonEmptyProps } from '../../EventStatsMocks';
 

--- a/src/components/EventStats/Statistics/Feedback/Feedback.spec.tsx
+++ b/src/components/EventStats/Statistics/Feedback/Feedback.spec.tsx
@@ -1,6 +1,6 @@
 import { PieChart } from '@mui/x-charts/PieChart';
 import { render, waitFor } from '@testing-library/react';
-import { NotificationToastContainer } from 'components/NotificationToast/NotificationToast';
+import { NotificationToastContainer } from 'shared-components/NotificationToast/NotificationToast';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router';

--- a/src/components/UserPortal/SecuredRouteForUser/SecuredRouteForUser.spec.tsx
+++ b/src/components/UserPortal/SecuredRouteForUser/SecuredRouteForUser.spec.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { render, screen, cleanup } from '@testing-library/react';
 import { vi, beforeEach, afterEach, describe, it, expect } from 'vitest';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import SecuredRouteForUser from './SecuredRouteForUser';
 import userEvent from '@testing-library/user-event';
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: { warning: vi.fn() },
 }));
 

--- a/src/components/UserPortal/SecuredRouteForUser/SecuredRouteForUser.tsx
+++ b/src/components/UserPortal/SecuredRouteForUser/SecuredRouteForUser.tsx
@@ -28,7 +28,7 @@
 import React, { useCallback, useEffect, useRef } from 'react';
 import { Navigate, Outlet } from 'react-router';
 import { useTranslation } from 'react-i18next';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import PageNotFound from 'screens/Public/PageNotFound/PageNotFound';
 import useLocalStorage from 'utils/useLocalstorage';
 

--- a/src/components/UserPortal/UserPortalNavigationBar/UserPortalNavigationBar.tsx
+++ b/src/components/UserPortal/UserPortalNavigationBar/UserPortalNavigationBar.tsx
@@ -32,7 +32,7 @@ import { GET_ORGANIZATION_BASIC_DATA } from 'GraphQl/Queries/Queries';
 import NotificationIcon from 'components/NotificationIcon/NotificationIcon';
 import LanguageSelector from './LanguageSelector';
 import UserProfileDropdown from './UserDropdown';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 
 export const UserPortalNavigationBar = (
   props: InterfaceUserPortalNavbarProps,

--- a/src/components/UsersTableItem/UserTableItem.spec.tsx
+++ b/src/components/UsersTableItem/UserTableItem.spec.tsx
@@ -4,7 +4,7 @@ import utc from 'dayjs/plugin/utc';
 import { MockedProvider } from '@apollo/react-testing';
 import { render, screen, waitFor } from '@testing-library/react';
 import { I18nextProvider } from 'react-i18next';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { StaticMockLink } from 'utils/StaticMockLink';
 import i18nForTest from 'utils/i18nForTest';
 import type { InterfaceQueryUserListItemForAdmin } from 'utils/interfaces';
@@ -29,7 +29,7 @@ async function wait(ms = 100): Promise<void> {
   });
 }
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     success: vi.fn(),
     error: vi.fn(),

--- a/src/components/UsersTableItem/UsersTableItem.tsx
+++ b/src/components/UsersTableItem/UsersTableItem.tsx
@@ -18,7 +18,7 @@ import BaseModal from 'shared-components/BaseModal/BaseModal';
 import SearchBar from 'shared-components/SearchBar/SearchBar';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { errorHandler } from 'utils/errorHandler';
 import type { InterfaceQueryUserListItemForAdmin } from 'utils/interfaces';
 import styles from './UsersTableItem.module.css';

--- a/src/components/UsersTableItem/UsersTableItem.tsx
+++ b/src/components/UsersTableItem/UsersTableItem.tsx
@@ -23,6 +23,7 @@ import { errorHandler } from 'utils/errorHandler';
 import type { InterfaceQueryUserListItemForAdmin } from 'utils/interfaces';
 import styles from './UsersTableItem.module.css';
 import { ProfileAvatarDisplay } from 'shared-components/ProfileAvatarDisplay/ProfileAvatarDisplay';
+import { useModalState } from 'shared-components/CRUDModalTemplate/hooks/useModalState';
 
 type Props = {
   user: InterfaceQueryUserListItemForAdmin;
@@ -38,8 +39,8 @@ const UsersTableItem = (props: Props): JSX.Element => {
   const [showJoinedOrganizations, setShowJoinedOrganizations] = useState(false);
   const [showBlockedOrganizations, setShowBlockedOrganizations] =
     useState(false);
-  const [showRemoveUserModal, setShowRemoveUserModal] = useState(false);
-  const [showBlockedUserModal, setShowBlockedUserModal] = useState(false);
+  const removeUserModal = useModalState();
+  const blockedUserModal = useModalState();
   const [removeUserProps, setremoveUserProps] = useState<{
     orgName: string;
     orgId: string;
@@ -74,7 +75,7 @@ const UsersTableItem = (props: Props): JSX.Element => {
           tCommon('removedSuccessfully', { item: 'User' }) as string,
         );
         resetAndRefetch();
-        setShowRemoveUserModal(false);
+        removeUserModal.close();
       }
     } catch (error: unknown) {
       errorHandler(t, error);
@@ -91,7 +92,7 @@ const UsersTableItem = (props: Props): JSX.Element => {
           tCommon('unblockedSuccessfully', { item: 'User' }) as string,
         );
         resetAndRefetch();
-        setShowBlockedUserModal(false);
+        blockedUserModal.close();
         setShowBlockedOrganizations(true);
       }
     } catch (error: unknown) {
@@ -155,14 +156,14 @@ const UsersTableItem = (props: Props): JSX.Element => {
   };
 
   function onHideRemoveUserModal(): void {
-    setShowRemoveUserModal(false);
+    removeUserModal.close();
     if (removeUserProps.setShowOnCancel === 'JOINED') {
       setShowJoinedOrganizations(true);
     }
   }
 
   function onHideBlockUserModal(): void {
-    setShowBlockedUserModal(false);
+    blockedUserModal.close();
     if (removeUserProps.setShowOnCancel === 'Blocked') {
       setShowBlockedOrganizations(true);
     }
@@ -348,7 +349,7 @@ const UsersTableItem = (props: Props): JSX.Element => {
                                 setShowOnCancel: 'JOINED',
                               });
                               setShowJoinedOrganizations(false);
-                              setShowRemoveUserModal(true);
+                              removeUserModal.open();
                             }}
                           >
                             {tCommon('removeUser')}
@@ -364,7 +365,7 @@ const UsersTableItem = (props: Props): JSX.Element => {
         </Row>
       </BaseModal>
       <BaseModal
-        show={showRemoveUserModal}
+        show={removeUserModal.isOpen}
         key={`modal-remove-org-${index}`}
         dataTestId={`modal-remove-user-${user.id}`} // i18n-ignore-line
         onHide={() => onHideRemoveUserModal()}
@@ -512,7 +513,7 @@ const UsersTableItem = (props: Props): JSX.Element => {
                                 setShowOnCancel: 'Blocked',
                               });
                               setShowBlockedOrganizations(false);
-                              setShowBlockedUserModal(true);
+                              blockedUserModal.open();
                             }}
                           >
                             {tCommon('unblock')}
@@ -528,7 +529,7 @@ const UsersTableItem = (props: Props): JSX.Element => {
         </Row>
       </BaseModal>
       <BaseModal
-        show={showBlockedUserModal}
+        show={blockedUserModal.isOpen}
         key={`modal-unblock-user-${index}`}
         dataTestId={`modal-unblock-user-${user.id}`} // i18n-ignore-line
         onHide={() => onHideBlockUserModal()}

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -23,7 +23,7 @@ import {
   BACKEND_WEBSOCKET_URL,
   deriveBackendWebsocketUrl,
 } from 'Constant/constant';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import i18n from './utils/i18n';
 import { requestMiddleware, responseMiddleware } from 'utils/timezoneUtils';
 import createUploadLink from 'apollo-upload-client/createUploadLink.mjs';

--- a/src/index.spec.tsx
+++ b/src/index.spec.tsx
@@ -55,7 +55,7 @@ const getTestExpiredToken = (): string =>
 
 // Mock external dependencies
 vi.mock(
-  'components/NotificationToast/NotificationToast',
+  'shared-components/NotificationToast/NotificationToast',
   (): { NotificationToast: InterfaceNotificationToastMock } => ({
     NotificationToast: {
       error: vi.fn(),

--- a/src/shared-components/ActionItems/ActionItemDeleteModal/ActionItemDeleteModal.spec.tsx
+++ b/src/shared-components/ActionItems/ActionItemDeleteModal/ActionItemDeleteModal.spec.tsx
@@ -15,7 +15,7 @@ import { store } from 'state/store';
 import i18nForTest from '../../../utils/i18nForTest';
 import { MOCKS, MOCKS_ERROR } from '../ActionItem.mocks';
 import { StaticMockLink } from 'utils/StaticMockLink';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 dayjs.extend(utc);
@@ -23,7 +23,7 @@ import ItemDeleteModal, {
   type IItemDeleteModalProps,
 } from './ActionItemDeleteModal';
 import { vi, afterEach, beforeEach } from 'vitest';
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     success: vi.fn(),
     error: vi.fn(),

--- a/src/shared-components/ActionItems/ActionItemDeleteModal/ActionItemDeleteModal.tsx
+++ b/src/shared-components/ActionItems/ActionItemDeleteModal/ActionItemDeleteModal.tsx
@@ -34,7 +34,7 @@ import type {
   IActionItemInfo,
   IDeleteActionItemInput,
 } from 'types/shared-components/ActionItems/interface';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { DeleteModal } from 'shared-components/CRUDModalTemplate/DeleteModal';
 import { FormFieldGroup } from 'shared-components/FormFieldGroup/FormFieldGroup';
 

--- a/src/shared-components/CheckIn/CheckInWrapper.spec.tsx
+++ b/src/shared-components/CheckIn/CheckInWrapper.spec.tsx
@@ -7,7 +7,7 @@ import { Provider } from 'react-redux';
 import { store } from 'state/store';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from 'utils/i18nForTest';
-import { NotificationToastContainer } from 'components/NotificationToast/NotificationToast';
+import { NotificationToastContainer } from 'shared-components/NotificationToast/NotificationToast';
 import {
   LocalizationProvider,
   AdapterDayjs,

--- a/src/shared-components/CheckIn/Modal/Row/TableRow.spec.tsx
+++ b/src/shared-components/CheckIn/Modal/Row/TableRow.spec.tsx
@@ -6,7 +6,7 @@ import { Provider } from 'react-redux';
 import { store } from 'state/store';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from 'utils/i18nForTest';
-import { NotificationToastContainer } from 'components/NotificationToast/NotificationToast';
+import { NotificationToastContainer } from 'shared-components/NotificationToast/NotificationToast';
 import {
   LocalizationProvider,
   AdapterDayjs,

--- a/src/shared-components/CheckIn/Modal/Row/TableRow.tsx
+++ b/src/shared-components/CheckIn/Modal/Row/TableRow.tsx
@@ -31,7 +31,7 @@ import type { InterfaceTableCheckIn } from 'types/shared-components/CheckIn/inte
 import Button from '@mui/material/Button';
 import { useMutation } from '@apollo/client';
 import { MARK_CHECKIN } from 'GraphQl/Mutations/mutations';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { generate } from '@pdfme/generator';
 import { tagTemplate } from '../../tagTemplate';
 import { useTranslation } from 'react-i18next';

--- a/src/shared-components/CheckIn/Modal/Row/TableRow.tsx
+++ b/src/shared-components/CheckIn/Modal/Row/TableRow.tsx
@@ -28,7 +28,7 @@
  */
 import React from 'react';
 import type { InterfaceTableCheckIn } from 'types/shared-components/CheckIn/interface';
-import Button from '@mui/material/Button';
+import Button from 'shared-components/Button/Button';
 import { useMutation } from '@apollo/client';
 import { MARK_CHECKIN } from 'GraphQl/Mutations/mutations';
 import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
@@ -113,10 +113,10 @@ export const TableRow = ({
     >
       {data.isCheckedIn ? (
         <div>
-          <Button variant="contained" disabled className="m-2 p-2">
+          <Button variant="success" disabled className="m-2 p-2">
             {t('checkedIn')}
           </Button>
-          <Button variant="contained" className="m-2 p-2" onClick={notify}>
+          <Button variant="success" className="m-2 p-2" onClick={notify}>
             {t('downloadTag')}
           </Button>
         </div>

--- a/src/shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper.spec.tsx
+++ b/src/shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper.spec.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ErrorBoundaryWrapper } from './ErrorBoundaryWrapper';
 import type { InterfaceErrorFallbackProps } from 'types/shared-components/ErrorBoundaryWrapper/interface';
@@ -265,7 +265,8 @@ describe('ErrorBoundaryWrapper', () => {
       expect(screen.getByTestId('custom-reset')).toBeInTheDocument();
     });
 
-    it('custom fallback component receives error and onReset props', () => {
+    it('custom fallback component receives error and onReset props', async () => {
+      const user = userEvent.setup();
       const onResetSpy = vi.fn();
       const renderCustomFallbackComponent = ({
         error,
@@ -295,7 +296,7 @@ describe('ErrorBoundaryWrapper', () => {
       );
 
       const resetButton = screen.getByTestId('test-reset');
-      fireEvent.click(resetButton);
+      await user.click(resetButton);
 
       expect(onResetSpy).toHaveBeenCalledTimes(1);
     });

--- a/src/shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper.spec.tsx
+++ b/src/shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper.spec.tsx
@@ -4,9 +4,9 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ErrorBoundaryWrapper } from './ErrorBoundaryWrapper';
 import type { InterfaceErrorFallbackProps } from 'types/shared-components/ErrorBoundaryWrapper/interface';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     error: vi.fn(),
     success: vi.fn(),

--- a/src/shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper.tsx
+++ b/src/shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper.tsx
@@ -18,31 +18,31 @@
  * - Clear recovery actions
  *
  * @example
- * // Basic usage with default fallback
- * ```jsx
- * <ErrorBoundaryWrapper>
- *   <YourComponent />
- * </ErrorBoundaryWrapper>
+ * Basic usage with default fallback
+ * ```tsx
+ * <ErrorBoundaryWrapper\>
+ *   <YourComponent /\>
+ * </ErrorBoundaryWrapper\>
  * ```
  *
  * @example
- * // With custom error message and logging
- * ```jsx
+ * With custom error message and logging
+ * ```tsx
  * <ErrorBoundaryWrapper
- *   errorMessage={translatedErrorMessage}
- *   onError={(error, info) => logToService(error, info)}
- *   onReset={() => navigate('/dashboard')}
- * >
- *   <ComplexModal />
- * </ErrorBoundaryWrapper>
+ *   errorMessage=\{translatedErrorMessage\}
+ *   onError=\{(error, info) =\> logToService(error, info)\}
+ *   onReset=\{() =\> navigate('/dashboard')\}
+ * \>
+ *   <ComplexModal /\>
+ * </ErrorBoundaryWrapper\>
  * ```
  *
  * @example
- * // With custom fallback component
- * ```jsx
- * <ErrorBoundaryWrapper fallbackComponent={CustomModalError}>
- *   <Modal>...</Modal>
- * </ErrorBoundaryWrapper>
+ * With custom fallback component
+ * ```tsx
+ * <ErrorBoundaryWrapper fallbackComponent=\{CustomModalError\}\>
+ *   <Modal\>...</Modal\>
+ * </ErrorBoundaryWrapper\>
  * ```
  */
 

--- a/src/shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper.tsx
+++ b/src/shared-components/ErrorBoundaryWrapper/ErrorBoundaryWrapper.tsx
@@ -52,7 +52,7 @@ import type {
   InterfaceErrorBoundaryWrapperState,
 } from 'types/shared-components/ErrorBoundaryWrapper/interface';
 import styles from './ErrorBoundaryWrapper.module.css';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import Button from 'shared-components/Button';
 
 export class ErrorBoundaryWrapper extends React.Component<

--- a/src/shared-components/EventListCard/EventListCard.spec.tsx
+++ b/src/shared-components/EventListCard/EventListCard.spec.tsx
@@ -21,7 +21,7 @@ import { props } from './EventListCardProps.mock';
 import { ERROR_MOCKS, MOCKS } from './Modal/EventListCardMocks';
 import { vi, beforeAll, afterAll, afterEach, expect, it } from 'vitest';
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     success: vi.fn(),
     error: vi.fn(),
@@ -30,7 +30,7 @@ vi.mock('components/NotificationToast/NotificationToast', () => ({
     dismiss: vi.fn(),
   },
 }));
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 
 let setItem: ReturnType<typeof useLocalStorage>['setItem'];
 let clearAllItems: ReturnType<typeof useLocalStorage>['clearAllItems'];

--- a/src/shared-components/EventListCard/Modal/EventListCardModals.spec.tsx
+++ b/src/shared-components/EventListCard/Modal/EventListCardModals.spec.tsx
@@ -9,7 +9,7 @@ import { describe, test, expect, vi, beforeEach, Mock } from 'vitest';
 import { useMutation } from '@apollo/client';
 import { useNavigate, useParams } from 'react-router';
 import useLocalStorage from 'utils/useLocalstorage';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { errorHandler } from 'utils/errorHandler';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
@@ -49,7 +49,7 @@ vi.mock('react-router', () => ({
 vi.mock('utils/useLocalstorage', () => ({
   default: vi.fn(),
 }));
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     success: vi.fn(),
     error: vi.fn(),

--- a/src/shared-components/EventListCard/Modal/EventListCardModals.tsx
+++ b/src/shared-components/EventListCard/Modal/EventListCardModals.tsx
@@ -36,7 +36,7 @@ import {
   REGISTER_EVENT,
 } from 'GraphQl/Mutations/EventMutations';
 import { useMutation } from '@apollo/client';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { useUpdateEventHandler } from './updateLogic';
 import { errorHandler } from 'utils/errorHandler';
 

--- a/src/shared-components/EventListCard/Modal/updateLogic.spec.ts
+++ b/src/shared-components/EventListCard/Modal/updateLogic.spec.ts
@@ -7,7 +7,7 @@ import {
   UPDATE_THIS_AND_FOLLOWING_EVENTS_MUTATION,
   UPDATE_ENTIRE_RECURRING_EVENT_SERIES_MUTATION,
 } from 'GraphQl/Mutations/EventMutations';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { errorHandler } from 'utils/errorHandler';
 import type { InterfaceEvent } from 'types/Event/interface';
 import { UserRole } from 'types/Event/interface';
@@ -28,7 +28,7 @@ vi.mock('@apollo/client', async () => {
   };
 });
 
-vi.mock('components/NotificationToast/NotificationToast', async () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', async () => ({
   NotificationToast: {
     info: vi.fn(),
     error: vi.fn(),

--- a/src/shared-components/EventListCard/Modal/updateLogic.ts
+++ b/src/shared-components/EventListCard/Modal/updateLogic.ts
@@ -6,7 +6,7 @@ import {
   UPDATE_THIS_AND_FOLLOWING_EVENTS_MUTATION,
   UPDATE_ENTIRE_RECURRING_EVENT_SERIES_MUTATION,
 } from 'GraphQl/Mutations/EventMutations';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { errorHandler } from 'utils/errorHandler';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';

--- a/src/shared-components/OrganizationCard/OrganizationCard.spec.tsx
+++ b/src/shared-components/OrganizationCard/OrganizationCard.spec.tsx
@@ -12,7 +12,7 @@ import {
 } from 'GraphQl/Mutations/OrganizationMutations';
 import { ORGANIZATION_LIST } from 'GraphQl/Queries/Queries';
 import { USER_JOINED_ORGANIZATIONS_PG } from 'GraphQl/Queries/OrganizationQueries';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 
 // Mock utils/i18n to use the test i18n instance for NotificationToast
 vi.mock('utils/i18n', async () => {
@@ -80,7 +80,7 @@ vi.mock('shared-components/TruncatedText/TruncatedText', () => ({
   default: ({ text }: { text: string }) => <span>{text}</span>,
 }));
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     success: vi.fn(),
     error: vi.fn(),

--- a/src/shared-components/OrganizationCard/OrganizationCard.tsx
+++ b/src/shared-components/OrganizationCard/OrganizationCard.tsx
@@ -52,7 +52,7 @@ import {
 } from 'GraphQl/Mutations/OrganizationMutations';
 import { ORGANIZATION_LIST } from 'GraphQl/Queries/Queries';
 import { USER_JOINED_ORGANIZATIONS_PG } from 'GraphQl/Queries/OrganizationQueries';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import useLocalStorage from 'utils/useLocalstorage';
 import Button from 'shared-components/Button';
 import { ProfileAvatarDisplay } from 'shared-components/ProfileAvatarDisplay/ProfileAvatarDisplay';

--- a/src/shared-components/Recurrence/CustomRecurrenceModal.spec.tsx
+++ b/src/shared-components/Recurrence/CustomRecurrenceModal.spec.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 
 dayjs.extend(utc);
 
 // Mock NotificationToast
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     error: vi.fn(),
     success: vi.fn(),

--- a/src/shared-components/Recurrence/CustomRecurrenceModal.tsx
+++ b/src/shared-components/Recurrence/CustomRecurrenceModal.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { CRUDModalTemplate } from 'shared-components/CRUDModalTemplate/CRUDModalTemplate';
 import {
   Days,

--- a/src/shared-components/pinnedPosts/pinnedPostCard.tsx
+++ b/src/shared-components/pinnedPosts/pinnedPostCard.tsx
@@ -60,7 +60,7 @@ import { formatDate } from '../../utils/dateFormatter';
 import useLocalStorage from '../../utils/useLocalstorage';
 import styles from './pinnedPostCard.module.css';
 import defaultImg from '../../assets/images/defaultImg.png';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { Button } from '../Button';
 
 const PinnedPostCard: React.FC<InterfacePinnedPostCardProps> = ({

--- a/src/shared-components/pinnedPosts/pinnedPostCard.tsx
+++ b/src/shared-components/pinnedPosts/pinnedPostCard.tsx
@@ -144,10 +144,16 @@ const PinnedPostCard: React.FC<InterfacePinnedPostCardProps> = ({
             pb: 1,
           }}
         >
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1.5 }}>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 'var(--space-4)',
+            }}
+          >
             <Avatar
               src={pinnedPost.node?.creator?.avatarURL || undefined}
-              sx={{ width: 28, height: 28 }}
+              sx={{ width: 'var(--space-7)', height: 'var(--space-7)' }}
             >
               {pinnedPost.node?.creator?.name?.[0]}
             </Avatar>
@@ -156,7 +162,7 @@ const PinnedPostCard: React.FC<InterfacePinnedPostCardProps> = ({
             </Typography>
           </Box>
 
-          <Box sx={{ display: 'flex', gap: 0.5 }}>
+          <Box sx={{ display: 'flex', gap: 'var(--space-2)' }}>
             <IconButton size="small" aria-label={t('pinnedPost')}>
               <PushPin className={styles.pushPin} />
             </IconButton>
@@ -180,7 +186,7 @@ const PinnedPostCard: React.FC<InterfacePinnedPostCardProps> = ({
                   transformOrigin={{ vertical: 'top', horizontal: 'right' }}
                   PaperProps={{
                     sx: {
-                      minWidth: '150px',
+                      minWidth: 'var(--space-15)',
                       '& .MuiMenuItem-root': { px: 2, py: 1 },
                     },
                   }}
@@ -264,8 +270,8 @@ const PinnedPostCard: React.FC<InterfacePinnedPostCardProps> = ({
         <CardContent className={styles.cardContent}>
           <Typography
             sx={{
-              fontWeight: 500,
-              fontSize: '18px',
+              fontWeight: 'var(--font-weight-medium)',
+              fontSize: 'var(--font-size-lg)',
               display: '-webkit-box',
               WebkitLineClamp: 1,
               WebkitBoxOrient: 'vertical',
@@ -280,7 +286,7 @@ const PinnedPostCard: React.FC<InterfacePinnedPostCardProps> = ({
             color="text.secondary"
             sx={{
               mb: 1,
-              fontSize: '12px',
+              fontSize: 'var(--font-size-xs)',
             }}
           >
             {t('postedOn', { date: formatDate(pinnedPost.node.createdAt) })}

--- a/src/shared-components/pinnedPosts/pinnedPostsLayout.spec.tsx
+++ b/src/shared-components/pinnedPosts/pinnedPostsLayout.spec.tsx
@@ -16,10 +16,10 @@ import { TOGGLE_PINNED_POST } from '../../GraphQl/Mutations/OrganizationMutation
 import { DELETE_POST_MUTATION } from '../../GraphQl/Mutations/mutations';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 dayjs.extend(utc);
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     error: vi.fn(),
     success: vi.fn(),

--- a/src/shared-components/pinnedPosts/pinnedPostsLayout.spec.tsx
+++ b/src/shared-components/pinnedPosts/pinnedPostsLayout.spec.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-  act,
-} from '@testing-library/react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MockedProvider } from '@apollo/client/testing';
 import { I18nextProvider } from 'react-i18next';

--- a/src/shared-components/postCard/PostCard.spec.tsx
+++ b/src/shared-components/postCard/PostCard.spec.tsx
@@ -13,7 +13,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { store } from '../../state/store';
 import i18nForTest from '../../utils/i18nForTest';
 import { StaticMockLink } from '../../utils/StaticMockLink';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import dayjs from 'dayjs';
@@ -31,7 +31,7 @@ import { GET_POST_COMMENTS, CURRENT_USER } from '../../GraphQl/Queries/Queries';
 import useLocalStorage from '../../utils/useLocalstorage';
 import { errorHandler } from '../../utils/errorHandler';
 
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     error: vi.fn(),
     success: vi.fn(),

--- a/src/shared-components/postCard/PostCard.spec.tsx
+++ b/src/shared-components/postCard/PostCard.spec.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { MockedProvider, type MockedResponse } from '@apollo/client/testing';
-import {
-  render,
-  screen,
-  waitFor,
-  fireEvent,
-  within,
-} from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
 import { I18nextProvider } from 'react-i18next';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';

--- a/src/shared-components/postCard/PostCard.tsx
+++ b/src/shared-components/postCard/PostCard.tsx
@@ -10,7 +10,7 @@
  */
 import React, { useState } from 'react';
 import { useMutation } from '@apollo/client';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { useTranslation } from 'react-i18next';
 import {
   IconButton,

--- a/src/shared-components/posts/createPostModal/createPostModal.spec.tsx
+++ b/src/shared-components/posts/createPostModal/createPostModal.spec.tsx
@@ -12,7 +12,7 @@ import CreatePostModal from './createPostModal';
 import { I18nextProvider } from 'react-i18next';
 import i18nForTest from '../../../utils/i18nForTest';
 import { errorHandler } from 'utils/errorHandler';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 // Styles loaded dynamically to avoid lint error about restricted imports in tests
 let styles: Record<string, string> = {};
 
@@ -29,7 +29,7 @@ const originalAcceptDescriptor = Object.getOwnPropertyDescriptor(
 );
 
 // Mock NotificationToast
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     success: vi.fn(),
     error: vi.fn(),

--- a/src/shared-components/posts/createPostModal/createPostModal.spec.tsx
+++ b/src/shared-components/posts/createPostModal/createPostModal.spec.tsx
@@ -1,5 +1,6 @@
 import React, { act } from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent } from '@testing-library/dom';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MockedProvider, MockedResponse } from '@apollo/client/testing';

--- a/src/shared-components/posts/createPostModal/createPostModal.tsx
+++ b/src/shared-components/posts/createPostModal/createPostModal.tsx
@@ -22,7 +22,7 @@ import {
   CREATE_POST_MUTATION,
   UPDATE_POST_MUTATION,
 } from 'GraphQl/Mutations/mutations';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { errorHandler } from 'utils/errorHandler';
 import { useTranslation } from 'react-i18next';
 import { ICreatePostData, ICreatePostInput } from 'types/Post/type';

--- a/src/shared-components/posts/createPostModal/createPostModal.tsx
+++ b/src/shared-components/posts/createPostModal/createPostModal.tsx
@@ -29,6 +29,7 @@ import { ICreatePostData, ICreatePostInput } from 'types/Post/type';
 
 import { ICreatePostModalProps } from 'types/Post/interface';
 import { ProfileAvatarDisplay } from 'shared-components/ProfileAvatarDisplay/ProfileAvatarDisplay';
+import Button from 'shared-components/Button/Button';
 
 function CreatePostModal({
   show,
@@ -204,7 +205,7 @@ function CreatePostModal({
   return (
     <>
       {/* Backdrop overlay */}
-      <button
+      <Button
         className={`${styles.backdrop} ${show ? styles.backdropShow : ''}`}
         onClick={!isLoading ? handleClose : undefined}
         data-testid="modalBackdrop"
@@ -236,7 +237,7 @@ function CreatePostModal({
               </span>
             </div>
           </div>
-          <button
+          <Button
             className={styles.closeButton}
             onClick={!isLoading ? handleClose : undefined}
             aria-label={t('createPostModal.close')}
@@ -244,7 +245,7 @@ function CreatePostModal({
             type="button"
           >
             <Close />
-          </button>
+          </Button>
         </div>
 
         {/* Content Area */}
@@ -305,7 +306,7 @@ function CreatePostModal({
         {/* Footer */}
         <div className={styles.modalFooter}>
           <div className={styles.mediaActions}>
-            <button
+            <Button
               type="button"
               className={styles.mediaButton}
               aria-label={t('createPostModal.addAttachment')}
@@ -325,8 +326,8 @@ function CreatePostModal({
                 hidden
                 onChange={handleImageSelect}
               />
-            </button>
-            <button
+            </Button>
+            <Button
               type="button"
               className={styles.mediaButton}
               aria-label={
@@ -349,12 +350,12 @@ function CreatePostModal({
                   color: isPinned ? '#0a66c2' : '',
                 }}
               />
-            </button>
+            </Button>
           </div>
 
           <div className={styles.postActions}>
             <form onSubmit={createPostHandler}>
-              <button
+              <Button
                 className={`${styles.postButton} ${
                   isPostDisabled || isLoading ? styles.postButtonDisabled : ''
                 }`}
@@ -369,7 +370,7 @@ function CreatePostModal({
                 ) : (
                   t('createPostModal.saveChanges')
                 )}
-              </button>
+              </Button>
             </form>
           </div>
         </div>

--- a/src/types/AdminPortal/UserDetails/UserTags/interface.ts
+++ b/src/types/AdminPortal/UserDetails/UserTags/interface.ts
@@ -1,4 +1,4 @@
-/** UI-mapped representation of a user tag for table display. */
+/** UI-mapped representation of a user tag for table display.  */
 export interface InterfaceUserTag {
   id: string;
   name: string;

--- a/src/types/AdminPortal/UserDetails/UserTags/type.ts
+++ b/src/types/AdminPortal/UserDetails/UserTags/type.ts
@@ -1,2 +1,2 @@
-/** Props for the UserTags component. */
+/** Props for the UserTags component.  */
 export type InterfaceUserTagsProps = { id?: string };

--- a/src/utils/errorHandler.tsx
+++ b/src/utils/errorHandler.tsx
@@ -1,4 +1,4 @@
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 
 /** 
   This function is used to handle api errors in the application.

--- a/src/utils/useSession.tsx
+++ b/src/utils/useSession.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router';
 import { errorHandler } from 'utils/errorHandler';
 import useLocalStorage from './useLocalstorage';
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import { toast } from 'react-toastify';
 
 type UseSessionReturnType = {

--- a/src/utils/useSession.tsx
+++ b/src/utils/useSession.tsx
@@ -8,7 +8,6 @@ import { useNavigate } from 'react-router';
 import { errorHandler } from 'utils/errorHandler';
 import useLocalStorage from './useLocalstorage';
 import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
-import { toast } from 'react-toastify';
 
 type UseSessionReturnType = {
   startSession: () => void;
@@ -75,7 +74,7 @@ const useSession = (): UseSessionReturnType => {
       await logout();
     } catch (error) {
       console.error('Error during logout:', error);
-      toast.error(tCommon('errorOccurred'));
+      NotificationToast.error(tCommon('errorOccurred'));
     }
     clearAllItems();
     endSession();

--- a/src/utils/userUpdateUtils.spec.ts
+++ b/src/utils/userUpdateUtils.spec.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { removeEmptyFields, validateImageFile } from './userUpdateUtils';
 
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 
 // Mock NotificationToast
-vi.mock('components/NotificationToast/NotificationToast', () => ({
+vi.mock('shared-components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     error: vi.fn(),
   },

--- a/src/utils/userUpdateUtils.ts
+++ b/src/utils/userUpdateUtils.ts
@@ -1,4 +1,4 @@
-import { NotificationToast } from 'components/NotificationToast/NotificationToast';
+import { NotificationToast } from 'shared-components/NotificationToast/NotificationToast';
 import {
   FILE_UPLOAD_MAX_SIZE_MB,
   FILE_UPLOAD_ALLOWED_TYPES,


### PR DESCRIPTION
## What kind of change does this PR introduce?
Refactoring

## Issue Number:
Fixes #6172

## Snapshots/Videos:
N/A - No UI changes

## If relevant, did you update the documentation?
No documentation changes required.

## Summary
This PR continues the NotificationToast migration started in #6584. It updates import paths in **components**, **shared-components**, **utils**, and **root** files to use the standardized `shared-components/NotificationToast/NotificationToast` path.

**Scope**: 72 files changed — purely mechanical `sed` find-and-replace of import paths and test mock paths. Zero logic changes.

This is **Batch 1 of 2** PRs:
- **Batch 1 (this PR)**: `src/components/`, `src/shared-components/`, `src/utils/`, `src/App.tsx`, `src/index.tsx` — 72 files
- **Batch 2 (follow-up)**: `src/screens/` — ~58 files

## Does this PR introduce a breaking change?
No. This is a structural refactor only; runtime behavior remains unchanged. The deprecated re-export in `src/components/NotificationToast/NotificationToast.tsx` (from #6584) ensures backward compatibility.

## Checklist

### CodeRabbit AI Review
- [x] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [x] I have implemented or provided justification for each non-critical suggestion
- [x] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

## Have you read the contributing guide?
Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized internal module structure to improve code organization and maintainability across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->