### PR TITLE
Remove password update logic from UserContactDetails

### DIFF
--- a/docs/docs/auto-docs/screens/AdminPortal/MemberDetail/UserContactDetails/variables/default.md
+++ b/docs/docs/auto-docs/screens/AdminPortal/MemberDetail/UserContactDetails/variables/default.md
@@ -6,4 +6,4 @@
 
 > `const` **default**: `React.FC`\<[`InterfaceMemberDetailProps`](../../../../../types/AdminPortal/MemberDetail/interface/type-aliases/InterfaceMemberDetailProps.md)\>
 
-Defined in: [src/screens/AdminPortal/MemberDetail/UserContactDetails.tsx:61](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/screens/AdminPortal/MemberDetail/UserContactDetails.tsx#L61)
+Defined in: [src/screens/AdminPortal/MemberDetail/UserContactDetails.tsx:60](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/screens/AdminPortal/MemberDetail/UserContactDetails.tsx#L60)

--- a/docs/docs/auto-docs/screens/AdminPortal/MemberDetail/UserContactDetails/variables/default.md
+++ b/docs/docs/auto-docs/screens/AdminPortal/MemberDetail/UserContactDetails/variables/default.md
@@ -6,4 +6,4 @@
 
 > `const` **default**: `React.FC`\<[`InterfaceMemberDetailProps`](../../../../../types/AdminPortal/MemberDetail/interface/type-aliases/InterfaceMemberDetailProps.md)\>
 
-Defined in: [src/screens/AdminPortal/MemberDetail/UserContactDetails.tsx:62](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/screens/AdminPortal/MemberDetail/UserContactDetails.tsx#L62)
+Defined in: [src/screens/AdminPortal/MemberDetail/UserContactDetails.tsx:61](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/screens/AdminPortal/MemberDetail/UserContactDetails.tsx#L61)

--- a/docs/docs/auto-docs/types/UserPortal/UserPortalCard/interface/interfaces/InterfaceUserPortalCardProps.md
+++ b/docs/docs/auto-docs/types/UserPortal/UserPortalCard/interface/interfaces/InterfaceUserPortalCardProps.md
@@ -78,7 +78,7 @@ Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:14](https://github
 
 ### variant?
 
-> `optional` **variant**: `"compact"` \| `"standard"` \| `"expanded"`
+> `optional` **variant**: `"standard"` \| `"compact"` \| `"expanded"`
 
 Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:20](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/UserPortal/UserPortalCard/interface.ts#L20)
 

--- a/docs/docs/auto-docs/types/UserPortal/UserPortalCard/interface/interfaces/InterfaceUserPortalCardProps.md
+++ b/docs/docs/auto-docs/types/UserPortal/UserPortalCard/interface/interfaces/InterfaceUserPortalCardProps.md
@@ -78,7 +78,7 @@ Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:14](https://github
 
 ### variant?
 
-> `optional` **variant**: `"standard"` \| `"compact"` \| `"expanded"`
+> `optional` **variant**: `"compact"` \| `"standard"` \| `"expanded"`
 
 Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:20](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/UserPortal/UserPortalCard/interface.ts#L20)
 

--- a/src/screens/AdminPortal/MemberDetail/UserContactDetails.spec.tsx
+++ b/src/screens/AdminPortal/MemberDetail/UserContactDetails.spec.tsx
@@ -1154,27 +1154,6 @@ describe('MemberDetail', () => {
     });
   });
 
-  test('displays error when password validation fails', async () => {
-    renderMemberDetailScreen(createLink(MOCKS1));
-    await waitForLoadingComplete();
-
-    const passwordInput = screen.getByTestId(
-      'inputPassword',
-    ) as HTMLInputElement;
-    await user.clear(passwordInput);
-    await user.type(passwordInput, 'weak');
-
-    const saveButton = screen.getByTestId('saveChangesBtn');
-    await user.click(saveButton);
-
-    await waitFor(
-      () => {
-        expect(mockToast.error).toHaveBeenCalled();
-      },
-      { timeout: 3000 },
-    );
-  });
-
   test('handles avatar URL to file conversion failure', async () => {
     vi.mocked(urlToFile).mockRejectedValueOnce(new Error('Conversion failed'));
     renderUserProfileScreen(createLink(MOCKS1));

--- a/src/screens/AdminPortal/MemberDetail/UserContactDetails.spec.tsx
+++ b/src/screens/AdminPortal/MemberDetail/UserContactDetails.spec.tsx
@@ -16,10 +16,7 @@ import dayjs from 'dayjs';
 import { urlToFile } from 'utils/urlToFile';
 import utc from 'dayjs/plugin/utc';
 dayjs.extend(utc);
-import {
-  UPDATE_CURRENT_USER_MUTATION,
-  UPDATE_USER_MUTATION,
-} from 'GraphQl/Mutations/mutations';
+import { UPDATE_USER_MUTATION } from 'GraphQl/Mutations/mutations';
 import { UNASSIGN_USER_TAG } from 'GraphQl/Mutations/TagMutations';
 import { GET_USER_BY_ID } from 'GraphQl/Queries/Queries';
 
@@ -156,51 +153,6 @@ const MOCKS1 = [
       data: {
         unassignUserTag: {
           _id: '1',
-        },
-      },
-    },
-  },
-  {
-    request: {
-      query: UPDATE_CURRENT_USER_MUTATION,
-    },
-    variableMatcher: (variables: Record<string, unknown>) => {
-      return (
-        variables &&
-        typeof variables === 'object' &&
-        'input' in variables &&
-        typeof variables.input === 'object'
-      );
-    },
-    result: {
-      data: {
-        updateCurrentUser: {
-          id: 'rishav-jha-mech',
-          name: 'Rishav Jha',
-          emailAddress: 'test221@gmail.com',
-          role: 'administrator',
-          createdAt: dayjs.utc().subtract(1, 'month').toISOString(),
-          updatedAt: dayjs.utc().toISOString(),
-          birthDate: '',
-          gender: 'male',
-          addressLine1: 'Line 1',
-          addressLine2: 'Line 2',
-          city: 'city',
-          state: 'State1',
-          countryCode: 'in',
-          postalCode: '111111',
-          description: 'This is a description',
-          mobilePhoneNumber: '+9999999999',
-          homePhoneNumber: '+9999999998',
-          workPhoneNumber: '+9999999998',
-          educationGrade: 'grade_8',
-          employmentStatus: 'employed',
-          maritalStatus: 'engaged',
-          natalSex: 'male',
-          naturalLanguageCode: 'en',
-          isEmailAddressVerified: false,
-          avatarURL: 'http://example.com/avatar.jpg',
-          avatarMimeType: 'image/jpeg',
         },
       },
     },
@@ -349,51 +301,6 @@ const MOCKS2 = [
           createdOrganizations: [],
           eventsAttended: [],
           __typename: 'User',
-        },
-      },
-    },
-  },
-  {
-    request: {
-      query: UPDATE_CURRENT_USER_MUTATION,
-    },
-    variableMatcher: (variables: Record<string, unknown>) => {
-      return (
-        variables &&
-        typeof variables === 'object' &&
-        'input' in variables &&
-        typeof variables.input === 'object'
-      );
-    },
-    result: {
-      data: {
-        updateCurrentUser: {
-          id: '0194d80f-03cd-79cd-8135-683494b187a1',
-          name: 'Rishav Jha',
-          emailAddress: 'test221@gmail.com',
-          role: 'regular',
-          createdAt: dayjs.utc().subtract(1, 'month').toISOString(),
-          updatedAt: dayjs.utc().toISOString(),
-          birthDate: '2000-01-01',
-          gender: 'male',
-          addressLine1: 'Line 1',
-          addressLine2: 'Line 2',
-          city: 'nyc',
-          state: 'State1',
-          countryCode: 'bb',
-          postalCode: '111111',
-          description: 'This is a description',
-          mobilePhoneNumber: '+9999999999',
-          homePhoneNumber: '+9999999998',
-          workPhoneNumber: '+9999999998',
-          educationGrade: 'grade_8',
-          employmentStatus: 'employed',
-          maritalStatus: 'engaged',
-          natalSex: 'male',
-          naturalLanguageCode: 'en',
-          isEmailAddressVerified: false,
-          avatarURL: 'http://example.com/avatar.jpg',
-          avatarMimeType: 'image/jpeg',
         },
       },
     },

--- a/src/screens/AdminPortal/MemberDetail/UserContactDetails.tsx
+++ b/src/screens/AdminPortal/MemberDetail/UserContactDetails.tsx
@@ -17,7 +17,6 @@
  * @remarks
  * - Uses Apollo Client hooks for fetching and updating user data.
  * - Handles avatar uploads with file type and size validation.
- * - Provides form validation for sensitive fields such as passwords.
  * - Uses react-bootstrap components and MUI-based date pickers for UI.
  * - Supports localization via react-i18next.
  *

--- a/src/screens/AdminPortal/MemberDetail/UserContactDetails.tsx
+++ b/src/screens/AdminPortal/MemberDetail/UserContactDetails.tsx
@@ -54,7 +54,6 @@ import {
 } from 'utils/formEnumFields';
 import dayjs from 'dayjs';
 import DropDownButton from 'shared-components/DropDownButton/DropDownButton';
-import { validatePassword } from 'utils/passwordValidator';
 import { FormFieldGroup } from 'shared-components/FormFieldGroup/FormFieldGroup';
 import { InterfaceMemberDetailProps } from 'types/AdminPortal/MemberDetail/interface';
 import { resolveAvatarFile } from './resolveAvatarFile';
@@ -95,7 +94,6 @@ const UserContactDetails: React.FC<InterfaceMemberDetailProps> = ({
     name: '',
     natalSex: '',
     naturalLanguageCode: '',
-    password: '',
     postalCode: '',
     state: '',
     workPhoneNumber: '',
@@ -180,13 +178,6 @@ const UserContactDetails: React.FC<InterfaceMemberDetailProps> = ({
           ([, v]) => v != null && (typeof v !== 'string' || v.trim()),
         ),
       ) as Partial<T>;
-    const passwordError = formState.password
-      ? validatePassword(formState.password)
-      : null;
-    if (passwordError) {
-      NotificationToast.error(passwordError);
-      return;
-    }
 
     let avatarFile = await resolveAvatarFile({
       newAvatarUploaded,
@@ -211,7 +202,6 @@ const UserContactDetails: React.FC<InterfaceMemberDetailProps> = ({
       name: formState.name,
       natalSex: formState.natalSex,
       naturalLanguageCode: formState.naturalLanguageCode,
-      password: formState.password,
       postalCode: formState.postalCode,
       state: formState.state,
       workPhoneNumber: formState.workPhoneNumber,
@@ -448,23 +438,6 @@ const UserContactDetails: React.FC<InterfaceMemberDetailProps> = ({
                       variant="outline-secondary"
                     />
                   </div>
-                </Col>
-                <Col md={12}>
-                  <label htmlFor="password" className="form-label">
-                    {tCommon('password')}
-                  </label>
-                  <input
-                    id="password"
-                    value={formState.password}
-                    className={`form-control ${styles.inputColor}`}
-                    type="password"
-                    name="password"
-                    onChange={(e) =>
-                      handleFieldChange('password', e.target.value)
-                    }
-                    data-testid="inputPassword"
-                    placeholder={tCommon('enterPassword')}
-                  />
                 </Col>
                 <Col md={12}>
                   <label htmlFor="description" className="form-label">


### PR DESCRIPTION
**What kind of change does this PR introduce?**

This PR introduces a **refactor** change. It removes the password field from the Overview tab of the user profile since password updates are now handled through the Security tab.

Issue Number:

Fixes #7494

Snapshots/Videos:
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Removed the password validation test case and simplified related test mocks/imports.

* **Refactor**
  * Removed the password field and associated validation/submit logic from the user contact details form.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->