### PR TITLE
fix: update install script to suggest pnpm run serve instead of dev

### DIFF
--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -384,7 +384,7 @@ else
     log_info ""
     log_info "Next steps:"
     log_info "  1. Run 'pnpm run setup' to configure your application"
-    log_info "  2. Run 'pnpm run dev' to start the development server"
+    log_info "  2. Run 'pnpm run serve' to start the development server"
 
     # Shell config reminder for fnm
     if command_exists fnm; then


### PR DESCRIPTION
**issue:** #7557 

The install script 'scripts/install/install.sh' showed 'pnpm run dev' in the post-install summary, but the correct command is 'pnpm run serve' (as defined in 'package.json'). This PR fixes the suggested command. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the installation guidance to use `pnpm run serve` for starting the development server in the next steps section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->