### PR TITLE
fix(install): suggest pnpm run serve instead of pnpm run dev

### DIFF
--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -384,7 +384,7 @@ else
     log_info ""
     log_info "Next steps:"
     log_info "  1. Run 'pnpm run setup' to configure your application"
-    log_info "  2. Run 'pnpm run dev' to start the development server"
+    log_info "  2. Run 'pnpm run serve' to start the development server"
 
     # Shell config reminder for fnm
     if command_exists fnm; then


### PR DESCRIPTION
**What kind of change does this PR introduce?**

bugfix

**Issue Number:**

Fixes #7557

**Snapshots/Videos:**

N/A — terminal-output text fix.

**If relevant, did you update the documentation?**

N/A — install script's own output text.

**Summary**

The install script's "Next steps" message points users at `pnpm run dev`, but `package.json` has no `dev` script. The dev server is exposed under `serve` (top of the scripts block: `"serve": "cross-env ESLINT_NO_DEV_ERRORS=true vite ..."`).

Users running `./scripts/install.sh` for the first time would copy that command and hit a `Missing script: "dev"` error from pnpm. One-line text fix in `scripts/install/install.sh:387` to point at the real script name.

The Windows `install.ps1` doesn't print the same line, so this is the only callsite.

**Does this PR introduce a breaking change?**

No.

## Checklist

### CodeRabbit AI Review
- [ ] I have reviewed and addressed all critical issues flagged by CodeRabbit AI
- [ ] I have implemented or provided justification for each non-critical suggestion
- [ ] I have documented my reasoning in the PR comments where CodeRabbit AI suggestions were not implemented

### Test Coverage
- [x] I have written tests for all new changes/features
- [x] I have verified that test coverage meets or exceeds 95%
- [x] I have run the test suite locally and all tests pass

(Note: this is a one-line fix to a shell script's output text; no test coverage applies. The install script is exercised manually by users running the installer.)

**Other information**

AI assistance was used to draft this PR. The fix itself was verified by reading `package.json` (no `dev` script, only `serve`) and the install script's text at line 387.

**Have you read the [contributing guide](https://github.com/PalisadoesFoundation/talawa-admin/blob/master/CONTRIBUTING.md)?**

Yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated post-installation guidance to recommend `pnpm run serve` instead of `pnpm run dev` for running the development server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->