### PR TITLE
test: cover endTime update when startTime exceeds current endTime

### DIFF
--- a/src/shared-components/EventListCard/Modal/Preview/EventListCardPreviewModal.spec.tsx
+++ b/src/shared-components/EventListCard/Modal/Preview/EventListCardPreviewModal.spec.tsx
@@ -195,7 +195,6 @@ describe('EventListCardPreviewModal', () => {
   });
 
   beforeEach(() => {
-    vi.clearAllMocks();
     (CustomRecurrenceModal as Mock).mockImplementation(() => (
       <div data-testid="mock-custom-recurrence-modal" />
     ));


### PR DESCRIPTION
**What kind of change does this PR introduce?**

**Issue Number:**

Closes #3645

Added a test to ensure that the PreviewModal component correctly updates the `endTime` 
when a new `startTime` is entered that is later than the current `endTime`.

# Changes
- Added a reactive `formState` in the test to simulate controlled input updates.
- Verified that `setFormState` is called with the new `startTime` and updated `endTime`.
- Ensures the component logic for:
  `endTime: timeToDayJs(formState.endTime) < time ? time.format('HH:mm:ss') : formState.endTime`
  is covered.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for event time handling: added a case ensuring end time updates when start time is set later.
  * Tests now use fixed explicit UTC dates for stable, deterministic time assertions.
  * Testing teardown improved: added cleanup calls and restored mocks to ensure isolated, reliable test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->