### PR TITLE
docs: fix 404 E2E testing documentation links

### DIFF
--- a/cypress/README.md
+++ b/cypress/README.md
@@ -3,4 +3,4 @@
 Use the single source of truth for Cypress E2E documentation:
 
 - Local docs: `docs/docs/docs/developer-resources/e2e-testing.md`
-- Online docs: [Online E2E testing docs](https://docs-admin.talawa.io/docs/developer-resources/e2e-testing/)
+- Online docs: [Online E2E testing docs](https://docs-admin.talawa.io/docs/developer-resources/testing/e2e-testing)

--- a/docs/docs/docs/developer-resources/e2e-testing.md
+++ b/docs/docs/docs/developer-resources/e2e-testing.md
@@ -9,7 +9,7 @@ This project uses Cypress for comprehensive end-to-end testing to ensure the app
 
 ## Additional Resources
 
-- [Online docs](https://docs-admin.talawa.io/docs/developer-resources/e2e-testing)
+- [Online docs](https://docs-admin.talawa.io/docs/developer-resources/testing/e2e-testing)
 - Cypress local quick reference: `cypress/README.md`
 
 ## Prerequisites


### PR DESCRIPTION
Two files link to `https://docs-admin.talawa.io/docs/developer-resources/e2e-testing`, which returns 404. The published page sits under the `testing/` section:

- `cypress/README.md` line 6
- `docs/docs/docs/developer-resources/e2e-testing.md` line 12

Both now point at [`/docs/developer-resources/testing/e2e-testing`](https://docs-admin.talawa.io/docs/developer-resources/testing/e2e-testing), which returns 200 and is the URL the docs site's own sidebar links to.

The full pre-commit hook chain ran on this commit (design token validation, Python venv checks, lint-staged) and passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the link to the online Cypress end-to-end testing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->