### PR TITLE
test: add assertion for SearchBar when onSearch is missing

### DIFF
--- a/src/shared-components/SearchBar/SearchBar.spec.tsx
+++ b/src/shared-components/SearchBar/SearchBar.spec.tsx
@@ -325,9 +325,8 @@ describe('SearchBar', () => {
     await user.type(input, 'test{enter}');
 
     // Verify component doesn't crash and maintains input value
-    await waitFor(() => {
-      expect(input).toHaveValue('test');
-    });
+    //removed waitFor as it was not necessary and could cause false positives if the component re-renders for other reasons
+    expect(input).toHaveValue('test');
   });
 
   describe('showTrailingIcon feature', () => {


### PR DESCRIPTION
Test improvement (adds missing assertion)

Issue Number:
7452

Fixes #7452

Summary
Adds an assertion to the “handles missing onSearch prop gracefully” test to verify the input value remains updated after typing/Enter even when onSearch is undefined.
corrected code as someone already added an expect with a waitFor but waitFor was not needed as the SearchBar updates the input value immediately on typing (no timers/debounce/async effects), and pressing Enter simply returns early when onSearch is undefined. A direct expect(input).toHaveValue('test') is sufficient and avoids unnecessary waiting/polling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test efficiency and reliability by removing an unnecessary asynchronous wait in a SearchBar test.
  * Simplified assertion flow so input behavior is validated immediately after interaction, reducing flakiness and speeding up test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->