### PR TITLE
fix: wrap flaky assertion in waitFor in AdvertisementRegister.spec.tsx (Fixes #7420)

### DIFF
--- a/src/components/AdminPortal/Advertisements/core/AdvertisementRegister/AdvertisementRegister.spec.tsx
+++ b/src/components/AdminPortal/Advertisements/core/AdvertisementRegister/AdvertisementRegister.spec.tsx
@@ -1632,9 +1632,8 @@ describe('Testing Advertisement Register Component', () => {
 
     await waitFor(() => {
       expect(createMock).toHaveBeenCalled();
+      expect(toastErrorSpy).not.toHaveBeenCalled();
     });
-
-    expect(toastErrorSpy).not.toHaveBeenCalled();
   });
 
   it('Handles updateAdvertisement returning no data', async () => {


### PR DESCRIPTION
## Summary
Fixes a flaky test by wrapping the `toastErrorSpy` assertion inside `waitFor` to eliminate a race condition.

## Problem
The test 'Does not show toast when create error is not an Error instance' had a race condition at line 1579. After confirming the mutation was called via `waitFor`, the assertion `expect(toastErrorSpy).not.toHaveBeenCalled()` ran immediately without waiting for error handling to complete.

In CI/CD sharded environments with variable response times, this caused intermittent failures.

## Solution
Moved the `toastErrorSpy` assertion inside the `waitFor` block, matching the correct pattern already used at lines 1506 and 1677 in the same file.

```diff
  await waitFor(() => {
    expect(createMock).toHaveBeenCalled();
+   expect(toastErrorSpy).not.toHaveBeenCalled();
  });
-
-expect(toastErrorSpy).not.toHaveBeenCalled();
```

## Test Results
All 32 tests pass ✅

Fixes #7420