### PR TITLE
Feat: Add Validator Rule To Flag `var()` in `DataGrid` Column `width` Properties

### DIFF
--- a/src/test-utils/validate-tokens-patterns.spec.ts
+++ b/src/test-utils/validate-tokens-patterns.spec.ts
@@ -499,6 +499,54 @@ describe('TSX_PATTERNS', () => {
       ]);
     });
   });
+
+  describe('dataGridVarWidth', () => {
+    test('matches width with var() single quotes', () => {
+      expect(
+        "width: 'var(--space-15)'".match(TSX_PATTERNS.dataGridVarWidth),
+      ).toEqual(["width: 'var(--space-15)'"]);
+    });
+
+    test('matches minWidth with var() double quotes', () => {
+      expect(
+        'minWidth: "var(--vw-8)"'.match(TSX_PATTERNS.dataGridVarWidth),
+      ).toEqual(['minWidth: "var(--vw-8)"']);
+    });
+
+    test('matches maxWidth with var()', () => {
+      expect(
+        "maxWidth: 'var(--max-col-width)'".match(TSX_PATTERNS.dataGridVarWidth),
+      ).toEqual(["maxWidth: 'var(--max-col-width)'"]);
+    });
+
+    test('matches minWidth with var(--vw-80) pattern', () => {
+      expect(
+        "minWidth: 'var(--vw-80)'".match(TSX_PATTERNS.dataGridVarWidth),
+      ).toEqual(["minWidth: 'var(--vw-80)'"]);
+    });
+
+    test('does not match width with spacing token (no var())', () => {
+      expect(
+        "width: 'space-15'".match(TSX_PATTERNS.dataGridVarWidth),
+      ).toBeNull();
+    });
+
+    test('does not match width with numeric value', () => {
+      expect('width: 150'.match(TSX_PATTERNS.dataGridVarWidth)).toBeNull();
+    });
+
+    test('does not match height with var()', () => {
+      expect(
+        "height: 'var(--space-15)'".match(TSX_PATTERNS.dataGridVarWidth),
+      ).toBeNull();
+    });
+
+    test('does not match width without quotes around var()', () => {
+      expect(
+        'width: var(--space-15)'.match(TSX_PATTERNS.dataGridVarWidth),
+      ).toBeNull();
+    });
+  });
 });
 
 describe('ALLOWLIST_PATTERNS', () => {

--- a/src/test-utils/validate-tokens.spec.ts
+++ b/src/test-utils/validate-tokens.spec.ts
@@ -382,6 +382,47 @@ describe('validateFiles', () => {
     expect(result).toEqual([]);
   });
 
+  test('detects var() in DataGrid column width properties in TSX files', async () => {
+    readFileSyncMock.mockReturnValue(
+      "const columns = [{ field: 'id', minWidth: 'var(--vw-8)' }];",
+    );
+
+    const result = await validateFiles('**/*.tsx', ['src/components/Test.tsx']);
+
+    expect(result.some((r) => r.type === 'tsx-datagrid-var')).toBe(true);
+    expect(result.some((r) => r.match.includes('var(--vw-8)'))).toBe(true);
+  });
+
+  test('detects var() in width with double quotes in TSX files', async () => {
+    readFileSyncMock.mockReturnValue(
+      'const columns = [{ field: "name", width: "var(--space-15)" }];',
+    );
+
+    const result = await validateFiles('**/*.tsx', ['src/components/Test.tsx']);
+
+    expect(result.some((r) => r.type === 'tsx-datagrid-var')).toBe(true);
+  });
+
+  test('does not flag DataTable meta.width with var() in TSX files', async () => {
+    readFileSyncMock.mockReturnValue(
+      "const columns = [{ id: 'sno', meta: { width: 'var(--space-11)' } }];",
+    );
+
+    const result = await validateFiles('**/*.tsx', ['src/components/Test.tsx']);
+
+    expect(result.some((r) => r.type === 'tsx-datagrid-var')).toBe(false);
+  });
+
+  test('allows spacing token names in DataGrid column widths', async () => {
+    readFileSyncMock.mockReturnValue(
+      "const columns = [{ field: 'id', minWidth: 'space-15' }];",
+    );
+
+    const result = await validateFiles('**/*.tsx', ['src/components/Test.tsx']);
+
+    expect(result.some((r) => r.type === 'tsx-datagrid-var')).toBe(false);
+  });
+
   test('handles file read errors gracefully', async () => {
     const consoleErrorSpy = vi
       .spyOn(console, 'error')

--- a/src/test-utils/validate-tokens.spec.ts
+++ b/src/test-utils/validate-tokens.spec.ts
@@ -413,6 +413,24 @@ describe('validateFiles', () => {
     expect(result.some((r) => r.type === 'tsx-datagrid-var')).toBe(false);
   });
 
+  test('does not flag multiline DataTable meta.width with var()', async () => {
+    readFileSyncMock.mockReturnValue(
+      [
+        'const columns = [{',
+        "  id: 'sno',",
+        '  meta: {',
+        '    sortable: true,',
+        "    width: 'var(--space-11)',",
+        '  },',
+        '}];',
+      ].join('\n'),
+    );
+
+    const result = await validateFiles('**/*.tsx', ['src/components/Test.tsx']);
+
+    expect(result.some((r) => r.type === 'tsx-datagrid-var')).toBe(false);
+  });
+
   test('allows spacing token names in DataGrid column widths', async () => {
     readFileSyncMock.mockReturnValue(
       "const columns = [{ field: 'id', minWidth: 'space-15' }];",


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feat

**Issue Number:**
Fixes #7367 

**If relevant, did you update the documentation?**
- `docs/docs/docs/developer-resources/design-token-system.md`
- `docs/docs/docs/developer-resources/data-grid-wrapper.md`

**Summary**

- Add `tsx-datagrid-var` validation rule to `validate-tokens.ts` that flags `var()` usage in `width/minWidth/maxWidth` properties in TSX files, since MUI DataGrid requires numeric values
- Skip `meta: { width: 'var(...)' }` patterns used by DataTable (legitimate CSS usage)
- Rename `validate-tokens-patterns.test.ts` to `.spec.ts` for naming consistency

**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added validation that flags CSS variable (var()) usage in DataGrid column width properties (width, minWidth, maxWidth), ensuring DataGrid columns use numeric values; declarations inside DataTable meta blocks are exempted.

* **Tests**
  * Added comprehensive tests covering quoted var() forms, meta-block exemptions (single- and multi-line), spacing-token allowances, and various non-matching cases to prevent false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->