### PR TITLE
Fixed conditional org filter

### DIFF
--- a/src/screens/UserPortal/Organizations/Organizations.spec.tsx
+++ b/src/screens/UserPortal/Organizations/Organizations.spec.tsx
@@ -568,6 +568,8 @@ test('should search organizations when clicking search button', async () => {
 });
 
 test('Mode dropdown switches list correctly', async () => {
+  setItem('role', 'administrator');
+
   render(
     <MockedProvider link={link}>
       <BrowserRouter>
@@ -886,6 +888,8 @@ test('should handle mode switching to joined organizations', async () => {
 });
 
 test('should handle mode switching to created organizations', async () => {
+  setItem('role', 'administrator');
+
   render(
     <MockedProvider link={link}>
       <BrowserRouter>
@@ -910,6 +914,38 @@ test('should handle mode switching to created organizations', async () => {
   await waitFor(() => {
     expect(screen.getByTestId('organizations-list')).toBeInTheDocument();
   });
+});
+
+test('should not show created organizations option for user role', async () => {
+  // Don't set role or set it to 'user' - both should have the same effect
+  setItem('role', 'user');
+
+  render(
+    <MockedProvider link={link}>
+      <BrowserRouter>
+        <Provider store={store}>
+          <I18nextProvider i18n={i18nForTest}>
+            <Organizations />
+          </I18nextProvider>
+        </Provider>
+      </BrowserRouter>
+    </MockedProvider>,
+  );
+
+  await waitFor(() => {
+    expect(screen.getByTestId('modeChangeBtn-container')).toBeInTheDocument();
+  });
+
+  // Open the mode dropdown
+  const modeButton = screen.getByTestId('modeChangeBtn-toggle');
+  await userEvent.click(modeButton);
+
+  // Should have Mode 0 (All Organizations) and Mode 1 (Joined Organizations)
+  expect(screen.getByTestId('modeChangeBtn-item-0')).toBeInTheDocument();
+  expect(screen.getByTestId('modeChangeBtn-item-1')).toBeInTheDocument();
+
+  // Should NOT have Mode 2 (Created Organizations)
+  expect(screen.queryByTestId('modeChangeBtn-item-2')).not.toBeInTheDocument();
 });
 
 test('should handle null user data in joined organizations', async () => {
@@ -1043,6 +1079,8 @@ test('should handle missing organizationsWhereMember in joined organizations', a
 });
 
 test('should handle null createdOrganizations in created organizations', async () => {
+  setItem('role', 'administrator');
+
   const nullCreatedMocks = [
     COMMUNITY_TIMEOUT_MOCK,
     {
@@ -1108,6 +1146,8 @@ test('should handle null createdOrganizations in created organizations', async (
 });
 
 test('should handle missing createdOrganizations field', async () => {
+  setItem('role', 'administrator');
+
   const missingUserMocks = [
     COMMUNITY_TIMEOUT_MOCK,
     {
@@ -1662,6 +1702,8 @@ test('should search in joined mode (mode 1) via doSearch', async () => {
 });
 
 test('should search in created mode (mode 2) via doSearch', async () => {
+  setItem('role', 'administrator');
+
   const createdSearchMocks = [
     COMMUNITY_TIMEOUT_MOCK,
     CURRENT_USER_VERIFIED_MOCK,
@@ -1997,6 +2039,8 @@ test('should search joined organizations in mode 1', async () => {
 });
 
 test('should search created organizations in mode 2', async () => {
+  setItem('role', 'administrator');
+
   const createdSearchLink = new StaticMockLink(
     [
       COMMUNITY_TIMEOUT_MOCK,

--- a/src/screens/UserPortal/Organizations/Organizations.tsx
+++ b/src/screens/UserPortal/Organizations/Organizations.tsx
@@ -215,11 +215,12 @@ export default function Organizations(): React.JSX.Element {
   const [filterName, setFilterName] = React.useState('');
   const [searchText, setSearchText] = useState('');
   const [mode, setMode] = React.useState(0);
+  const role = getItem('role') == 'administrator' ? 'administrator' : 'user';
 
   const modes = [
     t('allOrganizations'),
     t('joinedOrganizations'),
-    t('createdOrganizations'),
+    ...(role === 'administrator' ? [t('createdOrganizations')] : []),
   ];
 
   const userId: string | null = getItem('userId');
@@ -342,7 +343,6 @@ export default function Organizations(): React.JSX.Element {
   };
 
   const isLoading = loadingAll || loadingJoined || loadingCreated;
-  const role = 'user';
 
   return (
     <>


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Fixed conditional display of ```created organization``` filter.

**Issue Number:** #7294

<!--Add related issue number here.-->
Fixes #7294

**Snapshots/Videos:**
role == user:
<img width="1920" height="1036" alt="image" src="https://github.com/user-attachments/assets/c10ecf80-0ee0-42c0-a7f0-590d2aaf5319" />

role == administrator:
<img width="1913" height="1032" alt="image" src="https://github.com/user-attachments/assets/23abcb39-8d4a-4466-9fa2-c71d42393e35" />

**If relevant, did you update the documentation?**
Updated TSDOC comment in ```src/screens/UserPortal/Organizations/Organizations.tsx```.

**Summary**
Fixed conditional display of ```created organization``` filter.

**Does this PR introduce a breaking change?**
NO

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [ ] I have written tests for all new changes/features
- [ ] I have verified that test coverage meets or exceeds 95%
- [ ] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
* The "Created Organizations" option is now restricted to administrators only. Non-admin users will only see "All Organizations" and "Joined Organizations" modes, ensuring proper access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->