### PR TITLE
refactor(types): remove duplicated SidebarOrgSection props interface

### DIFF
--- a/docs/docs/auto-docs/shared-components/SidebarOrgSection/SidebarOrgSection/functions/default.md
+++ b/docs/docs/auto-docs/shared-components/SidebarOrgSection/SidebarOrgSection/functions/default.md
@@ -6,7 +6,7 @@
 
 > **default**(`__namedParameters`): `ReactElement`\<`unknown`, `string` \| `JSXElementConstructor`\<`any`\>\>
 
-Defined in: [src/shared-components/SidebarOrgSection/SidebarOrgSection.tsx:49](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/shared-components/SidebarOrgSection/SidebarOrgSection.tsx#L49)
+Defined in: [src/shared-components/SidebarOrgSection/SidebarOrgSection.tsx:36](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/shared-components/SidebarOrgSection/SidebarOrgSection.tsx#L36)
 
 ## Parameters
 

--- a/docs/docs/auto-docs/types/shared-components/SidebarOrgSection/interface/interfaces/IOrganizationData.md
+++ b/docs/docs/auto-docs/types/shared-components/SidebarOrgSection/interface/interfaces/IOrganizationData.md
@@ -1,0 +1,103 @@
+[Admin Docs](/)
+
+***
+
+# Interface: IOrganizationData
+
+Defined in: [src/types/shared-components/SidebarOrgSection/interface.ts:13](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/shared-components/SidebarOrgSection/interface.ts#L13)
+
+## Properties
+
+### addressLine1?
+
+> `optional` **addressLine1**: `string`
+
+Defined in: [src/types/shared-components/SidebarOrgSection/interface.ts:17](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/shared-components/SidebarOrgSection/interface.ts#L17)
+
+***
+
+### addressLine2?
+
+> `optional` **addressLine2**: `string`
+
+Defined in: [src/types/shared-components/SidebarOrgSection/interface.ts:18](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/shared-components/SidebarOrgSection/interface.ts#L18)
+
+***
+
+### avatarURL?
+
+> `optional` **avatarURL**: `string`
+
+Defined in: [src/types/shared-components/SidebarOrgSection/interface.ts:23](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/shared-components/SidebarOrgSection/interface.ts#L23)
+
+***
+
+### city?
+
+> `optional` **city**: `string`
+
+Defined in: [src/types/shared-components/SidebarOrgSection/interface.ts:19](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/shared-components/SidebarOrgSection/interface.ts#L19)
+
+***
+
+### countryCode?
+
+> `optional` **countryCode**: `string`
+
+Defined in: [src/types/shared-components/SidebarOrgSection/interface.ts:22](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/shared-components/SidebarOrgSection/interface.ts#L22)
+
+***
+
+### createdAt
+
+> **createdAt**: `string`
+
+Defined in: [src/types/shared-components/SidebarOrgSection/interface.ts:24](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/shared-components/SidebarOrgSection/interface.ts#L24)
+
+***
+
+### description?
+
+> `optional` **description**: `string`
+
+Defined in: [src/types/shared-components/SidebarOrgSection/interface.ts:16](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/shared-components/SidebarOrgSection/interface.ts#L16)
+
+***
+
+### id
+
+> **id**: `string`
+
+Defined in: [src/types/shared-components/SidebarOrgSection/interface.ts:14](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/shared-components/SidebarOrgSection/interface.ts#L14)
+
+***
+
+### isUserRegistrationRequired?
+
+> `optional` **isUserRegistrationRequired**: `boolean`
+
+Defined in: [src/types/shared-components/SidebarOrgSection/interface.ts:25](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/shared-components/SidebarOrgSection/interface.ts#L25)
+
+***
+
+### name
+
+> **name**: `string`
+
+Defined in: [src/types/shared-components/SidebarOrgSection/interface.ts:15](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/shared-components/SidebarOrgSection/interface.ts#L15)
+
+***
+
+### postalCode?
+
+> `optional` **postalCode**: `string`
+
+Defined in: [src/types/shared-components/SidebarOrgSection/interface.ts:21](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/shared-components/SidebarOrgSection/interface.ts#L21)
+
+***
+
+### state?
+
+> `optional` **state**: `string`
+
+Defined in: [src/types/shared-components/SidebarOrgSection/interface.ts:20](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/shared-components/SidebarOrgSection/interface.ts#L20)

--- a/src/shared-components/SidebarOrgSection/SidebarOrgSection.tsx
+++ b/src/shared-components/SidebarOrgSection/SidebarOrgSection.tsx
@@ -30,21 +30,8 @@ import AngleRightIcon from 'assets/svgs/angleRight.svg?react';
 import styles from './SidebarOrgSection.module.css';
 import type { ISidebarOrgSectionProps } from '../../types/shared-components/SidebarOrgSection/interface';
 import { ProfileAvatarDisplay } from 'shared-components/ProfileAvatarDisplay/ProfileAvatarDisplay';
-
-interface IOrganizationData {
-  id: string;
-  name: string;
-  description?: string | null;
-  addressLine1?: string | null;
-  addressLine2?: string | null;
-  city?: string | null;
-  state?: string | null;
-  postalCode?: string | null;
-  countryCode?: string | null;
-  avatarURL?: string | null;
-  createdAt: string;
-  isUserRegistrationRequired?: boolean;
-}
+import { IOrganizationData } from '../../types/shared-components/SidebarOrgSection/interface';
+import Button from 'shared-components/Button';
 
 const SidebarOrgSection = ({
   orgId,
@@ -67,14 +54,14 @@ const SidebarOrgSection = ({
   return (
     <div className={`${styles.organizationContainer} pe-3`}>
       {loading ? (
-        <button
+        <Button
           className={`${styles.profileContainer} shimmer`}
           data-testid="orgBtn"
           type="button"
         />
       ) : !data?.organization ? (
         !isProfilePage && (
-          <button
+          <Button
             type="button"
             className={`${styles.profileContainer} ${styles.bgDanger} text-start text-white`}
             disabled
@@ -84,10 +71,10 @@ const SidebarOrgSection = ({
               <WarningAmberOutlined />
             </div>
             {tErrors('errorLoading', { entity: 'Organization' })}
-          </button>
+          </Button>
         )
       ) : (
-        <button
+        <Button
           type="button"
           className={styles.profileContainer}
           data-testid="OrgBtn"
@@ -114,7 +101,7 @@ const SidebarOrgSection = ({
               <AngleRightIcon fill={'var(--bs-secondary)'} />
             </div>
           </div>
-        </button>
+        </Button>
       )}
     </div>
   );

--- a/src/types/shared-components/SidebarOrgSection/interface.ts
+++ b/src/types/shared-components/SidebarOrgSection/interface.ts
@@ -9,3 +9,18 @@ export interface ISidebarOrgSectionProps {
   /** Whether current page is the profile page. */
   isProfilePage?: boolean;
 }
+
+export interface IOrganizationData {
+  id: string;
+  name: string;
+  description?: string | null;
+  addressLine1?: string | null;
+  addressLine2?: string | null;
+  city?: string | null;
+  state?: string | null;
+  postalCode?: string | null;
+  countryCode?: string | null;
+  avatarURL?: string | null;
+  createdAt: string;
+  isUserRegistrationRequired?: boolean;
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?**

**Issue Number:**

Closes #5076

This PR resolves two remaining CI and architecture compliance issues:

i18n violation caused by a hardcoded "Plugin Settings" string

Props interface duplication in SidebarOrgSection

The following reported issues were already resolved in earlier PRs: 
  3) Static Inline Styles in Shared Components
  4) Canonical Folder Structure

# Changes in This PR
 **1) Replaced hardcoded string in SidebarPluginSection:**

// Before
'Plugin Settings'

// After
{t('pluginSettings')}

**2) Props Interface Deduplication**

Removed inline ISidebarOrgSectionProps from:

        src/components/Sidebar/SidebarOrgSection/SidebarOrgSection.tsx

Imported shared interface from src/types
