### PR TITLE
Feat/mui import safe only

### DIFF
--- a/scripts/convert-mui-imports.js
+++ b/scripts/convert-mui-imports.js
@@ -1,0 +1,149 @@
+import fs from 'fs';
+import path from 'path';
+import ts from 'typescript';
+
+const MATERIAL = '@mui/material';
+const ICONS = '@mui/icons-material';
+
+const red = (text) => `\u001b[31m${text}\u001b[0m`;
+const green = (text) => `\u001b[32m${text}\u001b[0m`;
+const bold = (text) => `\u001b[1m${text}\u001b[0m`;
+
+const parseArgs = (argv) => {
+  const filesFlagIndex = argv.indexOf('--files');
+  const rawFiles =
+    filesFlagIndex !== -1
+      ? argv.slice(filesFlagIndex + 1).filter((arg) => !arg.startsWith('--'))
+      : argv.filter((arg) => !arg.startsWith('--'));
+
+  if (!rawFiles.length) {
+    console.error(
+      red(
+        'No files provided. Usage: node scripts/convert-mui-imports.js --files <file ...>',
+      ),
+    );
+    process.exitCode = 1;
+    return [];
+  }
+
+  return [...new Set(rawFiles.map((file) => path.resolve(file)))];
+};
+
+const transformFile = (filePath) => {
+  if (!fs.existsSync(filePath)) {
+    console.warn(red(`Skipping missing file: ${filePath}`));
+    return;
+  }
+
+  const content = fs.readFileSync(filePath, 'utf8');
+
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    filePath.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
+  );
+
+  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+
+  const newStatements = [];
+  let modified = false;
+
+  sourceFile.statements.forEach((node) => {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      const source = node.moduleSpecifier.text;
+
+      if (source !== MATERIAL && source !== ICONS) {
+        newStatements.push(node);
+        return;
+      }
+
+      // Skip type-only imports
+      if (node.importClause && node.importClause.isTypeOnly) {
+        newStatements.push(node);
+        return;
+      }
+
+      const namedBindings =
+        node.importClause && node.importClause.namedBindings;
+
+      if (namedBindings && ts.isNamedImports(namedBindings)) {
+        namedBindings.elements.forEach((element) => {
+          const importedName = element.propertyName
+            ? element.propertyName.text
+            : element.name.text;
+
+          const localName = element.name.text;
+
+          const newImport = ts.factory.createImportDeclaration(
+            undefined,
+            ts.factory.createImportClause(
+              false,
+              ts.factory.createIdentifier(localName),
+              undefined,
+            ),
+            ts.factory.createStringLiteral(`${source}/${importedName}`),
+            undefined,
+          );
+
+          newStatements.push(newImport);
+        });
+
+        modified = true;
+        return;
+      }
+
+      // Preserve default-only imports
+      newStatements.push(node);
+      return;
+    }
+
+    newStatements.push(node);
+  });
+
+  if (!modified) {
+    console.log(`No changes in ${filePath}`);
+    return;
+  }
+
+  const updatedSourceFile = ts.factory.updateSourceFile(
+    sourceFile,
+    newStatements,
+  );
+
+  const result = printer.printFile(updatedSourceFile);
+
+  fs.writeFileSync(filePath, result, 'utf8');
+  console.log(
+    green('Converted:'),
+    bold(path.relative(process.cwd(), filePath)),
+  );
+};
+
+const main = () => {
+  const files = parseArgs(process.argv.slice(2));
+  if (!files.length) return;
+
+  let errorCount = 0;
+
+  for (const file of files) {
+    try {
+      transformFile(file);
+    } catch (error) {
+      console.error(red(`Error processing ${file}:`), error);
+      errorCount++;
+    }
+  }
+
+  if (errorCount > 0) {
+    process.exitCode = 1;
+  } else {
+    console.log(green('✓ MUI import conversion completed successfully.'));
+  }
+};
+
+main();


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Refactoring 
<!-- E.g. a bugfix, feature, refactoring, etc… -->

**Issue Number:**

<!--Add related issue number here.-->
Fixes #5920 


**If relevant, did you update the documentation?**
No 
<!--Add link to Talawa-Docs.-->

**Summary**
Added a codemod script (convert-mui-imports.js) that uses the TypeScript AST
to convert MUI barrel imports (e.g. import { Button } from '@mui/material')
into deep path imports (e.g. import Button from '@mui/material/Button').

Only files that do not use vi.mock('@mui/material') barrel mocks in their
test suite were converted, preserving Vitest's ability to intercept MUI
modules in tests that rely on mocking the barrel entry point.

A cross-platform wrapper script (convert-mui-and-format.mjs) was added to
run the codemod and immediately format only the affected files via Prettier,
avoiding a full codebase reformat. Both scripts are exposed as npm scripts:
convert-mui and convert-mui:fix.

Remaining unsafe files (those with barrel mocks) will be addressed in a
follow-up PR after the mock strategy is updated to use deep import mocks.

**Does this PR introduce a breaking change?**
No 

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Other information**

<!--Add extra information about this PR here-->

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refactored Material-UI imports across components to use direct module paths for improved build optimization and performance.
  * Added npm scripts for automated conversion of Material-UI import statements.

* **Tests**
  * Enhanced test coverage with additional element identifiers on form components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->