### PR TITLE
fix: allow clearing recurrence rule when updating event sequence

### DIFF
--- a/src/shared-components/EventListCard/Modal/updateLogic.ts
+++ b/src/shared-components/EventListCard/Modal/updateLogic.ts
@@ -150,7 +150,6 @@ export const useUpdateEventHandler = () => {
       // This prevents unnecessary splits when only updating metadata
       if (
         updateOption === 'following' &&
-        recurrence !== null &&
         hasRecurrenceChanged
       ) {
         updateInput.recurrence = recurrence;


### PR DESCRIPTION
Fixes #7473

### Problem Description
When editing a recurring event occurrence and selecting "Update this and all following events", if the user changes the recurrence dropdown from a repeating rule (e.g., Daily, Weekly) to "Does not repeat", the application incorrectly showed a "No changes to update" toast. The `recurrence: null` state change was not being successfully pushed to the backend, blocking the update.

### Solution
This occurred because `updateLogic.ts` explicitly prevented the `recurrence` object from being attached to the `updateInput` payload when `recurrence === null` (via a `recurrence !== null` check in line 153). 

This PR removes the explicit `!== null` check. Now, when `recurrence` changes from a valid rule object to `null`, `hasRecurrenceChanged` returns `true`, and `updateInput.recurrence = null` is successfully passed to the server, clearing out the recurring sequence to become a one-off "Does not repeat" event.

I have verified `hasRecurrenceChanged()` inside `EventListCardModals.tsx` effectively captures this change correctly, making this isolated logic tweak to `updateLogic.ts` the full robust fix.

### Test Instructions
1. Navigate to calendar.
2. Edit a recurring event sequence.
3. Change its repeat condition to "Does not repeat".
4. Select "Update this and all following events".
5. Previously would fail with "no changes", now successfully updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue preventing proper updates to recurring event settings when modifying following instances, allowing recurrence values to be correctly applied in all cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->