### PR TITLE
fix: update install script startup command

### DIFF
--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -384,7 +384,7 @@ else
     log_info ""
     log_info "Next steps:"
     log_info "  1. Run 'pnpm run setup' to configure your application"
-    log_info "  2. Run 'pnpm run dev' to start the development server"
+    log_info "  2. Run 'pnpm run serve' to start the development server"
 
     # Shell config reminder for fnm
     if command_exists fnm; then


### PR DESCRIPTION
## Summary

Updated the installation summary to display the correct startup command.

## Changes

- Replaced `pnpm run dev` with `pnpm run serve` in `scripts/install/install.sh`

Fixes #7557

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to use `pnpm run serve` instead of `pnpm run dev` for starting the development server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->