### PR TITLE
Fix flaky AdvertisementRegister test for non-Error create failures

### DIFF
--- a/src/components/AdminPortal/Advertisements/core/AdvertisementRegister/AdvertisementRegister.spec.tsx
+++ b/src/components/AdminPortal/Advertisements/core/AdvertisementRegister/AdvertisementRegister.spec.tsx
@@ -1632,9 +1632,8 @@ describe('Testing Advertisement Register Component', () => {
 
     await waitFor(() => {
       expect(createMock).toHaveBeenCalled();
+      expect(toastErrorSpy).not.toHaveBeenCalled();
     });
-
-    expect(toastErrorSpy).not.toHaveBeenCalled();
   });
 
   it('Handles updateAdvertisement returning no data', async () => {


### PR DESCRIPTION
What kind of change does this PR introduce?

Bugfix (test stability improvement)

Issue Number:

Fixes #7420 

Summary

This PR fixes an intermittent race condition in the AdvertisementRegister test: Does not show toast when create error is not an Error instance.

Previously, the test waited only for the mutation call and then immediately asserted that the error toast was not called. In CI/CD, especially with sharded runs and variable timing, this could execute before or after async error-handling completed, causing flaky outcomes.

The fix moves the no-toast assertion into the same waitFor block as the mutation assertion, ensuring both conditions are evaluated in a synchronized async window. This aligns with existing stable test patterns in the same spec and improves reliability across local and CI environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test assertion timing for advertisement creation error handling.

---

*Note: This release contains internal test improvements with no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->