### PR TITLE
Fix: Event Registrants modal dropdown menu autocomplete rendering and test coverage mocks

### DIFF
--- a/docs/docs/auto-docs/components/AdminPortal/EventRegistrantsModal/Modal/EventRegistrantsModal/functions/EventRegistrantsModal.md
+++ b/docs/docs/auto-docs/components/AdminPortal/EventRegistrantsModal/Modal/EventRegistrantsModal/functions/EventRegistrantsModal.md
@@ -6,7 +6,7 @@
 
 > **EventRegistrantsModal**(`__namedParameters`): `Element`
 
-Defined in: [src/components/AdminPortal/EventRegistrantsModal/Modal/EventRegistrantsModal.tsx:63](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/AdminPortal/EventRegistrantsModal/Modal/EventRegistrantsModal.tsx#L63)
+Defined in: [src/components/AdminPortal/EventRegistrantsModal/Modal/EventRegistrantsModal.tsx:62](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/components/AdminPortal/EventRegistrantsModal/Modal/EventRegistrantsModal.tsx#L62)
 
 ## Parameters
 

--- a/docs/docs/auto-docs/test-utils/mocks/shared-autocomplete/functions/createIsOptionEqualToValueMock.md
+++ b/docs/docs/auto-docs/test-utils/mocks/shared-autocomplete/functions/createIsOptionEqualToValueMock.md
@@ -6,7 +6,9 @@
 
 > **createIsOptionEqualToValueMock**(`onResult`): `FC`\<`EqualityMockProps`\>
 
-Defined in: [src/test-utils/mocks/shared-autocomplete/createIsOptionEqualToValueMock.tsx:9](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/test-utils/mocks/shared-autocomplete/createIsOptionEqualToValueMock.tsx#L9)
+Defined in: [src/test-utils/mocks/shared-autocomplete/createIsOptionEqualToValueMock.tsx:15](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/test-utils/mocks/shared-autocomplete/createIsOptionEqualToValueMock.tsx#L15)
+
+Creates a mock Autocomplete component that invokes `isOptionEqualToValue`.
 
 ## Parameters
 
@@ -14,6 +16,10 @@ Defined in: [src/test-utils/mocks/shared-autocomplete/createIsOptionEqualToValue
 
 (`result`) => `void`
 
+Callback that receives the comparison result.
+
 ## Returns
 
 `FC`\<`EqualityMockProps`\>
+
+A mock Autocomplete component for tests.

--- a/docs/docs/auto-docs/test-utils/mocks/shared-autocomplete/functions/createIsOptionEqualToValueMock.md
+++ b/docs/docs/auto-docs/test-utils/mocks/shared-autocomplete/functions/createIsOptionEqualToValueMock.md
@@ -1,0 +1,19 @@
+[Admin Docs](/)
+
+***
+
+# Function: createIsOptionEqualToValueMock()
+
+> **createIsOptionEqualToValueMock**(`onResult`): `FC`\<`EqualityMockProps`\>
+
+Defined in: [src/test-utils/mocks/shared-autocomplete/createIsOptionEqualToValueMock.tsx:9](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/test-utils/mocks/shared-autocomplete/createIsOptionEqualToValueMock.tsx#L9)
+
+## Parameters
+
+### onResult
+
+(`result`) => `void`
+
+## Returns
+
+`FC`\<`EqualityMockProps`\>

--- a/src/components/AdminPortal/EventRegistrantsModal/Modal/EventRegistrantsModal.spec.tsx
+++ b/src/components/AdminPortal/EventRegistrantsModal/Modal/EventRegistrantsModal.spec.tsx
@@ -31,6 +31,7 @@ import { InterfaceBaseModalProps } from 'types/AdminPortal/EventRegistrantsModal
 import {
   EnhancedAutocompleteMock,
   createGetOptionLabelMock,
+  createIsOptionEqualToValueMock,
 } from 'test-utils/mocks/shared-autocomplete';
 
 vi.mock('./AddOnSpot/AddOnSpotAttendee', () => ({
@@ -262,6 +263,62 @@ const makeEventDetailsRecurringMock = (): ApolloMock => ({
           id: 'RRULE:FREQ=DAILY',
         },
       },
+    },
+  },
+});
+
+const makeEventDetailsWithOrganizationMock = (
+  organizationId: string,
+): ApolloMock => ({
+  request: {
+    query: EVENT_DETAILS,
+    variables: { eventId: 'event123' },
+  },
+  result: {
+    data: {
+      event: {
+        id: 'event123',
+        recurrenceRule: null,
+        organization: {
+          id: organizationId,
+        },
+      },
+    },
+  },
+});
+
+const makeEventDetailsWithoutEventMock = (): ApolloMock => ({
+  request: {
+    query: EVENT_DETAILS,
+    variables: { eventId: 'event123' },
+  },
+  result: {
+    data: {
+      event: null,
+    },
+  },
+});
+
+const makeMembersForOrganizationMock = (
+  organizationId: string,
+): ApolloMock => ({
+  request: {
+    query: MEMBERS_LIST,
+    variables: { organizationId },
+  },
+  result: {
+    data: {
+      usersByOrganizationId: [
+        {
+          id: 'fallback-user-1',
+          name: 'Fallback Member',
+          emailAddress: 'fallback@example.com',
+          role: 'member',
+          avatarURL: null,
+          createdAt: dayjs.utc().subtract(1, 'week').toISOString(),
+          updatedAt: dayjs.utc().subtract(1, 'week').toISOString(),
+        },
+      ],
     },
   },
 });
@@ -2376,6 +2433,232 @@ describe('EventRegistrantsModal - renderOption Coverage', () => {
     await waitFor(
       () => {
         expect(addRegistrantSpy).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 5000 },
+    );
+  });
+});
+
+describe('EventRegistrantsModal - Coverage for Org Fallback and Input Rendering', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test('uses event organization id when orgId prop is empty', async () => {
+    renderWithProviders(
+      [
+        makeEventDetailsWithOrganizationMock('org-fallback-123'),
+        makeAttendeesEmptyMock(),
+        makeMembersForOrganizationMock('org-fallback-123'),
+      ],
+      {
+        ...defaultProps,
+        orgId: '',
+      },
+    );
+
+    await screen.findByTestId('invite-modal', {}, { timeout: 5000 });
+
+    const option = await screen.findByTestId(
+      'option-fallback-user-1',
+      {},
+      { timeout: 5000 },
+    );
+    expect(option).toHaveTextContent('Fallback Member');
+  });
+
+  test('skips members query when both orgId and event organization are unavailable', async () => {
+    renderWithProviders(
+      [makeEventDetailsWithoutEventMock(), makeAttendeesEmptyMock()],
+      {
+        ...defaultProps,
+        orgId: '',
+      },
+    );
+
+    await screen.findByTestId('invite-modal', {}, { timeout: 5000 });
+
+    await waitFor(
+      () => {
+        expect(screen.getByTestId('no-options')).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+
+    expect(screen.getByText('No Registrations found')).toBeInTheDocument();
+  });
+
+  test('renders MUI TextField input and accepts typing without crashing', async () => {
+    renderWithProviders([
+      makeEventDetailsNonRecurringMock(),
+      makeAttendeesEmptyMock(),
+      makeMembersWithOneMock(),
+    ]);
+
+    await screen.findByTestId('invite-modal', {}, { timeout: 5000 });
+
+    const muiInput = await screen.findByTestId(
+      'shared-autocomplete-input',
+      {},
+      { timeout: 5000 },
+    );
+    expect(muiInput).toBeInTheDocument();
+
+    await userEvent.type(muiInput, 'harve');
+    expect(muiInput).toHaveValue('harve');
+  });
+
+  test('covers isAdding guard branch when add is triggered while pending', async () => {
+    vi.resetModules();
+
+    vi.doMock('shared-components/Autocomplete', async () => {
+      const { SimpleAutocompleteMock } =
+        await import('test-utils/mocks/shared-autocomplete');
+      return {
+        __esModule: true,
+        Autocomplete: SimpleAutocompleteMock,
+      };
+    });
+
+    vi.doMock('shared-components/Button', () => ({
+      __esModule: true,
+      default: (props: React.ButtonHTMLAttributes<HTMLButtonElement>) => {
+        const { onClick, children, disabled, ...rest } = props;
+        return (
+          <button
+            type="button"
+            onClick={onClick}
+            data-disabled={String(!!disabled)}
+            {...rest}
+          >
+            {children}
+          </button>
+        );
+      },
+    }));
+
+    const slowMutation = vi
+      .fn()
+      .mockImplementation(
+        () => new Promise((resolve) => setTimeout(resolve, 300)),
+      );
+
+    vi.doMock('@apollo/client', async () => {
+      const actual =
+        await vi.importActual<typeof ApolloClient>('@apollo/client');
+      return {
+        ...actual,
+        useMutation: () => [
+          slowMutation,
+          {
+            loading: false,
+            error: undefined,
+            called: false,
+            client: {} as ApolloClient.ApolloClient<object>,
+            reset: vi.fn(),
+          },
+        ],
+      };
+    });
+
+    const { EventRegistrantsModal } = await import('./EventRegistrantsModal');
+
+    render(
+      <MockedProvider
+        mocks={[
+          makeEventDetailsNonRecurringMock(),
+          makeAttendeesEmptyMock(),
+          makeMembersWithOneMock(),
+        ]}
+      >
+        <BrowserRouter>
+          <LocalizationProvider dateAdapter={AdapterDayjs}>
+            <Provider store={store}>
+              <I18nextProvider i18n={i18nForTest}>
+                <EventRegistrantsModal {...defaultProps} />
+              </I18nextProvider>
+            </Provider>
+          </LocalizationProvider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    await screen.findByTestId('invite-modal', {}, { timeout: 5000 });
+
+    const input = await screen.findByTestId(
+      'shared-autocomplete-input',
+      {},
+      { timeout: 5000 },
+    );
+    await userEvent.type(input, 'John');
+    const option = await screen.findByTestId(
+      'option-user1',
+      {},
+      { timeout: 5000 },
+    );
+    await userEvent.click(option);
+
+    const addButton = await screen.findByTestId(
+      'add-registrant-btn',
+      {},
+      { timeout: 5000 },
+    );
+    await userEvent.click(addButton);
+
+    await waitFor(
+      () => {
+        expect(addButton).toHaveAttribute('data-disabled', 'true');
+      },
+      { timeout: 5000 },
+    );
+
+    await userEvent.click(addButton);
+
+    await waitFor(
+      () => {
+        expect(slowMutation).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 5000 },
+    );
+  });
+
+  test('covers isOptionEqualToValue callback branch', async () => {
+    vi.resetModules();
+    const equalitySpy = vi.fn();
+
+    vi.doMock('shared-components/Autocomplete', () => ({
+      __esModule: true,
+      Autocomplete: createIsOptionEqualToValueMock(equalitySpy),
+    }));
+
+    const { EventRegistrantsModal } = await import('./EventRegistrantsModal');
+
+    render(
+      <MockedProvider
+        mocks={[
+          makeEventDetailsNonRecurringMock(),
+          makeAttendeesEmptyMock(),
+          makeMembersWithOneMock(),
+        ]}
+      >
+        <BrowserRouter>
+          <LocalizationProvider dateAdapter={AdapterDayjs}>
+            <Provider store={store}>
+              <I18nextProvider i18n={i18nForTest}>
+                <EventRegistrantsModal {...defaultProps} />
+              </I18nextProvider>
+            </Provider>
+          </LocalizationProvider>
+        </BrowserRouter>
+      </MockedProvider>,
+    );
+
+    await screen.findByTestId('invite-modal', {}, { timeout: 5000 });
+
+    await waitFor(
+      () => {
+        expect(equalitySpy).toHaveBeenCalledWith(true);
       },
       { timeout: 5000 },
     );

--- a/src/components/AdminPortal/EventRegistrantsModal/Modal/EventRegistrantsModal.tsx
+++ b/src/components/AdminPortal/EventRegistrantsModal/Modal/EventRegistrantsModal.tsx
@@ -48,7 +48,6 @@ import {
   EVENT_DETAILS,
 } from 'GraphQl/Queries/Queries';
 import { ADD_EVENT_ATTENDEE } from 'GraphQl/Mutations/mutations';
-import { FormTextField } from 'shared-components/FormFieldGroup/FormFieldGroup';
 import { Autocomplete } from 'shared-components/Autocomplete';
 import { useTranslation } from 'react-i18next';
 import AddOnSpotAttendee from './AddOnSpot/AddOnSpotAttendee';
@@ -107,8 +106,11 @@ export const EventRegistrantsModal = ({
     variables: { eventId: eventId },
   });
 
+  const membersOrganizationId = orgId || eventData?.event?.organization?.id;
+
   const { data: memberData } = useQuery(MEMBERS_LIST, {
-    variables: { organizationId: orgId },
+    variables: { organizationId: membersOrganizationId },
+    skip: !membersOrganizationId,
   });
 
   const [isAdding, setIsAdding] = useState(false);
@@ -218,6 +220,9 @@ export const EventRegistrantsModal = ({
             getOptionLabel={(member: InterfaceUser): string =>
               member.name || t('unknownUser')
             }
+            isOptionEqualToValue={(option, value) => option.id === value.id}
+            label={t('addRegistrantLabel') as string}
+            placeholder={t('addRegistrantPlaceholder') as string}
             renderOption={(props, option: InterfaceUser) => (
               <li {...props} key={option.id}>
                 <div className={styles.avatarContainer}>
@@ -261,26 +266,6 @@ export const EventRegistrantsModal = ({
               </div>
             }
             options={memberData?.usersByOrganizationId || []}
-            renderInput={(params) => (
-              <FormTextField
-                name="addRegistrant"
-                label={t('addRegistrantLabel') as string}
-                ref={params.InputProps.ref}
-                value={inputValue}
-                placeholder={t('addRegistrantPlaceholder') as string}
-                data-testid="autocomplete"
-                id={params.id}
-                disabled={params.disabled}
-                fullWidth
-                onChange={(v: string) => {
-                  if (params.inputProps?.onChange) {
-                    params.inputProps.onChange({
-                      target: { value: v },
-                    } as React.ChangeEvent<HTMLInputElement>);
-                  }
-                }}
-              />
-            )}
             value={member}
           />
           <br />

--- a/src/test-utils/mocks/shared-autocomplete/createIsOptionEqualToValueMock.tsx
+++ b/src/test-utils/mocks/shared-autocomplete/createIsOptionEqualToValueMock.tsx
@@ -6,6 +6,12 @@ type EqualityMockProps = InterfaceAutocompleteMockProps & {
   isOptionEqualToValue?: (a: unknown, b: unknown) => boolean;
 };
 
+/**
+ * Creates a mock Autocomplete component that invokes `isOptionEqualToValue`.
+ *
+ * @param onResult - Callback that receives the comparison result.
+ * @returns A mock Autocomplete component for tests.
+ */
 const createIsOptionEqualToValueMock = (
   onResult: (result: boolean) => void,
 ): React.FC<EqualityMockProps> => {

--- a/src/test-utils/mocks/shared-autocomplete/createIsOptionEqualToValueMock.tsx
+++ b/src/test-utils/mocks/shared-autocomplete/createIsOptionEqualToValueMock.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import type { InterfaceAutocompleteMockProps } from 'types/AdminPortal/EventRegistrantsModal/interface';
+
+type EqualityMockProps = InterfaceAutocompleteMockProps & {
+  options?: { id: string; name?: string }[];
+  isOptionEqualToValue?: (a: unknown, b: unknown) => boolean;
+};
+
+const createIsOptionEqualToValueMock = (
+  onResult: (result: boolean) => void,
+): React.FC<EqualityMockProps> => {
+  const IsOptionEqualToValueMock: React.FC<EqualityMockProps> = ({
+    options,
+    isOptionEqualToValue,
+    renderInput,
+  }) => {
+    if (options?.length && isOptionEqualToValue) {
+      onResult(isOptionEqualToValue(options[0], options[0]));
+    }
+
+    return (
+      <div data-testid="autocomplete-equality-mock">
+        {renderInput?.({
+          InputProps: { ref: React.createRef<HTMLInputElement>() },
+          id: 'equality-autocomplete',
+          disabled: false,
+          inputProps: {},
+        })}
+      </div>
+    );
+  };
+
+  return IsOptionEqualToValueMock;
+};
+
+export default createIsOptionEqualToValueMock;

--- a/src/test-utils/mocks/shared-autocomplete/index.ts
+++ b/src/test-utils/mocks/shared-autocomplete/index.ts
@@ -8,3 +8,4 @@
 export { default as SimpleAutocompleteMock } from './SimpleAutocompleteMock';
 export { default as EnhancedAutocompleteMock } from './EnhancedAutocompleteMock';
 export { default as createGetOptionLabelMock } from './createGetOptionLabelMock';
+export { default as createIsOptionEqualToValueMock } from './createIsOptionEqualToValueMock';


### PR DESCRIPTION
Description:
What kind of change does this PR introduce?
Bugfix + test improvements

Issue Number:
Fixes #7483 

Snapshots/Videos:

https://github.com/user-attachments/assets/b2c1f5e7-882a-4e60-849a-fab200d181fb

Summary
Fixes the Event Registrants modal autocomplete rendering to use the shared MUI input (restoring proper dropdown behavior) and updates the related tests/mocks to keep lint clean while maintaining coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Modal now correctly falls back when organization info is missing and skips member lookups when no org ID is available.
  * Improved autocomplete behavior and input handling to prevent duplicate additions during slow network/mutation states.

* **Tests**
  * Expanded test coverage for registrants modal edge cases: org fallback, empty event, autocomplete equality, input typing, and add-button/pending guard.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->