### PR TITLE
fix(cypress): update CURRENT_USER query to use user alias

### DIFF
--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -50,6 +50,8 @@ type SeedEventPayload = {
   location?: string;
   isPublic?: boolean;
   isRegisterable?: boolean;
+  latitude?: number;
+  longitude?: number;
   auth?: AuthOptions;
 };
 
@@ -116,6 +118,10 @@ type CreateUserTaskResult = {
 };
 type CreateVolunteerTaskResult = { volunteerId: string };
 type CreatePostTaskResult = { postId: string };
+type CreateActionItemCategoryTaskResult = {
+  categoryId: string;
+  name?: string;
+};
 
 type CredentialRecord = { email: string; password: string };
 type CredentialFixture = Record<AuthRole, CredentialRecord>;


### PR DESCRIPTION
**What kind of change does this PR introduce?**

**Issue Number:**

Closes #7313

Cypress Test Utilities: Fix CURRENT_USER alias and improve type safety

Updated loginByApi to consistently use data.user in the CURRENT_USER GraphQL query, removing the fallback to data.currentUser and improving error clarity.

Improved TypeScript type safety for seedTestData and related helper functions:

Replaced unsafe as any casts with proper Cypress.Chainable types.

Fixed optional field handling for volunteer and user objects.

Adjusted cleanupTestOrganization to safely chain user deletion tasks without unsafe casting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved login health-check for more reliable auth detection and clearer error messaging.
  * Added a helper to create and persist seed users for tests.
  * Enhanced seeding for events, posts, categories, and volunteers with clearer inputs, consistent return values, and ensured user creation when needed.
  * Unknown seed kinds now surface explicit errors.
  * Made test-organization cleanup behavior and public typing more consistent and predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->