### PR TITLE
perf(app): skip CURRENT_USER query on public routes 

### DIFF
--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -363,9 +363,11 @@ const setupAdminAuthState = (): void => {
   removeItem('AdminFor');
 };
 
+const { clearAllItems } = useLSModule.useLocalStorage();
 describe('Testing the App Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    clearAllItems();
     vi.spyOn(console, 'log').mockImplementation(() => {});
     vi.spyOn(console, 'error').mockImplementation(() => {});
   });

--- a/src/App.spec.tsx
+++ b/src/App.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { MockedProvider } from '@apollo/react-testing';
+import * as Apollo from '@apollo/client';
 import { MemoryRouter } from 'react-router';
 import { I18nextProvider } from 'react-i18next';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -351,6 +352,17 @@ const renderApp = (mockLink = link, initialRoute = '/') => {
   );
 };
 
+/**
+ * Helper function to set up admin authentication state in localStorage.
+ * Used to pre-authenticate tests that require admin role.
+ */
+const setupAdminAuthState = (): void => {
+  const { setItem, removeItem } = useLSModule.useLocalStorage();
+  setItem('IsLoggedIn', 'TRUE');
+  setItem('role', 'administrator');
+  removeItem('AdminFor');
+};
+
 describe('Testing the App Component', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -363,19 +375,31 @@ describe('Testing the App Component', () => {
     vi.restoreAllMocks();
   });
 
-  it('Regular user sees user portal when accessing admin routes', async () => {
-    renderApp(link, '/admin/orglist');
+  it('Unauthenticated user is redirected to login when accessing admin routes', async () => {
+    const useQuerySpy = vi.spyOn(Apollo, 'useQuery');
 
-    await waitFor(
-      () => {
-        // User should see user portal, not admin portal
-        expect(
-          screen.getByTestId('mock-user-organizations'),
-        ).toBeInTheDocument();
-        expect(screen.queryByTestId('mock-org-list')).not.toBeInTheDocument();
-      },
-      { timeout: 3000 },
-    );
+    try {
+      renderApp(link, '/admin/orglist');
+
+      await waitFor(
+        () => {
+          // Unauthenticated access to admin routes should land on login.
+          expect(screen.getByTestId('app-footer')).toBeInTheDocument();
+          expect(screen.queryByTestId('mock-org-list')).not.toBeInTheDocument();
+        },
+        { timeout: 3000 },
+      );
+
+      // Verify CURRENT_USER query was NOT skipped (protected route requires auth check)
+      const currentUserCall = useQuerySpy.mock.calls.find(
+        ([query]) => query === CURRENT_USER,
+      );
+      // Protected routes like /admin/orglist should NOT skip the query
+      // so the SecuredRoute component can validate authentication
+      expect(currentUserCall?.[1]).toMatchObject({ skip: false });
+    } finally {
+      useQuerySpy.mockRestore();
+    }
   });
 
   it('Login page shows footer for unauthenticated users', async () => {
@@ -431,6 +455,8 @@ describe('Testing the App Component', () => {
 
   it('should handle administrator user permissions correctly', async () => {
     const { usePluginRoutes } = await import('plugin');
+
+    setupAdminAuthState();
 
     renderApp(adminLink, '/admin/orglist');
 
@@ -526,6 +552,8 @@ describe('Testing the App Component', () => {
   it('should handle different plugin route types correctly', async () => {
     const { usePluginRoutes } = await import('plugin');
 
+    setupAdminAuthState();
+
     // Mock different return values for different calls
     vi.mocked(usePluginRoutes)
       .mockReturnValueOnce([]) // adminGlobalPluginRoutes
@@ -590,6 +618,8 @@ describe('Testing the App Component', () => {
   });
 
   it('should handle user with role admin correctly', async () => {
+    setupAdminAuthState();
+
     renderApp(adminLink, '/admin/orglist');
 
     await waitFor(() => {
@@ -669,5 +699,36 @@ describe('Testing the App Component', () => {
     renderApp(link, '/'); // public route
     await screen.findByTestId('app-footer');
     expect(mockInitializePluginSystemOnce).not.toHaveBeenCalled();
+
+    const errorMessages = vi
+      .mocked(console.error)
+      .mock.calls.flat()
+      .map((value) => String(value));
+
+    expect(
+      errorMessages.some((message) =>
+        message.includes(
+          'No more mocked responses for the query: query CurrentUser',
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  it('should skip CURRENT_USER query on public routes', async () => {
+    const useQuerySpy = vi.spyOn(Apollo, 'useQuery');
+
+    try {
+      renderApp(link2, '/');
+      await screen.findByTestId('app-footer');
+
+      const currentUserCall = useQuerySpy.mock.calls.find(
+        ([query]) => query === CURRENT_USER,
+      );
+
+      expect(currentUserCall).toBeDefined();
+      expect(currentUserCall?.[1]).toMatchObject({ skip: true });
+    } finally {
+      useQuerySpy.mockRestore();
+    }
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,8 +156,11 @@ const isPublicRoute = (path: string) =>
  */
 
 function App(): React.ReactElement {
-  const { data, loading } = useQuery(CURRENT_USER);
   const location = useLocation();
+  const isPublic = isPublicRoute(location.pathname);
+  const { data, loading } = useQuery(CURRENT_USER, {
+    skip: isPublic, // Skip the query on public routes
+  });
   const { t } = useTranslation('common');
   const { t: tErrors } = useTranslation('errors');
 
@@ -175,7 +178,6 @@ function App(): React.ReactElement {
   const userGlobalPluginRoutes = usePluginRoutes(userPermissions, false, false);
 
   // Initialize plugin system on app startup
-  const isPublic = isPublicRoute(location.pathname);
   useEffect(() => {
     if (isPublic) return;
 
@@ -195,6 +197,7 @@ function App(): React.ReactElement {
   }, [isPublic, apolloClient]);
 
   useEffect(() => {
+    if (isPublic) return;
     if (!loading && data?.user) {
       const auth = data.user;
       setItem('IsLoggedIn', 'TRUE');
@@ -205,7 +208,7 @@ function App(): React.ReactElement {
       // setItem('UserImage', auth.avatarURL|| "");
       initializeSubscriptions();
     }
-  }, [data, loading, setItem]);
+  }, [data, loading, setItem, isPublic]);
 
   return (
     <ErrorBoundaryWrapper


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Performance 

**Issue Number:**

<!--Add related issue number here.-->
Fixes #5923 

**If relevant, did you update the documentation?**
No 
<!--Add link to Talawa-Docs.-->

**Summary**
- Skip CURRENT_USER query on public routes ("/", "/register", etc.) to avoid unnecessary network calls during initial load
- Updated tests to align with the new authentication flow by simulating logged-in state where required
- Verified via Network tab that CURRENT_USER is no longer executed on public routes

**Does this PR introduce a breaking change?**
No
<!-- If this PR introduces a breaking change, please describe the impact and a migration path for existing applications. -->

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes
<!--Yes or No-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added and refined tests for admin, unauthenticated, and public routes; added helpers to set/clear auth state, spy on user-data query behavior, and assert no unexpected mock errors.

* **Bug Fixes**
  * Stop running the user-data query and bypass plugin initialization on public routes to avoid unnecessary API calls and related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->