### PR TITLE
Added the installation of the ripgrep package

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -328,27 +328,49 @@ jobs:
         run: |
           python .github-central/.github/workflows/scripts/disable_statements_check.py --files ${{ steps.changed-files.outputs.all_changed_files }}
 
-  Check-Test-Quality:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+Check-Test-Quality:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # Need history for git diff
 
-      - name: Update apt package index
-        run: sudo apt update
+    - name: Install required Ubuntu packages
+      run: sudo apt-get update && sudo apt-get install -y ripgrep
 
-      - name: Install required Ubuntu packages
-        run: sudo apt install -y ripgrep
+    - name: Get changed test files
+      id: changed-test-files
+      run: |
+        BASE_SHA=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
 
-      - name: Check for test anti-patterns
-        run: |
-          echo "🔍 Scanning for test quality issues..."
+        # Get changed test files only
+        CHANGED_TEST_FILES=$(git diff --name-only --diff-filter=ACMRT $BASE_SHA ${{ github.event.pull_request.head.sha }} \
+          | grep -E '\.(spec|test)\.(ts|tsx)$' \
+          | tr '\n' ' ' || true)
 
-          # Check 1: vi.clearAllMocks
-          if rg -q "vi\.restoreAllMocks" src/ --glob "*.spec.tsx" --glob "*.spec.ts" --glob "*.test.tsx" --glob "*.test.ts"; then
-            echo "❌ FAIL: vi.restoreAllMocks detected. Use vi.clearAllMocks instead."
-            rg -n "vi\.restoreAllMocks" src/ --glob "*.spec.tsx" --glob "*.spec.ts" --glob "*.test.tsx" --glob "*.test.ts"
-            exit 1
-          fi
+        echo "files=$CHANGED_TEST_FILES" >> $GITHUB_OUTPUT
+
+        if [ -z "$CHANGED_TEST_FILES" ]; then
+          echo "none=true" >> $GITHUB_OUTPUT
+        else
+          echo "none=false" >> $GITHUB_OUTPUT
+          echo "Changed test files: $CHANGED_TEST_FILES"
+        fi
+
+    - name: Check for test anti-patterns
+      if: steps.changed-test-files.outputs.none != 'true'
+      run: |
+        echo "🔍 Scanning changed test files for quality issues..."
+        CHANGED_FILES="${{ steps.changed-test-files.outputs.files }}"
+
+        # Check 1: vi.restoreAllMocks
+        if echo "$CHANGED_FILES" | xargs rg -q "vi\.restoreAllMocks" 2>/dev/null; then
+          echo "❌ FAIL: vi.restoreAllMocks detected. Use vi.clearAllMocks instead."
+          echo "$CHANGED_FILES" | xargs rg -n "vi\.restoreAllMocks"
+          exit 1
+        fi
+
+        echo "✅ All changed test files passed quality checks"
 
   Translation-Tag-Check:
     name: Translation Tag Check

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -328,49 +328,49 @@ jobs:
         run: |
           python .github-central/.github/workflows/scripts/disable_statements_check.py --files ${{ steps.changed-files.outputs.all_changed_files }}
 
-Check-Test-Quality:
-  runs-on: ubuntu-latest
-  steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0 # Need history for git diff
+  Check-Test-Quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Need history for git diff
 
-    - name: Install required Ubuntu packages
-      run: sudo apt-get update && sudo apt-get install -y ripgrep
+      - name: Install required Ubuntu packages
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
 
-    - name: Get changed test files
-      id: changed-test-files
-      run: |
-        BASE_SHA=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
+      - name: Get changed test files
+        id: changed-test-files
+        run: |
+          BASE_SHA=$(git merge-base ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }})
 
-        # Get changed test files only
-        CHANGED_TEST_FILES=$(git diff --name-only --diff-filter=ACMRT $BASE_SHA ${{ github.event.pull_request.head.sha }} \
-          | grep -E '\.(spec|test)\.(ts|tsx)$' \
-          | tr '\n' ' ' || true)
+          # Get changed test files only
+          CHANGED_TEST_FILES=$(git diff --name-only --diff-filter=ACMRT $BASE_SHA ${{ github.event.pull_request.head.sha }} \
+            | grep -E '\.(spec|test)\.(ts|tsx)$' \
+            | tr '\n' ' ' || true)
 
