### PR TITLE
fix(tests): resolve race condition in AdvertisementRegister flaky test

### DIFF
--- a/src/components/AdminPortal/Advertisements/core/AdvertisementRegister/AdvertisementRegister.spec.tsx
+++ b/src/components/AdminPortal/Advertisements/core/AdvertisementRegister/AdvertisementRegister.spec.tsx
@@ -1625,7 +1625,12 @@ describe('Testing Advertisement Register Component', () => {
       expect(createMock).toHaveBeenCalled();
     });
 
-    expect(toastErrorSpy).not.toHaveBeenCalled();
+    // Wait for React state to settle before asserting the negative case,
+    // preventing a race condition where the toast handler may not have
+    // had a chance to run yet after the mutation promise resolves.
+    await waitFor(() => {
+      expect(toastErrorSpy).not.toHaveBeenCalled();
+    });
   });
 
   it('Handles updateAdvertisement returning no data', async () => {


### PR DESCRIPTION
## Description

Fixes a race condition in the `AdvertisementRegister` test suite that caused intermittent test failures.

## Root Cause

In the test **"Does not show toast when create error is not an Error instance"**, after a `waitFor` confirmed the mutation was called, the negative assertion `expect(toastErrorSpy).not.toHaveBeenCalled()` was placed **outside** any async boundary:

```ts
// Before (flaky):
await waitFor(() => {
  expect(createMock).toHaveBeenCalled();
});

expect(toastErrorSpy).not.toHaveBeenCalled(); // ← race condition
```

Because the mutation mock rejects with a non-`Error` value (`'string error'`), the component's catch handler runs asynchronously after the mutation promise rejects. The bare `expect` could run before React had finished processing the rejection and updating state, leading to intermittent false positives.

## Fix

Wrap the negative assertion in a `waitFor` block to ensure React's event loop has fully settled before the assertion runs:

```ts
// After (stable):
await waitFor(() => {
  expect(createMock).toHaveBeenCalled();
});

// Wait for React state to settle before asserting the negative case,
// preventing a race condition where the toast handler may not have
// had a chance to run yet after the mutation promise resolves.
await waitFor(() => {
  expect(toastErrorSpy).not.toHaveBeenCalled();
});
```

## Changes

- `src/components/AdminPortal/Advertisements/core/AdvertisementRegister/AdvertisementRegister.spec.tsx`: Wrapped the negative `toastErrorSpy` assertion in a `waitFor` block (line ~1628)

## Related Issue

Fixes #7420

## Checklist

- [x] Only test file modified
- [x] No logic or behaviour changes — test-only fix
- [x] Fix is minimal and surgical (6 lines changed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability for advertisement registration by adding proper asynchronous waiting for error state verification, preventing race conditions during failed mutation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->