### PR TITLE
fix: move useLocalStorage call inside App component

### DIFF
--- a/docs/docs/auto-docs/App/functions/default.md
+++ b/docs/docs/auto-docs/App/functions/default.md
@@ -6,7 +6,7 @@
 
 > **default**(): `ReactElement`
 
-Defined in: [src/App.tsx:158](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/App.tsx#L158)
+Defined in: [src/App.tsx:157](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/App.tsx#L157)
 
 This is the main function for our application. It sets up all the routes and components,
 defining how the user can navigate through the app. The function uses React Router's `Routes`

--- a/docs/docs/auto-docs/types/UserPortal/UserPortalCard/interface/interfaces/InterfaceUserPortalCardProps.md
+++ b/docs/docs/auto-docs/types/UserPortal/UserPortalCard/interface/interfaces/InterfaceUserPortalCardProps.md
@@ -83,3 +83,5 @@ Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:14](https://github
 Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:20](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/UserPortal/UserPortalCard/interface.ts#L20)
 
 Visual density preset controlling padding and spacing
+
+

--- a/docs/docs/auto-docs/types/UserPortal/UserPortalCard/interface/interfaces/InterfaceUserPortalCardProps.md
+++ b/docs/docs/auto-docs/types/UserPortal/UserPortalCard/interface/interfaces/InterfaceUserPortalCardProps.md
@@ -78,7 +78,7 @@ Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:14](https://github
 
 ### variant?
 
-> `optional` **variant**: `"compact"` \| `"standard"` \| `"expanded"`
+> `optional` **variant**: `"standard"` \| `"compact"` \| `"expanded"`
 
 Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:20](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/UserPortal/UserPortalCard/interface.ts#L20)
 

--- a/docs/docs/auto-docs/types/UserPortal/UserPortalCard/interface/interfaces/InterfaceUserPortalCardProps.md
+++ b/docs/docs/auto-docs/types/UserPortal/UserPortalCard/interface/interfaces/InterfaceUserPortalCardProps.md
@@ -78,10 +78,8 @@ Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:14](https://github
 
 ### variant?
 
-> `optional` **variant**: `"standard"` \| `"compact"` \| `"expanded"`
+> `optional` **variant**: `"compact"` \| `"standard"` \| `"expanded"`
 
 Defined in: [src/types/UserPortal/UserPortalCard/interface.ts:20](https://github.com/PalisadoesFoundation/talawa-admin/blob/main/src/types/UserPortal/UserPortalCard/interface.ts#L20)
 
 Visual density preset controlling padding and spacing
-
-

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,7 +119,6 @@ const OAuthCallbackPage = lazy(
   () => import('components/Auth/OAuthCallback/OAuthCallback'),
 );
 
-const { setItem } = useLocalStorage();
 const PUBLIC_ROUTES = new Set([
   '/',
   '/register',
@@ -157,6 +156,7 @@ const isPublicRoute = (path: string) =>
 
 function App(): React.ReactElement {
   const location = useLocation();
+  const { setItem } = useLocalStorage();
   const isPublic = isPublicRoute(location.pathname);
   const { data, loading } = useQuery(CURRENT_USER, {
     skip: isPublic, // Skip the query on public routes

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { lazy, Suspense, useEffect, useMemo } from 'react';
 import { Route, Routes, useLocation } from 'react-router';
 import { useQuery, useApolloClient } from '@apollo/client';
-import useLocalStorage from 'utils/useLocalstorage';
+import { PREFIX, setItem } from 'utils/useLocalstorage';
 import SecuredRoute from 'components/AdminPortal/SecuredRoute/SecuredRoute';
 import SecuredRouteForUser from 'components/UserPortal/SecuredRouteForUser/SecuredRouteForUser';
 import OrganizationFundCampaign from 'screens/AdminPortal/OrganizationFundCampaign/OrganizationFundCampaigns';
@@ -156,7 +156,6 @@ const isPublicRoute = (path: string) =>
 
 function App(): React.ReactElement {
   const location = useLocation();
-  const { setItem } = useLocalStorage();
   const isPublic = isPublicRoute(location.pathname);
   const { data, loading } = useQuery(CURRENT_USER, {
     skip: isPublic, // Skip the query on public routes
@@ -200,15 +199,15 @@ function App(): React.ReactElement {
     if (isPublic) return;
     if (!loading && data?.user) {
       const auth = data.user;
-      setItem('IsLoggedIn', 'TRUE');
-      setItem('id', auth.id);
-      setItem('name', auth.name);
-      setItem('email', auth.emailAddress);
-      setItem('role', auth.role);
+      setItem(PREFIX, 'IsLoggedIn', 'TRUE');
+      setItem(PREFIX, 'id', auth.id);
+      setItem(PREFIX, 'name', auth.name);
+      setItem(PREFIX, 'email', auth.emailAddress);
+      setItem(PREFIX, 'role', auth.role);
       // setItem('UserImage', auth.avatarURL|| "");
       initializeSubscriptions();
     }
-  }, [data, loading, setItem, isPublic]);
+  }, [data, loading, isPublic]);
 
   return (
     <ErrorBoundaryWrapper


### PR DESCRIPTION
Fixes #7526

Moved `useLocalStorage()` from module scope into the `App` component 
body to comply with React Rules of Hooks.

## Testing
- `pnpm run typecheck` passes
- All 17 tests in `src/App.spec.tsx` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Moved login-related local storage handling into the component render flow; improves reliability of storing login status and user info. No public API changes and no user-facing behavior differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->