-        echo "files=$CHANGED_TEST_FILES" >> $GITHUB_OUTPUT
+          echo "files=$CHANGED_TEST_FILES" >> $GITHUB_OUTPUT
 
-        if [ -z "$CHANGED_TEST_FILES" ]; then
-          echo "none=true" >> $GITHUB_OUTPUT
-        else
-          echo "none=false" >> $GITHUB_OUTPUT
-          echo "Changed test files: $CHANGED_TEST_FILES"
-        fi
+          if [ -z "$CHANGED_TEST_FILES" ]; then
+            echo "none=true" >> $GITHUB_OUTPUT
+          else
+            echo "none=false" >> $GITHUB_OUTPUT
+            echo "Changed test files: $CHANGED_TEST_FILES"
+          fi
 
-    - name: Check for test anti-patterns
-      if: steps.changed-test-files.outputs.none != 'true'
-      run: |
-        echo "🔍 Scanning changed test files for quality issues..."
-        CHANGED_FILES="${{ steps.changed-test-files.outputs.files }}"
+      - name: Check for test anti-patterns
+        if: steps.changed-test-files.outputs.none != 'true'
+        run: |
+          echo "🔍 Scanning changed test files for quality issues..."
+          CHANGED_FILES="${{ steps.changed-test-files.outputs.files }}"
 
-        # Check 1: vi.restoreAllMocks
-        if echo "$CHANGED_FILES" | xargs rg -q "vi\.restoreAllMocks" 2>/dev/null; then
-          echo "❌ FAIL: vi.restoreAllMocks detected. Use vi.clearAllMocks instead."
-          echo "$CHANGED_FILES" | xargs rg -n "vi\.restoreAllMocks"
-          exit 1
-        fi
+          # Check 1: vi.restoreAllMocks
+          if echo "$CHANGED_FILES" | xargs rg -q "vi\.restoreAllMocks" 2>/dev/null; then
+            echo "❌ FAIL: vi.restoreAllMocks detected. Use vi.clearAllMocks instead."
+            echo "$CHANGED_FILES" | xargs rg -n "vi\.restoreAllMocks"
+            exit 1
+          fi
 
-        echo "✅ All changed test files passed quality checks"
+          echo "✅ All changed test files passed quality checks"
 
   Translation-Tag-Check:
     name: Translation Tag Check

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -332,6 +332,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Update apt package index
+        run: sudo apt update
+
+      - name: Install required Ubuntu packages
+        run: sudo apt install -y ripgrep
+
       - name: Check for test anti-patterns
         run: |
           echo "🔍 Scanning for test quality issues..."

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -364,9 +364,11 @@ jobs:
           CHANGED_FILES="${{ steps.changed-test-files.outputs.files }}"
 
           # Check 1: vi.restoreAllMocks
-          if echo "$CHANGED_FILES" | xargs rg -q "vi\.restoreAllMocks" 2>/dev/null; then
+          # Write the space-separated list as newline-separated for rg --file-list
+          echo "$CHANGED_FILES" | tr ' ' '\n' | grep -v '^$' > /tmp/changed_test_files.txt
+          if rg -q "vi\.restoreAllMocks" --file-list /tmp/changed_test_files.txt 2>/dev/null; then
             echo "❌ FAIL: vi.restoreAllMocks detected. Use vi.clearAllMocks instead."
-            echo "$CHANGED_FILES" | xargs rg -n "vi\.restoreAllMocks"
+            rg -n "vi\.restoreAllMocks" --file-list /tmp/changed_test_files.txt
             exit 1
           fi
 


### PR DESCRIPTION
Added the installation of the ripgrep package to solve the failure in the `rg` command here:

- https://github.com/PalisadoesFoundation/talawa-admin/pull/7389#issuecomment-3938879052

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to install required build prerequisites before quality checks.
  * Test-quality checks now focus only on changed test files, reducing unnecessary runs and false failures.
  * Anti-pattern checks run conditionally when tests change, with clearer success/failure output messages.
  * Streamlined workflow naming and formatting for more consistent CI reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->