### PR TITLE
does not trigger organizations lazy query on initial login view

### DIFF
--- a/src/screens/Auth/LoginPage/LoginPage.spec.tsx
+++ b/src/screens/Auth/LoginPage/LoginPage.spec.tsx
@@ -1,4 +1,5 @@
 import React, { act } from 'react';
+import * as ApolloClient from '@apollo/client';
 import { MockedProvider, type MockedResponse } from '@apollo/client/testing';
 import {
   render,
@@ -1771,6 +1772,23 @@ const setLocationPath = (pathname: string): void => {
 describe('Extra coverage for 100 %', () => {
   afterEach(() => {
     vi.doUnmock('Constant/constant.ts');
+  });
+
+  it('does not trigger organizations lazy query on initial login view', async () => {
+    const fetchOrgsSpy = vi.fn();
+    const useLazyQuerySpy = vi
+      .spyOn(ApolloClient, 'useLazyQuery')
+      .mockReturnValue([
+        fetchOrgsSpy,
+        { data: undefined },
+      ] as unknown as ReturnType<typeof ApolloClient.useLazyQuery>);
+
+    setLocationPath('/');
+    renderLoginPage();
+    await wait();
+
+    expect(fetchOrgsSpy).not.toHaveBeenCalled();
+    useLazyQuerySpy.mockRestore();
   });
 
   it('sets document.title on render', async () => {

--- a/src/screens/Auth/LoginPage/LoginPage.spec.tsx
+++ b/src/screens/Auth/LoginPage/LoginPage.spec.tsx
@@ -1783,12 +1783,54 @@ describe('Extra coverage for 100 %', () => {
         { data: undefined },
       ] as unknown as ReturnType<typeof ApolloClient.useLazyQuery>);
 
-    setLocationPath('/');
-    renderLoginPage();
-    await wait();
+    try {
+      setLocationPath('/');
+      renderLoginPage();
 
-    expect(fetchOrgsSpy).not.toHaveBeenCalled();
-    useLazyQuerySpy.mockRestore();
+      // Wait for stable DOM state: login form should be rendered
+      await waitFor(() => {
+        expect(screen.getByTestId('login-form-submit')).toBeInTheDocument();
+      });
+
+      // Assert fetchOrgs was not called on login tab
+      expect(fetchOrgsSpy).not.toHaveBeenCalled();
+    } finally {
+      useLazyQuerySpy.mockRestore();
+    }
+  });
+
+  it('triggers organizations lazy query when switching to register view with undefined data', async () => {
+    const fetchOrgsSpy = vi.fn();
+    const useLazyQuerySpy = vi
+      .spyOn(ApolloClient, 'useLazyQuery')
+      .mockReturnValue([
+        fetchOrgsSpy,
+        { data: undefined },
+      ] as unknown as ReturnType<typeof ApolloClient.useLazyQuery>);
+
+    try {
+      setLocationPath('/');
+      renderLoginPage();
+
+      // Wait for login form to render
+      await waitFor(() => {
+        expect(screen.getByTestId('login-form-submit')).toBeInTheDocument();
+      });
+
+      // Verify fetchOrgs has not been called on initial login view
+      expect(fetchOrgsSpy).not.toHaveBeenCalled();
+
+      // Switch to register view
+      const registerButton = await screen.findByTestId('goToRegisterPortion');
+      await user.click(registerButton);
+
+      // Wait for fetchOrgsSpy to be called exactly once when switching to register
+      await waitFor(() => {
+        expect(fetchOrgsSpy).toHaveBeenCalledTimes(1);
+      });
+    } finally {
+      useLazyQuerySpy.mockRestore();
+    }
   });
 
   it('sets document.title on render', async () => {

--- a/src/screens/Auth/LoginPage/LoginPage.tsx
+++ b/src/screens/Auth/LoginPage/LoginPage.tsx
@@ -10,7 +10,7 @@
  * <LoginPage />
  * ```
  */
-import { ApolloError, useQuery } from '@apollo/client';
+import { ApolloError, useQuery, useLazyQuery } from '@apollo/client';
 import React, { useEffect, useRef, useState } from 'react';
 
 import Button from 'shared-components/Button';
@@ -105,7 +105,15 @@ const LoginPage = (): JSX.Element => {
     fetchPolicy: 'cache-and-network',
   });
 
-  const { data: orgData } = useQuery(ORGANIZATION_LIST_NO_MEMBERS);
+  const [fetchOrgs, { data: orgData }] = useLazyQuery(
+    ORGANIZATION_LIST_NO_MEMBERS,
+  );
+  useEffect(() => {
+    if (showTab === 'REGISTER' && !orgData) {
+      fetchOrgs();
+    }
+  }, [showTab, orgData, fetchOrgs]);
+
   useEffect(() => {
     if (orgData?.organizations) {
       const options: InterfaceOrgOption[] = orgData.organizations.map(


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Performance 

**Issue Number:**

<!--Add related issue number here.-->
Fixes #5926 

**If relevant, did you update the documentation?**
No 

**Summary**
This PR defers the organization list query to the registration tab, reducing initial network payload and improving first-render performance for unauthenticated user and added tests

**Does this PR introduce a breaking change?**
No

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass


**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**
Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests verifying organization fetch is not triggered on initial login view and is triggered once when switching to the register view.

* **Bug Fixes**
  * Organization list now loads on-demand when the register tab is opened instead of loading automatically on page load.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->