### PR TITLE
fix: move useLocalStorage() inside App component to follow Rules of Hooks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -119,7 +119,6 @@ const OAuthCallbackPage = lazy(
   () => import('components/Auth/OAuthCallback/OAuthCallback'),
 );
 
-const { setItem } = useLocalStorage();
 const PUBLIC_ROUTES = new Set([
   '/',
   '/register',
@@ -163,6 +162,7 @@ function App(): React.ReactElement {
   });
   const { t } = useTranslation('common');
   const { t: tErrors } = useTranslation('errors');
+  const { setItem } = useLocalStorage();
 
   const apolloClient = useApolloClient();
 
@@ -208,7 +208,7 @@ function App(): React.ReactElement {
       // setItem('UserImage', auth.avatarURL|| "");
       initializeSubscriptions();
     }
-  }, [data, loading, setItem, isPublic]);
+  }, [data, loading, isPublic]);
 
   return (
     <ErrorBoundaryWrapper


### PR DESCRIPTION
## Summary
- Moved `useLocalStorage()` call from module scope (line 122) to inside the `App` component
- Removed `setItem` from `useEffect` dependency array as it's a stable reference

## Changes
- `src/App.tsx`: Moved hook call inside component body
- Follows [Rules of Hooks](https://react.dev/reference/rules/rules-of-hooks)

## Testing
- Verified that `setItem` is still called correctly in the useEffect
- No breaking changes to existing functionality

Fixes #7526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication behavior by ensuring saved data is updated at the right time within the app.
  * Reduced unnecessary re-runs of authentication-related updates for smoother, more reliable loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->