### PR TITLE
test: add full coverage tests for useDataTableSelection

### DIFF
--- a/src/shared-components/DataTable/hooks/useDataTableSelection.spec.tsx
+++ b/src/shared-components/DataTable/hooks/useDataTableSelection.spec.tsx
@@ -94,6 +94,7 @@ describe('useDataTableSelection', () => {
     await act(async () => {
       hook.result.current.runBulkAction(action);
       await Promise.resolve();
+      await Promise.resolve();
     });
 
     expect(consoleErrorSpy).toHaveBeenCalledWith(
@@ -214,7 +215,7 @@ describe('useDataTableSelection', () => {
       result.current.toggleRowSelection('1');
     });
 
-    expect(onSelectionChange).toHaveBeenCalled();
+    expect(onSelectionChange).toHaveBeenCalledWith(new Set(['1']));
   });
 
   it('normalizes selection when page changes', () => {
@@ -335,6 +336,7 @@ describe('useDataTableSelection', () => {
       result.current.runBulkAction(action);
     });
 
+    expect(actionFn).toHaveBeenCalledTimes(1);
     const [rows, selectedKeys] = actionFn.mock.calls[0];
 
     expect(selectedKeys).toEqual(['1']);


### PR DESCRIPTION
**What kind of change does this PR introduce?**

**Issue Number:**

Closes #7301

Goal: Improve code coverage for useDataTableSelection.ts and ensure previously uncovered lines are tested.

# Changes:

 * Created useDataTableSelection.spec.tsx for Vitest.

 * Added test for:
 * Row selection toggle (toggleRowSelection)

 * Select all / clear selection on page (selectAllOnPage, clearSelection)

 * Page change normalization




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests for data-table selection and bulk actions: row and page select/deselect, initial uncontrolled selection, controlled-mode callbacks and behavior without callbacks, computed selection flags, page-scoped clear and normalization when pages/visible keys change, confirmation flows (cancel/confirm), prevention for disabled actions (fn or boolean), and error logging for failing async bulk actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->