### PR TITLE
test: replace fireEvent with userEvent

### DIFF
--- a/src/shared-components/postCard/PostCard.spec.tsx
+++ b/src/shared-components/postCard/PostCard.spec.tsx
@@ -881,7 +881,7 @@ describe('PostCard', () => {
     // The dropdown should close after error - we can't assert modal state without additional setup
   });
 
-  it('disables comment send button when input is empty', async () => {
+  it('disables comment send button when input is empty', () => {
     renderPostCard();
 
     const sendButton = screen.getByTestId('comment-send');
@@ -950,9 +950,6 @@ describe('PostCard', () => {
   });
 
   it('should handle onCompleted callback when data.post.comments is null', async () => {
-    const { setItem } = useLocalStorage();
-    setItem('userId', '1');
-
     renderPostCardWithCustomMock(nullCommentsMock);
 
     // Show comments to trigger the query
@@ -971,9 +968,6 @@ describe('PostCard', () => {
   };
 
   it('should not display comments section when commentCount is 0', () => {
-    const { setItem } = useLocalStorage();
-    setItem('userId', '1');
-
     render(
       <MockedProvider link={link}>
         <BrowserRouter>
@@ -991,10 +985,6 @@ describe('PostCard', () => {
   });
 
   it('should render avatar with UserDefault fallback when avatarURL is null', () => {
-    const { setItem } = useLocalStorage();
-    setItem('userId', '1');
-
-    // Post props with null avatarURL to test the fallback
     const postWithNullAvatar = {
       ...defaultProps,
       creator: {

--- a/src/shared-components/postCard/PostCard.spec.tsx
+++ b/src/shared-components/postCard/PostCard.spec.tsx
@@ -31,17 +31,6 @@ import { GET_POST_COMMENTS, CURRENT_USER } from '../../GraphQl/Queries/Queries';
 import useLocalStorage from '../../utils/useLocalstorage';
 import { errorHandler } from '../../utils/errorHandler';
 
-vi.mock('../../utils/useLocalStorage', () => {
-  return {
-    default: () => ({
-      getItem: vi.fn(),
-      setItem: vi.fn(),
-      removeItem: vi.fn(),
-      clearAllItems: vi.fn(),
-    }),
-  };
-});
-
 vi.mock('components/NotificationToast/NotificationToast', () => ({
   NotificationToast: {
     error: vi.fn(),
@@ -1151,7 +1140,7 @@ describe('PostCard', () => {
 
     // Open dropdown
     const dropdownButton = screen.getByTestId('post-more-options-button');
-    await userEvent.click(dropdownButton);
+    await user.click(dropdownButton);
 
     // Wait for menu to appear, then click unpin option (uses same test ID)
     await waitFor(() => {
@@ -1159,7 +1148,7 @@ describe('PostCard', () => {
     });
 
     const unpinButton = screen.getByTestId('pin-post-menu-item');
-    await userEvent.click(unpinButton);
+    await user.click(unpinButton);
 
     await waitFor(() => {
       expect(NotificationToast.success).toHaveBeenCalledWith(

--- a/src/shared-components/postCard/PostCard.spec.tsx
+++ b/src/shared-components/postCard/PostCard.spec.tsx
@@ -975,7 +975,7 @@ describe('PostCard', () => {
     setItem('userId', '1');
 
     render(
-      <MockedProvider mocks={mocks} link={link}>
+      <MockedProvider link={link}>
         <BrowserRouter>
           <Provider store={store}>
             <I18nextProvider i18n={i18nForTest}>
@@ -1004,7 +1004,7 @@ describe('PostCard', () => {
     };
 
     render(
-      <MockedProvider mocks={mocks} link={link}>
+      <MockedProvider link={link}>
         <BrowserRouter>
           <Provider store={store}>
             <I18nextProvider i18n={i18nForTest}>
@@ -1768,11 +1768,9 @@ describe('PostCard', () => {
   });
 
   describe('Share functionality', () => {
-    let user: ReturnType<typeof userEvent.setup>;
     let originalClipboard: typeof navigator.clipboard;
     let originalLocation: Location;
     beforeEach(() => {
-      user = userEvent.setup();
       originalClipboard = navigator.clipboard;
       originalLocation = window.location;
       // Mock the clipboard API
@@ -1802,7 +1800,6 @@ describe('PostCard', () => {
         value: originalLocation,
         writable: true,
       });
-      cleanup();
     });
 
     test('opens share menu item and copies link to clipboard', async () => {


### PR DESCRIPTION
What kind of change does this PR introduce?

Issue Number:

Closes #6625

**This PR updates the PostCard test suite to replace fireEvent with userEvent for simulating user interactions.**


# Changes Made

 * Replaced fireEvent usage with userEvent

 * Updated keyboard interaction tests to use user.keyboard()

 * Updated click interactions to use user.click()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved reliability by switching tests to async user-interaction APIs with per-test setup/teardown, cleanup, mock resets, and localStorage isolation.
  * Replaced synchronous events with realistic async interactions (clicks, typing, keyboard) and updated query/wait strategies.
  * Expanded coverage: post body rendering, comments (empty and large lists), permissions, share/clipboard flows, and on-completed callbacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->