### PR TITLE
fix(install): suggest 'pnpm run serve' instead of 'pnpm run dev' (#7557)

### DIFF
--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -384,7 +384,7 @@ else
     log_info ""
     log_info "Next steps:"
     log_info "  1. Run 'pnpm run setup' to configure your application"
-    log_info "  2. Run 'pnpm run dev' to start the development server"
+    log_info "  2. Run 'pnpm run serve' to start the development server"
 
     # Shell config reminder for fnm
     if command_exists fnm; then


### PR DESCRIPTION
Closes #7557.

## Summary
The install script's \"Next steps\" message in \`scripts/install/install.sh\` told contributors to run \`pnpm run dev\`, but \`package.json\` only defines \`serve\`:

```json
\"serve\": \"cross-env ESLINT_NO_DEV_ERRORS=true vite --config config/vite.config.ts\"
```

Running the suggested command fails with `Missing script: \"dev\"` and new contributors hit a wall on the very first install.

One-character fix: change the suggestion to `pnpm run serve` so it matches the script that actually exists in the repo. \`serve\` is the existing dev-server entry, unchanged by this commit.

## Test plan
- [x] Confirmed only one occurrence in `scripts/` references the wrong command (`grep \"pnpm run dev\" scripts docs` returns no other hits).
- [x] `pnpm run serve` exists in `package.json` and starts the Vite dev server.
- [x] No code paths altered; pure user-facing string fix.

Signed-off per the project's DCO requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated post-installation messaging with corrected startup instructions for the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->